### PR TITLE
feat(log): add Logger interface and slog implementation

### DIFF
--- a/internal/log/logger.go
+++ b/internal/log/logger.go
@@ -1,0 +1,114 @@
+// Package log provides structured logging for tsuku.
+//
+// This package defines a Logger interface backed by Go's stdlib slog,
+// enabling testable logging throughout the codebase. Subsystems accept
+// the Logger via functional options, with a global default for convenience.
+//
+// Output semantics:
+//   - User output (stdout): Command results, progress, success messages
+//   - Diagnostic logging (stderr): Debug, Info, Warn, Error messages
+//
+// Verbosity levels:
+//   - ERROR (--quiet): Errors only
+//   - WARN (default): Warnings and user output
+//   - INFO (--verbose): Operational context
+//   - DEBUG (--debug): Internal state and troubleshooting details
+package log
+
+import (
+	"log/slog"
+	"sync"
+)
+
+// Logger is the interface for structured logging.
+// Methods match slog's signature for easy integration.
+type Logger interface {
+	// Debug logs at DEBUG level. Use for internal state, cache hits,
+	// version resolution details - information only useful for troubleshooting.
+	Debug(msg string, args ...any)
+
+	// Info logs at INFO level. Use for operational context like
+	// "Using cached asset" or "Connecting to registry".
+	Info(msg string, args ...any)
+
+	// Warn logs at WARN level. Use for recoverable issues like
+	// "Checksum mismatch, re-downloading".
+	Warn(msg string, args ...any)
+
+	// Error logs at ERROR level. Use for failures that prevent
+	// the operation from completing.
+	Error(msg string, args ...any)
+
+	// With returns a Logger with additional context attributes.
+	// The returned Logger includes the given key-value pairs in all
+	// subsequent log entries.
+	With(args ...any) Logger
+}
+
+// slogLogger wraps slog.Logger to implement the Logger interface.
+type slogLogger struct {
+	l *slog.Logger
+}
+
+// New creates a Logger backed by slog with the given handler.
+func New(h slog.Handler) Logger {
+	return &slogLogger{l: slog.New(h)}
+}
+
+func (s *slogLogger) Debug(msg string, args ...any) {
+	s.l.Debug(msg, args...)
+}
+
+func (s *slogLogger) Info(msg string, args ...any) {
+	s.l.Info(msg, args...)
+}
+
+func (s *slogLogger) Warn(msg string, args ...any) {
+	s.l.Warn(msg, args...)
+}
+
+func (s *slogLogger) Error(msg string, args ...any) {
+	s.l.Error(msg, args...)
+}
+
+func (s *slogLogger) With(args ...any) Logger {
+	return &slogLogger{l: s.l.With(args...)}
+}
+
+// noopLogger discards all log output.
+type noopLogger struct{}
+
+// NewNoop returns a logger that discards all output.
+// Useful for testing or when logging should be disabled.
+func NewNoop() Logger {
+	return noopLogger{}
+}
+
+func (noopLogger) Debug(string, ...any) {}
+func (noopLogger) Info(string, ...any)  {}
+func (noopLogger) Warn(string, ...any)  {}
+func (noopLogger) Error(string, ...any) {}
+func (noopLogger) With(...any) Logger   { return noopLogger{} }
+
+// defaultLogger is the global logger instance.
+var (
+	defaultLogger Logger = noopLogger{}
+	defaultMu     sync.RWMutex
+)
+
+// Default returns the global logger configured at startup.
+// Returns a noop logger if SetDefault has not been called.
+func Default() Logger {
+	defaultMu.RLock()
+	defer defaultMu.RUnlock()
+	return defaultLogger
+}
+
+// SetDefault sets the global logger.
+// This should be called once during program initialization,
+// typically in main() after parsing verbosity flags.
+func SetDefault(l Logger) {
+	defaultMu.Lock()
+	defer defaultMu.Unlock()
+	defaultLogger = l
+}

