### PR TITLE
feat(llm): implement circuit breaker

### DIFF
--- a/internal/llm/breaker.go
+++ b/internal/llm/breaker.go
@@ -1,0 +1,127 @@
+package llm
+
+import (
+	"sync"
+	"time"
+)
+
+// State represents the current state of a circuit breaker.
+type State int
+
+const (
+	// StateClosed is normal operation - requests pass through.
+	StateClosed State = iota
+	// StateOpen means the breaker is tripped - requests are rejected.
+	StateOpen
+	// StateHalfOpen allows one test request to check recovery.
+	StateHalfOpen
+)
+
+// String returns the string representation of the state.
+func (s State) String() string {
+	switch s {
+	case StateClosed:
+		return "closed"
+	case StateOpen:
+		return "open"
+	case StateHalfOpen:
+		return "half-open"
+	default:
+		return "unknown"
+	}
+}
+
+// CircuitBreaker implements the circuit breaker pattern for LLM providers.
+// It tracks failures and temporarily blocks requests to failing providers,
+// allowing recovery time while traffic shifts to healthy providers.
+type CircuitBreaker struct {
+	name             string
+	state            State
+	failures         int
+	lastFailure      time.Time
+	failureThreshold int
+	recoveryTimeout  time.Duration
+	mu               sync.Mutex
+
+	// now is a function that returns current time, injectable for testing.
+	now func() time.Time
+}
+
+// NewCircuitBreaker creates a circuit breaker with default settings.
+// Default threshold is 3 consecutive failures, recovery timeout is 60 seconds.
+func NewCircuitBreaker(name string) *CircuitBreaker {
+	return &CircuitBreaker{
+		name:             name,
+		state:            StateClosed,
+		failureThreshold: 3,
+		recoveryTimeout:  60 * time.Second,
+		now:              time.Now,
+	}
+}
+
+// Name returns the breaker's identifier.
+func (cb *CircuitBreaker) Name() string {
+	return cb.name
+}
+
+// Allow checks if a request should proceed.
+// Returns false if the breaker is open and recovery timeout hasn't elapsed.
+// If the breaker is open but timeout has elapsed, transitions to half-open.
+func (cb *CircuitBreaker) Allow() bool {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	switch cb.state {
+	case StateClosed:
+		return true
+	case StateOpen:
+		if cb.now().Sub(cb.lastFailure) >= cb.recoveryTimeout {
+			cb.state = StateHalfOpen
+			return true
+		}
+		return false
+	case StateHalfOpen:
+		// Only allow one request in half-open state
+		return true
+	default:
+		return false
+	}
+}
+
+// RecordSuccess resets the failure count and closes the breaker.
+// Should be called after a successful request.
+func (cb *CircuitBreaker) RecordSuccess() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	cb.failures = 0
+	cb.state = StateClosed
+}
+
+// RecordFailure increments the failure count and may trip the breaker.
+// If the failure threshold is reached, the breaker opens.
+func (cb *CircuitBreaker) RecordFailure() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	cb.failures++
+	cb.lastFailure = cb.now()
+
+	if cb.failures >= cb.failureThreshold {
+		cb.state = StateOpen
+	}
+}
+
+// State returns the current breaker state.
+func (cb *CircuitBreaker) State() State {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	return cb.state
+}
+
+// Failures returns the current failure count.
+func (cb *CircuitBreaker) Failures() int {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	return cb.failures
+}

