### PR TITLE
docs: add design for recipe detail pages with dependency visualization

### DIFF
--- a/docs/DESIGN-recipe-detail-pages.md
+++ b/docs/DESIGN-recipe-detail-pages.md
@@ -1,6 +1,6 @@
 # Design: Recipe Detail Pages with Dependency Visualization
 
-**Status**: Accepted
+**Status**: Planned
 
 ## Context and Problem Statement
 
@@ -402,6 +402,18 @@ type View =
 ```
 
 ## Implementation Approach
+
+**Milestone:** [Recipe Detail Pages](https://github.com/tsukumogami/tsuku/milestone/14)
+**Parent Issue:** [#263](https://github.com/tsukumogami/tsuku/issues/263)
+
+| Issue | Title | Dependencies |
+|-------|-------|--------------|
+| [#339](https://github.com/tsukumogami/tsuku/issues/339) | feat(registry): add dependency fields to recipes.json schema | None |
+| [#340](https://github.com/tsukumogami/tsuku/issues/340) | feat(website): add client-side router for recipe pages | None |
+| [#341](https://github.com/tsukumogami/tsuku/issues/341) | feat(website): implement recipe detail view renderer | #339, #340 |
+| [#342](https://github.com/tsukumogami/tsuku/issues/342) | feat(website): update grid cards to navigate to detail pages | #340 |
+| [#343](https://github.com/tsukumogami/tsuku/issues/343) | feat(website): add Cloudflare Pages redirect for recipe URLs | None |
+| [#344](https://github.com/tsukumogami/tsuku/issues/344) | feat(website): style recipe detail pages | #341 |
 
 ### Phase 1: Extend JSON Schema
 


### PR DESCRIPTION
## Summary

This design document proposes adding individual detail pages for each recipe on tsuku.dev, enabling users to:
- See dependencies before installing
- Link directly to specific tools
- Browse tool information without CLI access

## Key Decisions

1. **Client-side routing (SPA + History API)** - Consistent with existing grid architecture; no static HTML generation
2. **Extended recipes.json** - Schema v1.1.0 adds `dependencies` and `runtime_dependencies` fields
3. **Simple dependency lists** - Grouped by type (install vs runtime)

## Why Client-Side Routing?

The grid page already requires JavaScript (fetches JSON, renders cards client-side). Generating 267+ static HTML files would:
- Add build complexity for marginal benefit
- Create architectural inconsistency (grid is dynamic, details would be static)
- Provide SEO for individual recipes that users don't search for

Instead, we extend the existing SPA pattern with History API routing for clean URLs.

## Trade-offs Accepted

- No SEO for individual recipes (users search for "tsuku", not "tsuku k9s")
- Brief loading state on direct links (same as current grid behavior)
- Requires JavaScript (but grid already requires it)

## Links

- Issue: #263
- Design doc: `docs/DESIGN-recipe-detail-pages.md`