### PR TITLE
docs: add design for dependency provisioning

### DIFF
--- a/docs/DESIGN-dependency-provisioning.md
+++ b/docs/DESIGN-dependency-provisioning.md
@@ -6,6 +6,8 @@ Planned
 
 ## Implementation Issues
 
+**Legend**: Green = done, Blue = ready, Yellow = blocked
+
 ### Milestone: [Dependency Provisioning: Build Foundation](https://github.com/tsukumogami/tsuku/milestone/18)
 
 | Issue | Title | Dependencies |
@@ -18,6 +20,30 @@ Planned
 | [#544](https://github.com/tsukumogami/tsuku/issues/544) | feat(recipes): add expat recipe to validate zlib dependency | [#540](https://github.com/tsukumogami/tsuku/issues/540) |
 | [#545](https://github.com/tsukumogami/tsuku/issues/545) | feat(recipes): add gdbm recipe to validate configure_make | [#541](https://github.com/tsukumogami/tsuku/issues/541) |
 | [#546](https://github.com/tsukumogami/tsuku/issues/546) | feat(recipes): add m4 recipe to validate compilation | [#541](https://github.com/tsukumogami/tsuku/issues/541), [#542](https://github.com/tsukumogami/tsuku/issues/542) |
+
+```mermaid
+graph LR
+    I539["#539: CI test matrix"]
+    I540["#540: zlib recipe"]
+    I541["#541: make recipe"]
+    I542["#542: zig recipe"]
+    I543["#543: validation scripts"]
+    I544["#544: expat recipe"]
+    I545["#545: gdbm recipe"]
+    I546["#546: m4 recipe"]
+
+    I540 --> I544
+    I541 --> I545
+    I541 --> I546
+    I542 --> I546
+
+    classDef done fill:#c8e6c9
+    classDef ready fill:#bbdefb
+    classDef blocked fill:#fff9c4
+
+    class I539,I540,I541,I542,I543 ready
+    class I544,I545,I546 blocked
+```
 
 ### Milestone: [Dependency Provisioning: Build Environment](https://github.com/tsukumogami/tsuku/milestone/19)
 
@@ -34,68 +60,22 @@ Planned
 | [#555](https://github.com/tsukumogami/tsuku/issues/555) | feat(actions): implement cmake_build action | [#549](https://github.com/tsukumogami/tsuku/issues/549) |
 | [#556](https://github.com/tsukumogami/tsuku/issues/556) | feat(recipes): add ninja recipe to validate cmake_build | [#555](https://github.com/tsukumogami/tsuku/issues/555) |
 
-### Milestone: [Dependency Provisioning: Full Integration](https://github.com/tsukumogami/tsuku/milestone/20)
-
-| Issue | Title | Dependencies |
-|-------|-------|--------------|
-| [#557](https://github.com/tsukumogami/tsuku/issues/557) | feat(recipes): add readline recipe using homebrew_bottle | [#553](https://github.com/tsukumogami/tsuku/issues/553) |
-| [#558](https://github.com/tsukumogami/tsuku/issues/558) | feat(recipes): add sqlite recipe to validate readline | [#557](https://github.com/tsukumogami/tsuku/issues/557) |
-| [#559](https://github.com/tsukumogami/tsuku/issues/559) | feat(recipes): add git recipe to validate complete toolchain | [#554](https://github.com/tsukumogami/tsuku/issues/554) |
-
-### Milestone: [Dependency Provisioning: System-Required](https://github.com/tsukumogami/tsuku/milestone/21)
-
-| Issue | Title | Dependencies |
-|-------|-------|--------------|
-| [#560](https://github.com/tsukumogami/tsuku/issues/560) | feat(actions): implement require_system action with detection | None |
-| [#561](https://github.com/tsukumogami/tsuku/issues/561) | feat(recipes): add docker recipe using require_system | [#560](https://github.com/tsukumogami/tsuku/issues/560) |
-| [#562](https://github.com/tsukumogami/tsuku/issues/562) | feat(recipes): add cuda recipe using require_system | [#560](https://github.com/tsukumogami/tsuku/issues/560) |
-| [#563](https://github.com/tsukumogami/tsuku/issues/563) | feat(cli): add tsuku check-deps command | [#560](https://github.com/tsukumogami/tsuku/issues/560) |
-
-### Dependency Graph
-
 ```mermaid
-graph TD
-    subgraph M1["Build Foundation"]
-        I539["#539: CI test matrix"]
-        I540["#540: zlib recipe"]
-        I541["#541: make recipe"]
-        I542["#542: zig recipe"]
-        I543["#543: validation scripts"]
-        I544["#544: expat recipe"]
-        I545["#545: gdbm recipe"]
-        I546["#546: m4 recipe"]
-    end
+graph LR
+    I540["#540: zlib (M1)"]
+    I541["#541: make (M1)"]
+    I542["#542: zig (M1)"]
+    I547["#547: action implicit deps"]
+    I548["#548: pkg-config recipe"]
+    I549["#549: cmake recipe"]
+    I550["#550: buildAutotoolsEnv"]
+    I551["#551: setup_build_env"]
+    I552["#552: openssl recipe"]
+    I553["#553: ncurses recipe"]
+    I554["#554: curl recipe"]
+    I555["#555: cmake_build action"]
+    I556["#556: ninja recipe"]
 
-    subgraph M2["Build Environment"]
-        I547["#547: action implicit deps"]
-        I548["#548: pkg-config recipe"]
-        I549["#549: cmake recipe"]
-        I550["#550: buildAutotoolsEnv"]
-        I551["#551: setup_build_env"]
-        I552["#552: openssl recipe"]
-        I553["#553: ncurses recipe"]
-        I554["#554: curl recipe"]
-        I555["#555: cmake_build action"]
-        I556["#556: ninja recipe"]
-    end
-
-    subgraph M3["Full Integration"]
-        I557["#557: readline recipe"]
-        I558["#558: sqlite recipe"]
-        I559["#559: git recipe"]
-    end
-
-    subgraph M4["System-Required"]
-        I560["#560: require_system action"]
-        I561["#561: docker recipe"]
-        I562["#562: cuda recipe"]
-        I563["#563: check-deps command"]
-    end
-
-    I540 --> I544
-    I541 --> I545
-    I541 --> I546
-    I542 --> I546
     I541 --> I550
     I542 --> I550
     I548 --> I550
@@ -106,9 +86,62 @@ graph TD
     I552 --> I554
     I549 --> I555
     I555 --> I556
+
+    classDef done fill:#c8e6c9
+    classDef ready fill:#bbdefb
+    classDef blocked fill:#fff9c4
+    classDef external fill:#e0e0e0
+
+    class I540,I541,I542 external
+    class I547,I548,I549 ready
+    class I550,I551,I552,I553,I554,I555,I556 blocked
+```
+
+### Milestone: [Dependency Provisioning: Full Integration](https://github.com/tsukumogami/tsuku/milestone/20)
+
+| Issue | Title | Dependencies |
+|-------|-------|--------------|
+| [#557](https://github.com/tsukumogami/tsuku/issues/557) | feat(recipes): add readline recipe using homebrew_bottle | [#553](https://github.com/tsukumogami/tsuku/issues/553) |
+| [#558](https://github.com/tsukumogami/tsuku/issues/558) | feat(recipes): add sqlite recipe to validate readline | [#557](https://github.com/tsukumogami/tsuku/issues/557) |
+| [#559](https://github.com/tsukumogami/tsuku/issues/559) | feat(recipes): add git recipe to validate complete toolchain | [#554](https://github.com/tsukumogami/tsuku/issues/554) |
+
+```mermaid
+graph LR
+    I553["#553: ncurses (M2)"]
+    I554["#554: curl (M2)"]
+    I557["#557: readline recipe"]
+    I558["#558: sqlite recipe"]
+    I559["#559: git recipe"]
+
     I553 --> I557
     I557 --> I558
     I554 --> I559
+
+    classDef done fill:#c8e6c9
+    classDef ready fill:#bbdefb
+    classDef blocked fill:#fff9c4
+    classDef external fill:#e0e0e0
+
+    class I553,I554 external
+    class I557,I558,I559 blocked
+```
+
+### Milestone: [Dependency Provisioning: System-Required](https://github.com/tsukumogami/tsuku/milestone/21)
+
+| Issue | Title | Dependencies |
+|-------|-------|--------------|
+| [#560](https://github.com/tsukumogami/tsuku/issues/560) | feat(actions): implement require_system action with detection | None |
+| [#561](https://github.com/tsukumogami/tsuku/issues/561) | feat(recipes): add docker recipe using require_system | [#560](https://github.com/tsukumogami/tsuku/issues/560) |
+| [#562](https://github.com/tsukumogami/tsuku/issues/562) | feat(recipes): add cuda recipe using require_system | [#560](https://github.com/tsukumogami/tsuku/issues/560) |
+| [#563](https://github.com/tsukumogami/tsuku/issues/563) | feat(cli): add tsuku check-deps command | [#560](https://github.com/tsukumogami/tsuku/issues/560) |
+
+```mermaid
+graph LR
+    I560["#560: require_system action"]
+    I561["#561: docker recipe"]
+    I562["#562: cuda recipe"]
+    I563["#563: check-deps command"]
+
     I560 --> I561
     I560 --> I562
     I560 --> I563
@@ -116,13 +149,10 @@ graph TD
     classDef done fill:#c8e6c9
     classDef ready fill:#bbdefb
     classDef blocked fill:#fff9c4
-    classDef needsDesign fill:#e1bee7
 
-    class I539,I540,I541,I542,I543,I547,I548,I549,I560 ready
-    class I544,I545,I546,I550,I551,I552,I553,I554,I555,I556,I557,I558,I559,I561,I562,I563 blocked
+    class I560 ready
+    class I561,I562,I563 blocked
 ```
-
-**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design
 
 ## Context and Problem Statement
 


### PR DESCRIPTION
## Summary

Design document for Dependency Provisioning - how tsuku handles both:

1. **Build Essentials** (things tsuku CAN provide): compilers, build tools, libraries via Homebrew bottles
2. **System Dependencies** (things tsuku CANNOT provide): Docker, CUDA, kernel modules, privileged daemons

## Key Decisions

### Part 1: Build Essentials
- Tsuku provides all provisionable dependencies: gcc, make, cmake, zlib, openssl
- No `system:` annotation needed for things tsuku can provide
- Validation-first approach: test matrix to prove relocated tools work

### Part 2: System Dependencies  
- New `system:` prefix annotation for unprovisionable dependencies
- Detection functions check if system deps are present
- Clear error messages with platform-specific installation guidance
- Platform-specific requirements via `when` clause

## Examples

```toml
# Docker-based build - tsuku cannot provide Docker
[[steps]]
action = "docker_build"
dependencies = ["system:docker"]

# Source build - tsuku provides gcc, zlib
[[steps]]
action = "configure_make"
dependencies = ["zlib", "openssl"]  # No system: prefix - tsuku provides these
```

## Related Issue

Closes #523

## Design Document

- `docs/DESIGN-dependency-provisioning.md`

## Test Plan

- Architecture and security review completed via agents
- Document structure validated against design-doc standards