### PR TITLE
fix(actions): use VersionTag for go_install module version

### DIFF
--- a/internal/actions/go_install.go
+++ b/internal/actions/go_install.go
@@ -50,8 +50,9 @@ func (a *GoInstallAction) Execute(ctx *ExecutionContext, params map[string]inter
 	}
 
 	// SECURITY: Validate version string
-	if !isValidGoVersion(ctx.Version) {
-		return fmt.Errorf("invalid version format '%s': must match semver format", ctx.Version)
+	// Use VersionTag for Go modules as they require the "v" prefix (e.g., v1.0.0)
+	if !isValidGoVersion(ctx.VersionTag) {
+		return fmt.Errorf("invalid version format '%s': must match semver format", ctx.VersionTag)
 	}
 
 	// Get executables list (required)
@@ -74,7 +75,7 @@ func (a *GoInstallAction) Execute(ctx *ExecutionContext, params map[string]inter
 		return fmt.Errorf("go not found: install go first (tsuku install go)")
 	}
 
-	fmt.Printf("   Module: %s@%s\n", module, ctx.Version)
+	fmt.Printf("   Module: %s@%s\n", module, ctx.VersionTag)
 	fmt.Printf("   Executables: %v\n", executables)
 	fmt.Printf("   Using go: %s\n", goPath)
 
@@ -88,9 +89,10 @@ func (a *GoInstallAction) Execute(ctx *ExecutionContext, params map[string]inter
 	binDir := filepath.Join(installDir, "bin")
 
 	// Build install target
+	// Use VersionTag which preserves the "v" prefix required by Go modules
 	var target string
-	if ctx.Version != "" {
-		target = module + "@" + ctx.Version
+	if ctx.VersionTag != "" {
+		target = module + "@" + ctx.VersionTag
 	} else {
 		target = module + "@latest"
 	}

--- a/internal/actions/go_install_test.go
+++ b/internal/actions/go_install_test.go
@@ -106,7 +106,8 @@ func TestGoInstallAction_Execute_MissingModule(t *testing.T) {
 	ctx := &ExecutionContext{
 		Context:    context.Background(),
 		InstallDir: t.TempDir(),
-		Version:    "v1.0.0",
+		Version:    "1.0.0",
+		VersionTag: "v1.0.0",
 		WorkDir:    t.TempDir(),
 	}
 
@@ -130,7 +131,8 @@ func TestGoInstallAction_Execute_MissingExecutables(t *testing.T) {
 	ctx := &ExecutionContext{
 		Context:    context.Background(),
 		InstallDir: t.TempDir(),
-		Version:    "v1.0.0",
+		Version:    "1.0.0",
+		VersionTag: "v1.0.0",
 		WorkDir:    t.TempDir(),
 	}
 
@@ -154,7 +156,8 @@ func TestGoInstallAction_Execute_EmptyExecutables(t *testing.T) {
 	ctx := &ExecutionContext{
 		Context:    context.Background(),
 		InstallDir: t.TempDir(),
-		Version:    "v1.0.0",
+		Version:    "1.0.0",
+		VersionTag: "v1.0.0",
 		WorkDir:    t.TempDir(),
 	}
 
@@ -175,7 +178,8 @@ func TestGoInstallAction_Execute_InvalidModule(t *testing.T) {
 	ctx := &ExecutionContext{
 		Context:    context.Background(),
 		InstallDir: t.TempDir(),
-		Version:    "v1.0.0",
+		Version:    "1.0.0",
+		VersionTag: "v1.0.0",
 		WorkDir:    t.TempDir(),
 	}
 
@@ -199,7 +203,8 @@ func TestGoInstallAction_Execute_InvalidVersion(t *testing.T) {
 	ctx := &ExecutionContext{
 		Context:    context.Background(),
 		InstallDir: t.TempDir(),
-		Version:    "v1.0.0;rm -rf /", // Injection attempt
+		Version:    "1.0.0",
+		VersionTag: "v1.0.0;rm -rf /", // Injection attempt in VersionTag
 		WorkDir:    t.TempDir(),
 	}
 
@@ -223,7 +228,8 @@ func TestGoInstallAction_Execute_InvalidExecutableName(t *testing.T) {
 	ctx := &ExecutionContext{
 		Context:    context.Background(),
 		InstallDir: t.TempDir(),
-		Version:    "v1.0.0",
+		Version:    "1.0.0",
+		VersionTag: "v1.0.0",
 		WorkDir:    t.TempDir(),
 	}
 
@@ -261,7 +267,8 @@ func TestGoInstallAction_Execute_GoNotInstalled(t *testing.T) {
 	ctx := &ExecutionContext{
 		Context:    context.Background(),
 		InstallDir: t.TempDir(),
-		Version:    "v1.0.0",
+		Version:    "1.0.0",
+		VersionTag: "v1.0.0",
 		WorkDir:    t.TempDir(),
 	}
 
@@ -415,7 +422,8 @@ func TestGoInstallAction_Execute_GoInstallFails(t *testing.T) {
 	ctx := &ExecutionContext{
 		Context:    context.Background(),
 		InstallDir: t.TempDir(),
-		Version:    "v1.0.0",
+		Version:    "1.0.0",
+		VersionTag: "v1.0.0",
 		WorkDir:    t.TempDir(),
 	}
 
@@ -460,7 +468,8 @@ func TestGoInstallAction_Execute_ExecutableNotCreated(t *testing.T) {
 	ctx := &ExecutionContext{
 		Context:    context.Background(),
 		InstallDir: t.TempDir(),
-		Version:    "v1.0.0",
+		Version:    "1.0.0",
+		VersionTag: "v1.0.0",
 		WorkDir:    t.TempDir(),
 	}
 
@@ -505,7 +514,8 @@ func TestGoInstallAction_Execute_EmptyVersion(t *testing.T) {
 	ctx := &ExecutionContext{
 		Context:    context.Background(),
 		InstallDir: t.TempDir(),
-		Version:    "", // Empty version should use @latest
+		Version:    "",
+		VersionTag: "", // Empty version should use @latest
 		WorkDir:    t.TempDir(),
 	}
 
@@ -549,7 +559,8 @@ func TestGoInstallAction_Execute_Success(t *testing.T) {
 	ctx := &ExecutionContext{
 		Context:    context.Background(),
 		InstallDir: installDir,
-		Version:    "v1.0.0",
+		Version:    "1.0.0",
+		VersionTag: "v1.0.0",
 		WorkDir:    t.TempDir(),
 	}
 
@@ -607,7 +618,8 @@ func TestGoInstallAction_Execute_SuccessWithDebug(t *testing.T) {
 	ctx := &ExecutionContext{
 		Context:    context.Background(),
 		InstallDir: installDir,
-		Version:    "v1.0.0",
+		Version:    "1.0.0",
+		VersionTag: "v1.0.0",
 		WorkDir:    t.TempDir(),
 	}
 
@@ -652,7 +664,8 @@ func TestGoInstallAction_Execute_MultipleExecutables(t *testing.T) {
 	ctx := &ExecutionContext{
 		Context:    context.Background(),
 		InstallDir: installDir,
-		Version:    "v1.0.0",
+		Version:    "1.0.0",
+		VersionTag: "v1.0.0",
 		WorkDir:    t.TempDir(),
 	}
 
@@ -697,7 +710,8 @@ func TestGoInstallAction_Execute_SecondExecutableMissing(t *testing.T) {
 	ctx := &ExecutionContext{
 		Context:    context.Background(),
 		InstallDir: installDir,
-		Version:    "v1.0.0",
+		Version:    "1.0.0",
+		VersionTag: "v1.0.0",
 		WorkDir:    t.TempDir(),
 	}
 


### PR DESCRIPTION
## Summary

- Fix go_install action to use VersionTag instead of Version for module path
- Go modules require the "v" prefix (e.g., v1.0.0), but Version is normalized without prefix

## Problem

The go_install action was incorrectly using `ctx.Version` (normalized to `0.9.2`) instead of `ctx.VersionTag` (original tag `v0.9.2`) when building the install target. This caused errors like:

```
go: mvdan.cc/gofumpt@0.9.2: invalid version: unknown revision 0.9.2
```

## Solution

Changed go_install.go to use `ctx.VersionTag` which preserves the original version format with the "v" prefix.

## Test plan

- [x] All existing go_install tests pass
- [x] Full test suite passes
- [ ] Manual test with gofumpt recipe