### PR TITLE
fix(version): improve GitHub rate limit error messages

### DIFF
--- a/internal/version/resolver_test.go
+++ b/internal/version/resolver_test.go
@@ -1,6 +1,9 @@
 package version
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestNormalizeVersion(t *testing.T) {
 	tests := []struct {
@@ -125,4 +128,31 @@ func TestNewWithPyPIRegistry(t *testing.T) {
 	if resolver.httpClient == nil {
 		t.Error("NewWithPyPIRegistry() did not initialize httpClient")
 	}
+}
+
+func TestWrapGitHubRateLimitError(t *testing.T) {
+	resolver := New()
+
+	t.Run("non-rate-limit error returns nil", func(t *testing.T) {
+		err := fmt.Errorf("some other error")
+		result := resolver.wrapGitHubRateLimitError(err, GitHubContextVersionResolution)
+		if result != nil {
+			t.Errorf("wrapGitHubRateLimitError() = %v, want nil for non-rate-limit error", result)
+		}
+	})
+
+	t.Run("nil error returns nil", func(t *testing.T) {
+		result := resolver.wrapGitHubRateLimitError(nil, GitHubContextVersionResolution)
+		if result != nil {
+			t.Errorf("wrapGitHubRateLimitError() = %v, want nil for nil error", result)
+		}
+	})
+
+	t.Run("wrapped non-rate-limit error returns nil", func(t *testing.T) {
+		err := fmt.Errorf("wrapped: %w", fmt.Errorf("inner error"))
+		result := resolver.wrapGitHubRateLimitError(err, GitHubContextVersionResolution)
+		if result != nil {
+			t.Errorf("wrapGitHubRateLimitError() = %v, want nil for wrapped non-rate-limit error", result)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

- Add `GitHubRateLimitContext` type to qualify what operation was being performed when rate limited
- Update error message to explain "while resolving tool versions from GitHub" for clarity
- Update suggestion message to explain that tsuku uses GitHub API to discover available versions
- Add test for `wrapGitHubRateLimitError` to improve resolver.go test coverage

This is a follow-up to PR #127 addressing feedback:
1. Error message now explains **why** users hit GitHub rate limits
2. Context qualifier allows different error messages for future GitHub API uses
3. Improved test coverage for resolver.go

## Test plan

- [x] All existing tests pass
- [x] New tests for context-aware error messages added
- [x] Test for `wrapGitHubRateLimitError` function added