### PR TITLE
docs: add links to implementation issues in design doc

### DIFF
--- a/docs/DESIGN-installation-plans-eval.md
+++ b/docs/DESIGN-installation-plans-eval.md
@@ -11,13 +11,13 @@ Milestone: [Deterministic Recipe Execution](https://github.com/tsukumogami/tsuku
 
 | Issue | Title | Dependencies |
 |-------|-------|--------------|
-| #401 | feat(executor): add installation plan data types | None |
-| #402 | feat(executor): implement plan generator | Blocked by #401 |
-| #403 | feat(cli): add tsuku eval command | Blocked by #402 |
-| #404 | feat(install): store plans in state.json | Blocked by #402 |
-| #405 | feat(cli): add tsuku plan show command | Blocked by #404 |
-| #406 | feat(cli): add tsuku plan export command | Blocked by #404 |
-| #407 | fix(cache): harden download cache security | None (parallel) |
+| [#401](https://github.com/tsukumogami/tsuku/issues/401) | feat(executor): add installation plan data types | None |
+| [#402](https://github.com/tsukumogami/tsuku/issues/402) | feat(executor): implement plan generator | Blocked by #401 |
+| [#403](https://github.com/tsukumogami/tsuku/issues/403) | feat(cli): add tsuku eval command | Blocked by #402 |
+| [#404](https://github.com/tsukumogami/tsuku/issues/404) | feat(install): store plans in state.json | Blocked by #402 |
+| [#405](https://github.com/tsukumogami/tsuku/issues/405) | feat(cli): add tsuku plan show command | Blocked by #404 |
+| [#406](https://github.com/tsukumogami/tsuku/issues/406) | feat(cli): add tsuku plan export command | Blocked by #404 |
+| [#407](https://github.com/tsukumogami/tsuku/issues/407) | fix(cache): harden download cache security | None (parallel) |
 
 ## Upstream Design Reference
 


### PR DESCRIPTION
## Summary

- Add clickable GitHub links to issue numbers in the Implementation Issues table of DESIGN-installation-plans-eval.md

No issue associated with this change.