### PR TITLE
feat: add security vulnerability scanning with govulncheck

### DIFF
--- a/lint_test.go
+++ b/lint_test.go
@@ -45,6 +45,13 @@ func TestGoVet(t *testing.T) {
 	rungo(t, "vet", "./...")
 }
 
+func TestGovulncheck(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short mode: skipping govulncheck")
+	}
+	rungo(t, "run", "golang.org/x/vuln/cmd/govulncheck@latest", "./...")
+}
+
 func rungo(t *testing.T, args ...string) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- Add `TestGovulncheck` to `lint_test.go` to scan for known vulnerabilities in dependencies
- Runs as part of `go test ./...`, skipped with `-short` flag
- Uses `go run` so no pre-installation required

Closes #4