### PR TITLE
feat(validate): implement error parser for LLM repair

### DIFF
--- a/internal/validate/errors.go
+++ b/internal/validate/errors.go
@@ -1,0 +1,244 @@
+package validate
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// ErrorCategory classifies validation errors for targeted repair.
+type ErrorCategory string
+
+const (
+	// ErrorBinaryNotFound indicates the expected binary was not found after installation.
+	ErrorBinaryNotFound ErrorCategory = "binary_not_found"
+
+	// ErrorExtractionFailed indicates the archive could not be extracted.
+	ErrorExtractionFailed ErrorCategory = "extraction_failed"
+
+	// ErrorVerifyFailed indicates the verification command failed.
+	ErrorVerifyFailed ErrorCategory = "verify_failed"
+
+	// ErrorPermissionDenied indicates a file permission issue.
+	ErrorPermissionDenied ErrorCategory = "permission_denied"
+
+	// ErrorDownloadFailed indicates the asset download failed.
+	ErrorDownloadFailed ErrorCategory = "download_failed"
+
+	// ErrorUnknown is used when the error doesn't match any known pattern.
+	ErrorUnknown ErrorCategory = "unknown"
+)
+
+// ParsedError contains structured information about a validation failure.
+type ParsedError struct {
+	// Category classifies the type of error for targeted repair.
+	Category ErrorCategory
+
+	// Message is the sanitized error message.
+	Message string
+
+	// Details contains extracted information about the error.
+	// Keys may include: "command", "file", "expected", "actual".
+	Details map[string]string
+
+	// Suggestions contains potential fixes for this error category.
+	Suggestions []string
+}
+
+// Error patterns for each category
+var (
+	binaryNotFoundPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)command not found`),
+		regexp.MustCompile(`(?im)(\S+):\s+not found\s*$`), // Must be at end of line (multiline)
+		regexp.MustCompile(`(?i)no such file or directory`),
+		regexp.MustCompile(`(?i)cannot find[:\s]+(\S+)`),
+		regexp.MustCompile(`(?i)executable file not found`),
+		regexp.MustCompile(`(?i)exec[:\s]+"[^"]+"\s*:\s*not found`), // exec: "cmd": not found
+	}
+
+	extractionFailedPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)tar:\s+.*error`),
+		regexp.MustCompile(`(?i)tar:\s+cannot`),
+		regexp.MustCompile(`(?i)unzip[:\s]+.*error`),
+		regexp.MustCompile(`(?i)gzip[:\s]+.*error`),
+		regexp.MustCompile(`(?i)error opening archive`),
+		regexp.MustCompile(`(?i)not in gzip format`),
+		regexp.MustCompile(`(?i)invalid tar header`),
+		regexp.MustCompile(`(?i)unexpected EOF`),
+		regexp.MustCompile(`(?i)archive.*corrupt`),
+	}
+
+	verifyFailedPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)verification failed`),
+		regexp.MustCompile(`(?i)checksum.*mismatch`),
+		regexp.MustCompile(`(?i)sha256.*mismatch`),
+		regexp.MustCompile(`(?i)signature.*invalid`),
+		regexp.MustCompile(`(?i)gpg[:\s]+.*failed`),
+		regexp.MustCompile(`(?i)expected.*got`),
+	}
+
+	permissionDeniedPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)permission denied`),
+		regexp.MustCompile(`(?i)operation not permitted`),
+		regexp.MustCompile(`(?i)access denied`),
+		regexp.MustCompile(`(?i)EACCES`),
+		regexp.MustCompile(`(?i)cannot write`),
+		regexp.MustCompile(`(?i)read-only file system`),
+	}
+
+	downloadFailedPatterns = []*regexp.Regexp{
+		regexp.MustCompile(`(?i)download failed`),
+		regexp.MustCompile(`(?i)connection refused`),
+		regexp.MustCompile(`(?i)connection timed out`),
+		regexp.MustCompile(`(?i)could not resolve host`),
+		regexp.MustCompile(`(?i)404.*not found`),
+		regexp.MustCompile(`(?i)curl[:\s]+.*error`),
+		regexp.MustCompile(`(?i)wget[:\s]+.*error`),
+		regexp.MustCompile(`(?i)HTTP.*[45]\d\d`),
+	}
+)
+
+// Suggestions for each error category
+var categorySuggestions = map[ErrorCategory][]string{
+	ErrorBinaryNotFound: {
+		"Check the binary name in the recipe matches the actual binary in the archive",
+		"Verify the install_binaries action has the correct source path",
+		"Check if the binary needs to be extracted from a subdirectory",
+	},
+	ErrorExtractionFailed: {
+		"Verify the archive format matches the extraction action (tar.gz, zip, etc.)",
+		"Check if the archive requires a different extraction command",
+		"Ensure the download URL points to a valid archive file",
+	},
+	ErrorVerifyFailed: {
+		"Check that the verification command is correct for this tool",
+		"Verify the checksum or signature file is accessible",
+		"Try running without verification to isolate the issue",
+	},
+	ErrorPermissionDenied: {
+		"Check file permissions in the recipe actions",
+		"Ensure the chmod action is applied before execution",
+		"Verify the installation directory is writable",
+	},
+	ErrorDownloadFailed: {
+		"Verify the download URL is correct and accessible",
+		"Check if the URL requires authentication",
+		"Ensure the asset name pattern matches the actual release asset",
+	},
+	ErrorUnknown: {
+		"Review the full error output for clues",
+		"Check if all recipe actions are in the correct order",
+		"Verify the recipe syntax is correct",
+	},
+}
+
+// ParseValidationError analyzes validation output to categorize the failure.
+// It examines stdout, stderr, and the exit code to determine the error category
+// and provide targeted suggestions for repair.
+func ParseValidationError(stdout, stderr string, exitCode int) *ParsedError {
+	// Combine output for pattern matching
+	combined := stderr + "\n" + stdout
+
+	// Check patterns in order of specificity (most specific first)
+	// Extraction errors checked first because they may contain "not found" within tar/unzip context
+	if category, details := matchCategory(combined, extractionFailedPatterns, ErrorExtractionFailed); category != ErrorUnknown {
+		return &ParsedError{
+			Category:    category,
+			Message:     extractRelevantMessage(combined, 500),
+			Details:     details,
+			Suggestions: categorySuggestions[category],
+		}
+	}
+
+	if category, details := matchCategory(combined, binaryNotFoundPatterns, ErrorBinaryNotFound); category != ErrorUnknown {
+		return &ParsedError{
+			Category:    category,
+			Message:     extractRelevantMessage(combined, 500),
+			Details:     details,
+			Suggestions: categorySuggestions[category],
+		}
+	}
+
+	if category, details := matchCategory(combined, verifyFailedPatterns, ErrorVerifyFailed); category != ErrorUnknown {
+		return &ParsedError{
+			Category:    category,
+			Message:     extractRelevantMessage(combined, 500),
+			Details:     details,
+			Suggestions: categorySuggestions[category],
+		}
+	}
+
+	if category, details := matchCategory(combined, permissionDeniedPatterns, ErrorPermissionDenied); category != ErrorUnknown {
+		return &ParsedError{
+			Category:    category,
+			Message:     extractRelevantMessage(combined, 500),
+			Details:     details,
+			Suggestions: categorySuggestions[category],
+		}
+	}
+
+	if category, details := matchCategory(combined, downloadFailedPatterns, ErrorDownloadFailed); category != ErrorUnknown {
+		return &ParsedError{
+			Category:    category,
+			Message:     extractRelevantMessage(combined, 500),
+			Details:     details,
+			Suggestions: categorySuggestions[category],
+		}
+	}
+
+	// No specific pattern matched - return unknown with exit code info
+	details := make(map[string]string)
+	if exitCode != 0 {
+		details["exit_code"] = strconv.Itoa(exitCode)
+	}
+
+	return &ParsedError{
+		Category:    ErrorUnknown,
+		Message:     extractRelevantMessage(combined, 500),
+		Details:     details,
+		Suggestions: categorySuggestions[ErrorUnknown],
+	}
+}
+
+// matchCategory checks if any pattern in the list matches the output.
+// Returns the category if matched, or ErrorUnknown if not.
+func matchCategory(output string, patterns []*regexp.Regexp, category ErrorCategory) (ErrorCategory, map[string]string) {
+	details := make(map[string]string)
+
+	for _, pattern := range patterns {
+		matches := pattern.FindStringSubmatch(output)
+		if matches != nil {
+			// Extract any captured groups as details
+			if len(matches) > 1 {
+				details["matched"] = matches[1]
+			}
+			return category, details
+		}
+	}
+
+	return ErrorUnknown, nil
+}
+
+// extractRelevantMessage extracts a relevant portion of the error output.
+// It prioritizes stderr content and truncates to maxLength.
+func extractRelevantMessage(output string, maxLength int) string {
+	// Clean up the output
+	output = strings.TrimSpace(output)
+
+	if output == "" {
+		return "No error output captured"
+	}
+
+	// Take the last portion if too long (usually most relevant)
+	if len(output) > maxLength {
+		// Find a good break point
+		truncated := output[len(output)-maxLength:]
+		// Try to start at a newline
+		if idx := strings.Index(truncated, "\n"); idx > 0 && idx < 50 {
+			truncated = truncated[idx+1:]
+		}
+		return "..." + truncated
+	}
+
+	return output
+}

--- a/internal/validate/errors_test.go
+++ b/internal/validate/errors_test.go
@@ -1,0 +1,343 @@
+package validate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseValidationErrorBinaryNotFound(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+		stdout string
+	}{
+		{
+			name:   "command not found",
+			stderr: "bash: mytool: command not found",
+		},
+		{
+			name:   "not found suffix",
+			stderr: "mytool: not found\n", // Must be at end of line
+		},
+		{
+			name:   "no such file or directory",
+			stderr: "/usr/bin/mytool: no such file or directory",
+		},
+		{
+			name:   "cannot find",
+			stderr: "cannot find: mytool",
+		},
+		{
+			name:   "executable file not found",
+			stderr: "exec: executable file not found in $PATH",
+		},
+		{
+			name:   "exec not found",
+			stderr: "exec: \"mytool\": not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseValidationError(tt.stdout, tt.stderr, 127)
+
+			if result.Category != ErrorBinaryNotFound {
+				t.Errorf("expected category %v, got %v", ErrorBinaryNotFound, result.Category)
+			}
+			if len(result.Suggestions) == 0 {
+				t.Error("expected suggestions, got none")
+			}
+		})
+	}
+}
+
+func TestParseValidationErrorExtractionFailed(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+	}{
+		{
+			name:   "tar error",
+			stderr: "tar: Error opening archive: Failed to open 'file.tar.gz'",
+		},
+		{
+			name:   "tar cannot",
+			stderr: "tar: cannot open: No such file or directory",
+		},
+		{
+			name:   "unzip error",
+			stderr: "unzip: error extracting file.zip",
+		},
+		{
+			name:   "gzip error",
+			stderr: "gzip: stdin: not in gzip format",
+		},
+		{
+			name:   "not in gzip format",
+			stderr: "not in gzip format",
+		},
+		{
+			name:   "invalid tar header",
+			stderr: "archive/tar: invalid tar header",
+		},
+		{
+			name:   "unexpected EOF",
+			stderr: "unexpected EOF while reading archive",
+		},
+		{
+			name:   "corrupt archive",
+			stderr: "archive is corrupt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseValidationError("", tt.stderr, 1)
+
+			if result.Category != ErrorExtractionFailed {
+				t.Errorf("expected category %v, got %v", ErrorExtractionFailed, result.Category)
+			}
+			if len(result.Suggestions) == 0 {
+				t.Error("expected suggestions, got none")
+			}
+		})
+	}
+}
+
+func TestParseValidationErrorVerifyFailed(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+	}{
+		{
+			name:   "verification failed",
+			stderr: "verification failed: checksum does not match",
+		},
+		{
+			name:   "checksum mismatch",
+			stderr: "checksum mismatch for downloaded file",
+		},
+		{
+			name:   "sha256 mismatch",
+			stderr: "sha256 mismatch: expected abc123 got def456",
+		},
+		{
+			name:   "signature invalid",
+			stderr: "signature invalid for package",
+		},
+		{
+			name:   "gpg failed",
+			stderr: "gpg: verification failed",
+		},
+		{
+			name:   "expected got",
+			stderr: "expected 'abc123' got 'def456'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseValidationError("", tt.stderr, 1)
+
+			if result.Category != ErrorVerifyFailed {
+				t.Errorf("expected category %v, got %v", ErrorVerifyFailed, result.Category)
+			}
+			if len(result.Suggestions) == 0 {
+				t.Error("expected suggestions, got none")
+			}
+		})
+	}
+}
+
+func TestParseValidationErrorPermissionDenied(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+	}{
+		{
+			name:   "permission denied",
+			stderr: "/usr/local/bin/mytool: Permission denied",
+		},
+		{
+			name:   "operation not permitted",
+			stderr: "Operation not permitted",
+		},
+		{
+			name:   "access denied",
+			stderr: "Access denied to file",
+		},
+		{
+			name:   "EACCES",
+			stderr: "EACCES: permission denied, open '/file'",
+		},
+		{
+			name:   "cannot write",
+			stderr: "cannot write to /etc/config",
+		},
+		{
+			name:   "read-only file system",
+			stderr: "Read-only file system",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseValidationError("", tt.stderr, 1)
+
+			if result.Category != ErrorPermissionDenied {
+				t.Errorf("expected category %v, got %v", ErrorPermissionDenied, result.Category)
+			}
+			if len(result.Suggestions) == 0 {
+				t.Error("expected suggestions, got none")
+			}
+		})
+	}
+}
+
+func TestParseValidationErrorDownloadFailed(t *testing.T) {
+	tests := []struct {
+		name   string
+		stderr string
+	}{
+		{
+			name:   "download failed",
+			stderr: "download failed: network error",
+		},
+		{
+			name:   "connection refused",
+			stderr: "Connection refused",
+		},
+		{
+			name:   "connection timed out",
+			stderr: "Connection timed out",
+		},
+		{
+			name:   "could not resolve host",
+			stderr: "Could not resolve host: example.com",
+		},
+		{
+			name:   "404 not found",
+			stderr: "404 Not Found",
+		},
+		{
+			name:   "curl error",
+			stderr: "curl: (7) error connecting to host",
+		},
+		{
+			name:   "wget error",
+			stderr: "wget: error downloading file",
+		},
+		{
+			name:   "HTTP 500",
+			stderr: "HTTP 500 Internal Server Error",
+		},
+		{
+			name:   "HTTP 403",
+			stderr: "HTTP 403 Forbidden",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ParseValidationError("", tt.stderr, 1)
+
+			if result.Category != ErrorDownloadFailed {
+				t.Errorf("expected category %v, got %v", ErrorDownloadFailed, result.Category)
+			}
+			if len(result.Suggestions) == 0 {
+				t.Error("expected suggestions, got none")
+			}
+		})
+	}
+}
+
+func TestParseValidationErrorUnknown(t *testing.T) {
+	result := ParseValidationError("stdout content", "some generic error", 42)
+
+	if result.Category != ErrorUnknown {
+		t.Errorf("expected category %v, got %v", ErrorUnknown, result.Category)
+	}
+	if result.Details["exit_code"] != "42" {
+		t.Errorf("expected exit_code '42', got %q", result.Details["exit_code"])
+	}
+	if len(result.Suggestions) == 0 {
+		t.Error("expected suggestions, got none")
+	}
+}
+
+func TestParseValidationErrorEmptyOutput(t *testing.T) {
+	result := ParseValidationError("", "", 1)
+
+	if result.Category != ErrorUnknown {
+		t.Errorf("expected category %v, got %v", ErrorUnknown, result.Category)
+	}
+	if result.Message != "No error output captured" {
+		t.Errorf("expected 'No error output captured', got %q", result.Message)
+	}
+}
+
+func TestParseValidationErrorPriority(t *testing.T) {
+	// When multiple patterns could match, the first matched category wins
+	// Binary not found should be checked before others
+	stderr := "command not found: mytool\npermission denied"
+	result := ParseValidationError("", stderr, 127)
+
+	if result.Category != ErrorBinaryNotFound {
+		t.Errorf("expected category %v (first match), got %v", ErrorBinaryNotFound, result.Category)
+	}
+}
+
+func TestParseValidationErrorMessageTruncation(t *testing.T) {
+	// Generate very long output
+	longOutput := strings.Repeat("x", 1000)
+	result := ParseValidationError(longOutput, "", 1)
+
+	if len(result.Message) > 550 { // 500 + some overhead for "..."
+		t.Errorf("expected message to be truncated, got length %d", len(result.Message))
+	}
+}
+
+func TestParseValidationErrorStdoutFallback(t *testing.T) {
+	// Error in stdout should also be detected
+	result := ParseValidationError("command not found: mytool", "", 127)
+
+	if result.Category != ErrorBinaryNotFound {
+		t.Errorf("expected category %v from stdout, got %v", ErrorBinaryNotFound, result.Category)
+	}
+}
+
+func TestErrorCategoryStrings(t *testing.T) {
+	categories := []ErrorCategory{
+		ErrorBinaryNotFound,
+		ErrorExtractionFailed,
+		ErrorVerifyFailed,
+		ErrorPermissionDenied,
+		ErrorDownloadFailed,
+		ErrorUnknown,
+	}
+
+	for _, cat := range categories {
+		if string(cat) == "" {
+			t.Errorf("category %v has empty string value", cat)
+		}
+	}
+}
+
+func TestParsedErrorHasSuggestions(t *testing.T) {
+	// Every category should have suggestions
+	categories := map[ErrorCategory]string{
+		ErrorBinaryNotFound:   "command not found: test",
+		ErrorExtractionFailed: "tar: Error opening archive",
+		ErrorVerifyFailed:     "verification failed",
+		ErrorPermissionDenied: "permission denied",
+		ErrorDownloadFailed:   "download failed",
+		ErrorUnknown:          "random error",
+	}
+
+	for category, stderr := range categories {
+		result := ParseValidationError("", stderr, 1)
+		if len(result.Suggestions) == 0 {
+			t.Errorf("category %v should have suggestions", category)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Implement error categorization for validation failures
- Define ErrorCategory enum with six categories: binary_not_found, extraction_failed, verify_failed, permission_denied, download_failed, unknown
- Provide category-specific repair suggestions to guide LLM repair logic

## Changes
- Add `internal/validate/errors.go` with ParseValidationError function
- Add `internal/validate/errors_test.go` with comprehensive test coverage

## Test plan
- [x] Run `go test ./internal/validate/...` to verify all tests pass
- [x] Verify gofmt formatting is correct

Closes #326