### PR TITLE
docs: add design for container validation (Slice 2)

### DIFF
--- a/docs/DESIGN-container-validation-slice-2.md
+++ b/docs/DESIGN-container-validation-slice-2.md
@@ -1,10 +1,35 @@
 # Design Document: Container Validation (Slice 2)
 
-**Status**: Proposed
+**Status**: Planned
 
 **Parent Issue**: [#268 - Slice 2: Container Validation](https://github.com/tsukumogami/tsuku/issues/268)
 
 **Parent Design**: [DESIGN-llm-builder-infrastructure.md](DESIGN-llm-builder-infrastructure.md)
+
+<a id="implementation-issues"></a>
+**Implementation Issues**:
+
+| Issue | Title | Design Section | Dependencies |
+|-------|-------|----------------|--------------|
+| [#302](https://github.com/tsukumogami/tsuku/issues/302) | Implement container runtime abstraction and detection | [Runtime Detector](#runtime-detector-internalvalidateruntimego) | None |
+| [#303](https://github.com/tsukumogami/tsuku/issues/303) | Implement asset pre-download with checksum capture | [Pre-Download](#pre-download-internalvalidatepredownloadgo) | None |
+| [#304](https://github.com/tsukumogami/tsuku/issues/304) | Implement parallel safety with lock files | [Parallel Safety](#parallel-safety-internalvalidatelockgo) | None |
+| [#305](https://github.com/tsukumogami/tsuku/issues/305) | Implement Podman runtime | [Components](#components) | #302 |
+| [#306](https://github.com/tsukumogami/tsuku/issues/306) | Implement Docker runtime | [Components](#components) | #302 |
+| [#307](https://github.com/tsukumogami/tsuku/issues/307) | Implement startup cleanup for orphaned containers | [Startup Cleanup](#startup-cleanup) | #304 |
+| [#308](https://github.com/tsukumogami/tsuku/issues/308) | Implement container executor for recipe validation | [Container Executor](#container-executor-internalvalidatecontainergo) | #303, #305, #306 |
+
+```
+Dependency Graph:
+
+#302 (Runtime abstraction) ──┬──> #305 (Podman runtime) ───┐
+                             │                              │
+                             └──> #306 (Docker runtime) ────┼──> #308 (Container executor)
+                                                            │
+#303 (Pre-download) ────────────────────────────────────────┘
+
+#304 (Lock manager) ──> #307 (Startup cleanup)
+```
 
 ## Context and Problem Statement
 


### PR DESCRIPTION
## Summary

Design document for Issue #268 (Container Validation - Slice 2).

## Key Findings

**Rootless containers require one-time system configuration with root privileges:**

| Requirement | Can tsuku install without root? |
|-------------|--------------------------------|
| Container runtime binaries | Yes (podman-static) |
| `/etc/subuid` and `/etc/subgid` | No |
| `newuidmap` / `newgidmap` | No |
| Kernel parameters | No |

This means tsuku cannot fully eliminate the need for sudo for container validation. Instead, the design focuses on:
1. **Auto-detection** of existing container runtimes
2. **Graceful degradation** when containers unavailable
3. **Clear warnings** to guide users

## Design Decisions

1. **Runtime Strategy**: Auto-detect (Podman rootless > Docker rootless > Docker group > None)
2. **Missing Runtime**: Skip validation with warning
3. **Rootless Detection**: Hybrid (config check + container test)
4. **Base Image**: Alpine for speed

## Components

- `internal/validate/runtime.go` - Runtime abstraction and detection
- `internal/validate/predownload.go` - Asset pre-download with checksums
- `internal/validate/container.go` - Container execution and validation
- `internal/validate/lock.go` - Parallel safety

## Research Sources

- [Podman Rootless Tutorial](https://github.com/containers/podman/blob/main/docs/tutorials/rootless_tutorial.md)
- [podman-static](https://github.com/mgoltzsche/podman-static) - Static Podman binaries
- [Docker Rootless Mode](https://docs.docker.com/engine/security/rootless/)
- [Bubblewrap](https://github.com/containers/bubblewrap) - Low-level sandboxing

Related: #268