### PR TITLE
fix(readme): correct badge URLs to point to tsuku repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # tsuku
 
-[![Tests](https://github.com/tsuku-dev/tsuku-vision/actions/workflows/test.yml/badge.svg)](https://github.com/tsuku-dev/tsuku-vision/actions/workflows/test.yml)
-[![Lint](https://github.com/tsuku-dev/tsuku-vision/actions/workflows/lint.yml/badge.svg)](https://github.com/tsuku-dev/tsuku-vision/actions/workflows/lint.yml)
+[![Tests](https://github.com/tsuku-dev/tsuku/actions/workflows/test.yml/badge.svg)](https://github.com/tsuku-dev/tsuku/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/tsuku-dev/tsuku/graph/badge.svg)](https://codecov.io/gh/tsuku-dev/tsuku)
 
 A modern, universal package manager for development tools.
 


### PR DESCRIPTION
## Summary

- Update test badge to point to tsuku-dev/tsuku instead of tsuku-vision
- Replace non-existent lint badge with codecov coverage badge

Fixes #53