### PR TITLE
test: verify docs-only CI skip works

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Tests](https://github.com/tsuku-dev/tsuku/actions/workflows/test.yml/badge.svg)](https://github.com/tsuku-dev/tsuku/actions/workflows/test.yml)
 [![codecov](https://codecov.io/gh/tsuku-dev/tsuku/graph/badge.svg)](https://codecov.io/gh/tsuku-dev/tsuku)
 
-A modern, universal package manager for development tools.
+A modern, self-contained package manager for development tools.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- Test PR to verify #59 fix works correctly
- This PR only modifies README.md
- Integration tests should be SKIPPED (only Unit Tests and Matrix should run)

If integration tests run, the fix didn't work.