### PR TITLE
docs: clarify plan-based architecture in Milestone 2

### DIFF
--- a/docs/DESIGN-deterministic-resolution.md
+++ b/docs/DESIGN-deterministic-resolution.md
@@ -76,12 +76,15 @@ The installation plan is the key artifact - a fully-resolved, deterministic spec
 
 ### Milestone 2: Deterministic Execution
 
-**Goal**: Make plan replay the default for re-installations when version is pinned.
+**Goal**: Refactor installation to use the two-phase (eval/exec) model, making all installations plan-based.
+
+**Architectural change**: `tsuku install foo` becomes functionally equivalent to `tsuku eval foo | tsuku install --plan -`. Every installation generates a plan (or reuses a cached one), then executes that plan. This single execution path guarantees determinism by architecture rather than careful implementation.
 
 **Deliverables**:
+- Refactor executor so all installations go through plan generation and execution
 - Re-install uses stored plan when version constraint exactly matches resolved version
 - `--refresh` flag to force fresh evaluation
-- Checksum verification during download
+- Checksum verification during plan execution
 - Clear error on checksum mismatch (indicates upstream change)
 
 **Value delivered**:


### PR DESCRIPTION
## Summary

- Clarify that Milestone 2 is about refactoring all installations to use plans, not just optimizing re-installations
- Add "Architectural change" paragraph explaining that `tsuku install foo` ≡ `tsuku eval foo | tsuku install --plan -`

## Context

Issue #368 was poorly framed as "deterministic execution for pinned versions", suggesting plan-based execution was only for re-installations. The design docs (DESIGN-installation-plans-eval.md and DESIGN-decomposable-actions.md) already established the correct architecture, but DESIGN-deterministic-resolution.md's Milestone 2 section was ambiguous.

This PR aligns the strategic design with the tactical designs.

Related: #368, #370

## Test plan

- [ ] Verify the change reads clearly and aligns with DESIGN-installation-plans-eval.md and DESIGN-decomposable-actions.md