### PR TITLE
docs: add design document for recipe builders

### DIFF
--- a/docs/DESIGN-recipe-builders.md
+++ b/docs/DESIGN-recipe-builders.md
@@ -1,6 +1,6 @@
 # Design Document: Ecosystem-Specific Recipe Builders
 
-**Status**: Accepted
+**Status**: Planned
 
 ## Context and Problem Statement
 
@@ -723,7 +723,7 @@ Milestone: [Recipe Builders](https://github.com/tsuku-dev/tsuku/milestone/4)
 
 | Issue | Phase | Description |
 |-------|-------|-------------|
-| TBD | Phase 1a | Recipe writer with atomic file operations |
+| #93 | Phase 1a | Recipe writer with atomic file operations |
 | #40 | Phase 1b | Local recipe support + Cargo builder |
 | #41 | Phase 2 | Gem builder for RubyGems |
 | #42 | Phase 3 | PyPI builder for Python packages |
@@ -734,7 +734,7 @@ Milestone: [Recipe Builders](https://github.com/tsuku-dev/tsuku/milestone/4)
 ### Dependency Graph
 
 ```
-Phase 1a: Recipe Writer (TBD)
+Phase 1a: Recipe Writer (#93)
     │
     v
 Phase 1b: Local Recipe Support + Cargo Builder (#40)


### PR DESCRIPTION
## Summary

Adds design document for Recipe Builders feature (issue #39).

Recipe builders enable users to create tsuku recipes directly from package ecosystem metadata (crates.io, RubyGems, PyPI, npm) using a `tsuku create` command. This addresses the coverage gap where thousands of CLI tools exist across package ecosystems that aren't in the registry.

## Design Document Contents

- **Problem Statement**: Coverage gap for ecosystem tools, success criteria
- **External Research**: asdf/mise, Nix, cargo-binstall, pipx patterns
- **Considered Options**: Thin builder layer, extended action, external builders
- **Decision**: Thin Builder Layer (recipe generation only)
- **Architecture**: Builder interface, registry, executable discovery strategies
- **Implementation Phases**: 5 phases from Cargo builder to toolchain bootstrapping
- **Security**: Download verification, execution isolation, supply chain risks

## Key Design Decisions

- Builders are pure functions that generate `*recipe.Recipe` structs
- Two-step UX: `tsuku create` then `tsuku install` for transparency
- Local recipes stored in `~/.tsuku/recipes/` take precedence over registry
- Version-agnostic recipes suitable for contribution back to registry

## Closes

Closes #39