### PR TITLE
docs: update decomposable actions status to Current

### DIFF
--- a/docs/DESIGN-decomposable-actions.md
+++ b/docs/DESIGN-decomposable-actions.md
@@ -1,6 +1,6 @@
 # Design: Decomposable Actions and Primitive Operations
 
-- **Status**: Planned
+- **Status**: Current
 - **Milestone**: Deterministic Recipe Execution
 - **Author**: @dangazineu
 - **Created**: 2025-12-12


### PR DESCRIPTION
## Summary

- Update design document status from "Planned" to "Current"
- Reflects that all core implementation issues (#436-#449) are now closed

No issue for this documentation-only change.