--- a/internal/llm/breaker_test.go
+++ b/internal/llm/breaker_test.go
@@ -1,0 +1,269 @@
+package llm
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestNewCircuitBreaker(t *testing.T) {
+	cb := NewCircuitBreaker("test")
+
+	if cb.Name() != "test" {
+		t.Errorf("expected name 'test', got %q", cb.Name())
+	}
+	if cb.State() != StateClosed {
+		t.Errorf("expected initial state StateClosed, got %v", cb.State())
+	}
+	if cb.Failures() != 0 {
+		t.Errorf("expected initial failures 0, got %d", cb.Failures())
+	}
+}
+
+func TestCircuitBreakerAllowWhenClosed(t *testing.T) {
+	cb := NewCircuitBreaker("test")
+
+	if !cb.Allow() {
+		t.Error("expected Allow() to return true when closed")
+	}
+}
+
+func TestCircuitBreakerTripsAfterThreshold(t *testing.T) {
+	cb := NewCircuitBreaker("test")
+
+	// Record failures up to threshold
+	cb.RecordFailure()
+	cb.RecordFailure()
+	if cb.State() != StateClosed {
+		t.Errorf("expected state StateClosed after 2 failures, got %v", cb.State())
+	}
+
+	cb.RecordFailure() // Third failure should trip
+	if cb.State() != StateOpen {
+		t.Errorf("expected state StateOpen after 3 failures, got %v", cb.State())
+	}
+	if cb.Failures() != 3 {
+		t.Errorf("expected 3 failures, got %d", cb.Failures())
+	}
+}
+
+func TestCircuitBreakerRejectsWhenOpen(t *testing.T) {
+	cb := NewCircuitBreaker("test")
+
+	// Trip the breaker
+	cb.RecordFailure()
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	if cb.Allow() {
+		t.Error("expected Allow() to return false when open")
+	}
+}
+
+func TestCircuitBreakerRecoverySuccess(t *testing.T) {
+	cb := NewCircuitBreaker("test")
+
+	// Trip the breaker
+	cb.RecordFailure()
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	if cb.State() != StateOpen {
+		t.Errorf("expected state StateOpen, got %v", cb.State())
+	}
+
+	// Success resets state
+	cb.RecordSuccess()
+
+	if cb.State() != StateClosed {
+		t.Errorf("expected state StateClosed after success, got %v", cb.State())
+	}
+	if cb.Failures() != 0 {
+		t.Errorf("expected 0 failures after success, got %d", cb.Failures())
+	}
+	if !cb.Allow() {
+		t.Error("expected Allow() to return true after recovery")
+	}
+}
+
+func TestCircuitBreakerTransitionsToHalfOpen(t *testing.T) {
+	cb := NewCircuitBreaker("test")
+
+	// Use mock time
+	mockTime := time.Now()
+	cb.now = func() time.Time { return mockTime }
+
+	// Trip the breaker
+	cb.RecordFailure()
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	if cb.State() != StateOpen {
+		t.Errorf("expected state StateOpen, got %v", cb.State())
+	}
+
+	// Before timeout: should be rejected
+	mockTime = mockTime.Add(30 * time.Second)
+	if cb.Allow() {
+		t.Error("expected Allow() to return false before recovery timeout")
+	}
+
+	// After timeout: should transition to half-open
+	mockTime = mockTime.Add(31 * time.Second) // Total: 61 seconds
+	if !cb.Allow() {
+		t.Error("expected Allow() to return true after recovery timeout")
+	}
+	if cb.State() != StateHalfOpen {
+		t.Errorf("expected state StateHalfOpen, got %v", cb.State())
+	}
+}
+
+func TestCircuitBreakerHalfOpenToClosedOnSuccess(t *testing.T) {
+	cb := NewCircuitBreaker("test")
+
+	// Use mock time
+	mockTime := time.Now()
+	cb.now = func() time.Time { return mockTime }
+
+	// Trip the breaker
+	cb.RecordFailure()
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// Advance past recovery timeout
+	mockTime = mockTime.Add(61 * time.Second)
+	cb.Allow() // Transitions to half-open
+
+	if cb.State() != StateHalfOpen {
+		t.Errorf("expected state StateHalfOpen, got %v", cb.State())
+	}
+
+	// Success in half-open should close
+	cb.RecordSuccess()
+	if cb.State() != StateClosed {
+		t.Errorf("expected state StateClosed after success in half-open, got %v", cb.State())
+	}
+}
+
+func TestCircuitBreakerHalfOpenToOpenOnFailure(t *testing.T) {
+	cb := NewCircuitBreaker("test")
+
+	// Use mock time
+	mockTime := time.Now()
+	cb.now = func() time.Time { return mockTime }
+
+	// Trip the breaker
+	cb.RecordFailure()
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	// Advance past recovery timeout
+	mockTime = mockTime.Add(61 * time.Second)
+	cb.Allow() // Transitions to half-open
+
+	if cb.State() != StateHalfOpen {
+		t.Errorf("expected state StateHalfOpen, got %v", cb.State())
+	}
+
+	// Failure in half-open should trip again (failures now at 4)
+	cb.RecordFailure()
+	if cb.State() != StateOpen {
+		t.Errorf("expected state StateOpen after failure in half-open, got %v", cb.State())
+	}
+}
+
+func TestCircuitBreakerConcurrentAccess(t *testing.T) {
+	cb := NewCircuitBreaker("test")
+
+	var wg sync.WaitGroup
+	iterations := 100
+
+	// Concurrent failures
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cb.RecordFailure()
+		}()
+	}
+
+	// Concurrent successes
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cb.RecordSuccess()
+		}()
+	}
+
+	// Concurrent Allow checks
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cb.Allow()
+		}()
+	}
+
+	// Concurrent State checks
+	for i := 0; i < iterations; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			cb.State()
+		}()
+	}
+
+	wg.Wait()
+	// If we get here without panic or race condition, test passes
+}
+
+func TestStateString(t *testing.T) {
+	tests := []struct {
+		state    State
+		expected string
+	}{
+		{StateClosed, "closed"},
+		{StateOpen, "open"},
+		{StateHalfOpen, "half-open"},
+		{State(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		got := tt.state.String()
+		if got != tt.expected {
+			t.Errorf("State(%d).String() = %q, want %q", tt.state, got, tt.expected)
+		}
+	}
+}
+
+func TestCircuitBreakerSuccessResetsFailureCount(t *testing.T) {
+	cb := NewCircuitBreaker("test")
+
+	// Accumulate some failures (not enough to trip)
+	cb.RecordFailure()
+	cb.RecordFailure()
+
+	if cb.Failures() != 2 {
+		t.Errorf("expected 2 failures, got %d", cb.Failures())
+	}
+
+	// Success should reset
+	cb.RecordSuccess()
+
+	if cb.Failures() != 0 {
+		t.Errorf("expected 0 failures after success, got %d", cb.Failures())
+	}
+
+	// Now should need full threshold again to trip
+	cb.RecordFailure()
+	cb.RecordFailure()
+	if cb.State() != StateClosed {
+		t.Errorf("expected state StateClosed after 2 new failures, got %v", cb.State())
+	}
+
+	cb.RecordFailure()
+	if cb.State() != StateOpen {
+		t.Errorf("expected state StateOpen after 3 new failures, got %v", cb.State())
+	}
+}


### PR DESCRIPTION
## Summary

- Add `CircuitBreaker` struct with closed/open/half-open states
- Trips after 3 consecutive failures, recovers after 60s timeout
- Thread-safe with `sync.Mutex`
- Unit tests cover all state transitions with race detector verification

## Test plan

- [x] Build passes (`go build ./...`)
- [x] All tests pass (`go test ./...`)
- [x] Race detector passes (`go test -race ./internal/llm/...`)
- [x] Code formatted (`gofmt`)
- [x] Static analysis passes (`go vet`)

Closes #324