### PR TITLE
chore: post-transfer updates for new org

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -27,6 +27,6 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_DEPLOYER_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: tsukumogami
+          projectName: tsuku-dev
           directory: website
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Post-transfer updates after moving from `tsuku-dev` to `tsukumogami`:

- Update `website/install.sh` REPO to `tsukumogami/tsuku`
- Update Cloudflare Pages project name to `tsukumogami`

## Test plan

- [x] CI passes
- [ ] Install script works: `curl -fsSL https://get.tsuku.dev/now | bash`