### PR TITLE
feat(telemetry): add /version endpoint for deployment verification

### DIFF
--- a/.github/workflows/telemetry-deploy.yml
+++ b/.github/workflows/telemetry-deploy.yml
@@ -22,3 +22,17 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_WORKERS_DEPLOYER_TOKEN }}
           workingDirectory: telemetry
+          vars: |
+            COMMIT_SHA:${{ github.sha }}
+            DEPLOY_TIME:${{ github.event.head_commit.timestamp }}
+
+      - name: Verify deployment
+        run: |
+          sleep 5  # Give Workers a moment to propagate
+          RESPONSE=$(curl -sf -H "Authorization: Bearer ${{ vars.TELEMETRY_VERSION_TOKEN }}" https://telemetry.tsuku.dev/version)
+          DEPLOYED_SHA=$(echo "$RESPONSE" | jq -r '.commit_sha')
+          if [ "$DEPLOYED_SHA" != "${{ github.sha }}" ]; then
+            echo "::error::Deployment verification failed: expected ${{ github.sha }}, got $DEPLOYED_SHA"
+            exit 1
+          fi
+          echo "Deployment verified: $DEPLOYED_SHA"

--- a/scripts/telemetry-version.sh
+++ b/scripts/telemetry-version.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Fetch the deployed telemetry worker version
+# Requires: gh CLI authenticated, TELEMETRY_VERSION_TOKEN set as repo variable
+
+set -euo pipefail
+
+REPO="tsuku-dev/tsuku"
+ENDPOINT="https://telemetry.tsuku.dev/version"
+
+TOKEN=$(gh variable get TELEMETRY_VERSION_TOKEN --repo "$REPO" 2>/dev/null) || {
+  echo "Error: TELEMETRY_VERSION_TOKEN not set as repository variable" >&2
+  echo "Set it with: gh variable set TELEMETRY_VERSION_TOKEN --repo $REPO" >&2
+  exit 1
+}
+
+curl -sf -H "Authorization: Bearer $TOKEN" "$ENDPOINT" | jq .

--- a/telemetry/vitest.config.ts
+++ b/telemetry/vitest.config.ts
@@ -9,6 +9,13 @@ export default defineWorkersConfig({
     poolOptions: {
       workers: {
         wrangler: { configPath: "./wrangler.toml" },
+        miniflare: {
+          bindings: {
+            VERSION_TOKEN: "test-version-token",
+            COMMIT_SHA: "test-commit-sha",
+            DEPLOY_TIME: "2024-01-01T00:00:00Z",
+          },
+        },
       },
     },
   },

--- a/telemetry/wrangler.toml
+++ b/telemetry/wrangler.toml
@@ -10,6 +10,8 @@ dataset = "tsuku_telemetry"
 CF_ACCOUNT_ID = "3c4fa2269fc145e89553adc332dc9546"
 
 # CF_API_TOKEN should be set via wrangler secret
+# VERSION_TOKEN should be set via wrangler secret
+# COMMIT_SHA and DEPLOY_TIME are set by CI during deployment
 
 # Custom domain: telemetry.tsuku.dev
 # Configured via Cloudflare Dashboard (Workers > tsuku-telemetry > Settings > Domains & Routes)


### PR DESCRIPTION
## Summary

- Adds a protected `/version` endpoint that returns commit SHA and deploy time
- Allows verifying deployments by checking the deployed version matches the expected commit
- Endpoint requires Bearer token (`VERSION_TOKEN` secret) for access

## Implementation

- Added `VERSION_TOKEN`, `COMMIT_SHA`, and `DEPLOY_TIME` to the `Env` interface
- Created `/version` GET endpoint with token validation
- Updated deploy workflow to pass commit SHA and timestamp as vars
- Added 4 new tests for the endpoint (401 without auth, 401 with wrong token, 200 with valid token, CORS headers)

## Setup Required After Merge

Create the `VERSION_TOKEN` secret in Cloudflare Workers:

```bash
cd telemetry
wrangler secret put VERSION_TOKEN
# Enter a secure random token
```

## Usage

After deployment, verify with:

```bash
curl -H "Authorization: Bearer YOUR_TOKEN" https://telemetry.tsuku.dev/version
```

Returns:
```json
{
  "commit_sha": "abc123...",
  "deploy_time": "2024-12-04T19:30:00Z",
  "schema_version": "1"
}
```

## Test plan

- [x] All 44 tests pass (4 new tests for /version endpoint)
- [x] Type check passes
- [ ] CI passes
- [ ] After merge, set VERSION_TOKEN secret and verify endpoint works