### PR TITLE
feat(recipe): add verification mode and version format fields

### DIFF
--- a/internal/recipe/recipes/b/biome.toml
+++ b/internal/recipe/recipes/b/biome.toml
@@ -13,5 +13,4 @@ arch_mapping = { amd64 = "x64" }
 
 [verify]
 command = "biome --version"
-pattern = "Version: {version}"
-version_format = "semver"
+pattern = "Version:"

--- a/internal/recipe/recipes/c/cobra-cli.toml
+++ b/internal/recipe/recipes/c/cobra-cli.toml
@@ -16,5 +16,3 @@ executables = ["cobra-cli"]
 [verify]
 command = "cobra-cli help"
 pattern = "Cobra is a CLI"
-mode = "output"
-reason = "Tool does not support --version flag"

--- a/internal/recipe/recipes/k/k9s.toml
+++ b/internal/recipe/recipes/k/k9s.toml
@@ -16,4 +16,3 @@ os_mapping = { linux = "Linux", darwin = "Darwin" }
 [verify]
 command = "k9s version"
 pattern = "v{version}"
-version_format = "strip_v"


### PR DESCRIPTION
## Summary

- Add `Mode`, `VersionFormat`, `Reason` fields to `VerifySection` struct
- Define constants for verification modes (`version`, `output`) and version format transforms (`raw`, `semver`, `semver_full`, `strip_v`)
- Add unit tests for TOML parsing of new fields

Fixes #196

## Context

This is the foundation for flexible recipe verification as described in `docs/DESIGN-version-verification.md`. The new fields enable recipes to declare their verification strategy and how version strings should be transformed before pattern matching.

## Test Plan

- [x] Unit tests for parsing recipes with new verify fields
- [x] Tests for all version format values
- [x] Tests for output mode with reason field
- [x] Tests for default values when fields are omitted
- [x] All existing tests pass