### PR TITLE
docs: add design for flexible recipe verification

### DIFF
--- a/docs/DESIGN-version-verification.md
+++ b/docs/DESIGN-version-verification.md
@@ -1,6 +1,6 @@
 # Design: Flexible Recipe Verification
 
-- **Status**: Accepted
+- **Status**: Planned
 - **Issue**: #192
 - **Author**: @dangazineu
 - **Created**: 2025-12-06
@@ -853,4 +853,24 @@ When adding verification methods:
 2. **Opt-in enhancement**: Version verification remains the required baseline; additional methods are optional
 3. **Clear failure modes**: Each layer should report distinct, actionable errors
 4. **Independent evolution**: Recipes can adopt new methods without changing existing verification
+
+## Implementation Issues
+
+### Milestone: Version Verification
+
+- [#196](https://github.com/tsukumogami/tsuku/issues/196): feat(recipe): add verification mode and version format fields
+- [#197](https://github.com/tsukumogami/tsuku/issues/197): feat(version): implement version format transforms with validation
+- [#198](https://github.com/tsukumogami/tsuku/issues/198): feat(validator): enforce verification mode rules and security checks
+- [#199](https://github.com/tsukumogami/tsuku/issues/199): feat(executor): apply version format transforms during verification
+- [#200](https://github.com/tsukumogami/tsuku/issues/200): chore(recipes): migrate recipes to use verification modes
+- [#201](https://github.com/tsukumogami/tsuku/issues/201): docs: document verification modes and version format transforms
+
+### Milestone: Defense-in-Depth Verification
+
+- [#202](https://github.com/tsukumogami/tsuku/issues/202): feat(verify): version verification (Layer 2) [umbrella]
+- [#203](https://github.com/tsukumogami/tsuku/issues/203): feat(verify): post-install checksum pinning (Layer 3) [needs-design]
+- [#204](https://github.com/tsukumogami/tsuku/issues/204): feat(verify): functional testing framework (Layer 4) [needs-design]
+- [#205](https://github.com/tsukumogami/tsuku/issues/205): feat(verify): import tests from Homebrew formulas (Layer 4) [needs-design]
+- [#207](https://github.com/tsukumogami/tsuku/issues/207): feat(verify): import tests from Nix derivations (Layer 4) [needs-design]
+- [#208](https://github.com/tsukumogami/tsuku/issues/208): feat(verify): signature and SLSA provenance verification (Layer 1) [needs-design]
 


### PR DESCRIPTION
## Summary

- Proposes flexible verification modes (`version`, `functional`, `output`) to handle tools with different capabilities
- Adds version format transforms (`semver`, `strip_v`, `raw`) to address version format mismatches between tags and tool output
- Addresses ~40% of recipes that currently have weak version verification

## Context

Issue #192 identifies that many recipes can't use `{version}` placeholder due to format mismatches (e.g., GitHub tag `biome@2.3.8` vs tool output `2.3.8`). This design provides explicit transforms and verification modes to solve this.

## Key Design Decisions

1. **Explicit over magic**: Version transforms are explicitly declared in recipes, not heuristically applied
2. **Verification modes**: Three modes to cover different tool capabilities:
   - `version` (default): Requires `{version}` pattern match
   - `functional`: Tool runs successfully (for tools without `--version`)
   - `output`: Custom pattern matching
3. **Backward compatible**: All existing recipes continue working unchanged

## Security

- Added version string validation before shell expansion
- Expanded dangerous pattern detection in validator
- All security dimensions addressed per tsuku requirements

## Test plan

- [ ] Review design document for completeness
- [ ] Validate architectural clarity
- [ ] Check backward compatibility claims
- [ ] Review security mitigations