--- a/internal/log/logger_test.go
+++ b/internal/log/logger_test.go
@@ -1,0 +1,245 @@
+package log
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := New(h)
+
+	logger.Info("test message", "key", "value")
+
+	output := buf.String()
+	if !strings.Contains(output, "test message") {
+		t.Errorf("expected output to contain 'test message', got: %s", output)
+	}
+	if !strings.Contains(output, "key=value") {
+		t.Errorf("expected output to contain 'key=value', got: %s", output)
+	}
+}
+
+func TestLoggerLevels(t *testing.T) {
+	tests := []struct {
+		name     string
+		logFunc  func(Logger)
+		level    slog.Level
+		contains string
+	}{
+		{
+			name:     "Debug",
+			logFunc:  func(l Logger) { l.Debug("debug msg") },
+			level:    slog.LevelDebug,
+			contains: "debug msg",
+		},
+		{
+			name:     "Info",
+			logFunc:  func(l Logger) { l.Info("info msg") },
+			level:    slog.LevelInfo,
+			contains: "info msg",
+		},
+		{
+			name:     "Warn",
+			logFunc:  func(l Logger) { l.Warn("warn msg") },
+			level:    slog.LevelWarn,
+			contains: "warn msg",
+		},
+		{
+			name:     "Error",
+			logFunc:  func(l Logger) { l.Error("error msg") },
+			level:    slog.LevelError,
+			contains: "error msg",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+			logger := New(h)
+
+			tt.logFunc(logger)
+
+			output := buf.String()
+			if !strings.Contains(output, tt.contains) {
+				t.Errorf("expected output to contain %q, got: %s", tt.contains, output)
+			}
+			if !strings.Contains(output, strings.ToUpper(tt.name)) {
+				t.Errorf("expected output to contain level %q, got: %s", tt.name, output)
+			}
+		})
+	}
+}
+
+func TestLoggerWith(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := New(h)
+
+	// Create child logger with context
+	childLogger := logger.With("tool", "gh", "version", "2.0.0")
+	childLogger.Info("installing tool")
+
+	output := buf.String()
+	if !strings.Contains(output, "tool=gh") {
+		t.Errorf("expected output to contain 'tool=gh', got: %s", output)
+	}
+	if !strings.Contains(output, "version=2.0.0") {
+		t.Errorf("expected output to contain 'version=2.0.0', got: %s", output)
+	}
+	if !strings.Contains(output, "installing tool") {
+		t.Errorf("expected output to contain 'installing tool', got: %s", output)
+	}
+}
+
+func TestLoggerWithChaining(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := New(h)
+
+	// Chain multiple With calls
+	childLogger := logger.With("tool", "gh").With("action", "download")
+	childLogger.Debug("starting")
+
+	output := buf.String()
+	if !strings.Contains(output, "tool=gh") {
+		t.Errorf("expected output to contain 'tool=gh', got: %s", output)
+	}
+	if !strings.Contains(output, "action=download") {
+		t.Errorf("expected output to contain 'action=download', got: %s", output)
+	}
+}
+
+func TestNewNoop(t *testing.T) {
+	logger := NewNoop()
+
+	// These should not panic
+	logger.Debug("debug")
+	logger.Info("info")
+	logger.Warn("warn")
+	logger.Error("error")
+
+	// With should return a noop logger
+	child := logger.With("key", "value")
+	child.Info("should not panic")
+}
+
+func TestNoopLoggerWith(t *testing.T) {
+	logger := NewNoop()
+
+	// With on noop should return noop
+	child := logger.With("key", "value")
+
+	// Verify it's still a noop by checking type
+	_, ok := child.(noopLogger)
+	if !ok {
+		t.Error("expected With() on noopLogger to return noopLogger")
+	}
+}
+
+func TestDefaultLogger(t *testing.T) {
+	// Save original default
+	original := Default()
+	defer SetDefault(original)
+
+	// Default should work (initially noop)
+	Default().Info("should not panic")
+
+	// Set a custom default
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	customLogger := New(h)
+	SetDefault(customLogger)
+
+	// Verify Default() returns the custom logger
+	Default().Info("custom logger message")
+
+	output := buf.String()
+	if !strings.Contains(output, "custom logger message") {
+		t.Errorf("expected custom logger to be used, got: %s", output)
+	}
+}
+
+func TestDefaultLoggerConcurrency(t *testing.T) {
+	// Save original default
+	original := Default()
+	defer SetDefault(original)
+
+	// Run concurrent reads and writes
+	done := make(chan bool)
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < 100; j++ {
+				Default().Info("concurrent read")
+			}
+			done <- true
+		}()
+		go func() {
+			for j := 0; j < 100; j++ {
+				SetDefault(NewNoop())
+			}
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 20; i++ {
+		<-done
+	}
+}
+
+func TestLevelFiltering(t *testing.T) {
+	// Test that setting handler level filters lower-level messages
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn})
+	logger := New(h)
+
+	logger.Debug("debug - should not appear")
+	logger.Info("info - should not appear")
+	logger.Warn("warn - should appear")
+	logger.Error("error - should appear")
+
+	output := buf.String()
+
+	if strings.Contains(output, "debug - should not appear") {
+		t.Error("debug message should have been filtered")
+	}
+	if strings.Contains(output, "info - should not appear") {
+		t.Error("info message should have been filtered")
+	}
+	if !strings.Contains(output, "warn - should appear") {
+		t.Errorf("warn message should appear, got: %s", output)
+	}
+	if !strings.Contains(output, "error - should appear") {
+		t.Errorf("error message should appear, got: %s", output)
+	}
+}
+
+func TestLoggerWithKeyValuePairs(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	logger := New(h)
+
+	// Test various key-value types
+	logger.Info("test",
+		"string", "value",
+		"int", 42,
+		"bool", true,
+		"float", 3.14,
+	)
+
+	output := buf.String()
+	if !strings.Contains(output, "string=value") {
+		t.Errorf("expected 'string=value' in output: %s", output)
+	}
+	if !strings.Contains(output, "int=42") {
+		t.Errorf("expected 'int=42' in output: %s", output)
+	}
+	if !strings.Contains(output, "bool=true") {
+		t.Errorf("expected 'bool=true' in output: %s", output)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `internal/log` package with Logger interface and slog implementation
- Provides foundation for structured logging throughout the codebase
- Matches the design in `docs/DESIGN-structured-logging.md`

### What's included

- `Logger` interface with `Debug`, `Info`, `Warn`, `Error`, and `With` methods
- `New(h slog.Handler)` creates a slog-backed logger
- `NewNoop()` returns a logger that discards output (for testing)
- `Default()` and `SetDefault()` manage a global logger
- Thread-safe access using `sync.RWMutex`
- Comprehensive unit tests covering all methods and edge cases

This is Issue #417 in the Structured Logging Framework milestone. Subsequent issues will add the CLI handler (#419), verbosity flags (#421), and migrate existing code (#420, #422).

Fixes #417