### PR TITLE
feat: enforce code coverage threshold with Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24'
           cache-dependency-path: go.sum
 
       - name: Download dependencies
@@ -27,8 +27,12 @@ jobs:
       - name: Run tests
         run: go test -v -race -coverprofile=coverage.out ./...
 
-      - name: Generate coverage report
-        run: go tool cover -func=coverage.out
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.out
+          fail_ci_if_error: true
 
   # Generate test matrices - lightweight job that other jobs wait on
   matrix:
@@ -64,7 +68,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24'
           cache-dependency-path: go.sum
 
       - name: Build tsuku
@@ -93,7 +97,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24'
           cache-dependency-path: go.sum
 
       - name: Build tsuku

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 30%
+        threshold: 1%
+    patch:
+      default:
+        target: 70%
+
+ignore:
+  - "bundled/**/*"
+  - "internal/testutil/**/*"
+  - "*_test.go"

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -45,12 +45,12 @@ func TestResolveVersionWith_CustomSource(t *testing.T) {
 	// but the test verifies the integration works
 	versionInfo, err := exec.resolveVersionWith(ctx, resolver)
 
-	// If network is available, should get version; otherwise should fall back to "dev"
-	if err == nil || versionInfo.Version == "dev" {
-		t.Logf("resolveVersionWith() succeeded or fell back gracefully: version=%s", versionInfo.Version)
-	} else {
+	// If network is available, should get version; otherwise error is acceptable
+	if err != nil {
 		// Network failure is acceptable in unit tests
 		t.Logf("resolveVersionWith() failed (expected in offline tests): %v", err)
+	} else {
+		t.Logf("resolveVersionWith() succeeded: version=%s", versionInfo.Version)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Upload coverage to Codecov after test runs
- Set project threshold at 30% (current baseline) with 1% tolerance
- Require 70% coverage on new code (patch coverage)
- Ignore bundled recipes, test utilities, and test files

Closes #5