### PR TITLE
chore: add pre-commit hook for gofmt

### DIFF
--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Installs the git hooks from the scripts/ directory.
+
+HOOKS_DIR=$(git rev-parse --git-dir)/hooks
+SCRIPTS_DIR=$(git rev-parse --show-toplevel)/scripts
+
+ln -sfv "$SCRIPTS_DIR/pre-commit" "$HOOKS_DIR/pre-commit"
+
+echo "Git hooks installed successfully."

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/sh
+# A hook script to format Go code before committing.
+# If any Go files are staged, runs gofmt on them and re-stages the changes.
+
+# Get the list of staged Go files
+GO_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.go$')
+
+# Exit if no Go files are staged
+if [ -z "$GO_FILES" ]; then
+    exit 0
+fi
+
+# Format the staged Go files
+echo "$GO_FILES" | xargs gofmt -w
+
+# Re-add the formatted files to the staging area
+echo "$GO_FILES" | xargs git add
+
+exit 0


### PR DESCRIPTION
## Summary

- Add `scripts/pre-commit` hook that automatically formats staged Go files with `gofmt`
- Add `scripts/install-hooks.sh` to symlink hooks into `.git/hooks/`
- Helps catch formatting issues locally before they fail CI

To enable, run `./scripts/install-hooks.sh` from the repo root.