### PR TITLE
docs: add verbosity documentation and mark logging design complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,33 @@ tsuku update kubectl
 tsuku remove kubectl
 ```
 
+### Verbosity and Debugging
+
+tsuku supports multiple verbosity levels for troubleshooting:
+
+```bash
+# Quiet mode - errors only
+tsuku install kubectl --quiet
+tsuku install kubectl -q
+
+# Verbose mode - show operational details
+tsuku install kubectl --verbose
+tsuku install kubectl -v
+
+# Debug mode - full diagnostic output (includes timestamps and source locations)
+tsuku install kubectl --debug
+```
+
+Verbosity can also be controlled via environment variables:
+
+```bash
+TSUKU_QUIET=1 tsuku install kubectl    # Errors only
+TSUKU_VERBOSE=1 tsuku install kubectl  # Verbose output
+TSUKU_DEBUG=1 tsuku install kubectl    # Debug output
+```
+
+Flags take precedence over environment variables. Debug mode displays a warning banner since output may contain file paths and URLs.
+
 ### Dependency Management
 
 tsuku automatically handles tool dependencies:

--- a/docs/DESIGN-structured-logging.md
+++ b/docs/DESIGN-structured-logging.md
@@ -1,6 +1,6 @@
 # DESIGN: Structured Logging Framework
 
-**Status:** Planned
+**Status:** Completed
 
 ## Context and Problem Statement
 


### PR DESCRIPTION
## Summary

- Add verbosity/debugging section to README with examples for --quiet, --verbose, --debug flags and environment variables
- Mark docs/DESIGN-structured-logging.md status as Completed

Milestone 16 (Structured Logging Framework) is now complete. The milestone should be closed after this PR merges.