### PR TITLE
docs: add design for centralized validation logic

### DIFF
--- a/docs/DESIGN-centralize-validation.md
+++ b/docs/DESIGN-centralize-validation.md
@@ -2,7 +2,35 @@
 
 ## Status
 
-Accepted
+Planned
+
+## Implementation Issues
+
+### Milestone: [Centralize Validation Logic](https://github.com/tsukumogami/tsuku/milestone/22)
+
+| Issue | Title | Dependencies |
+|-------|-------|--------------|
+| [#568](https://github.com/tsukumogami/tsuku/issues/568) | feat(actions): add NetworkValidator interface | None |
+| [#569](https://github.com/tsukumogami/tsuku/issues/569) | feat(actions): implement RequiresNetwork on actions | [#568](https://github.com/tsukumogami/tsuku/issues/568) |
+| [#570](https://github.com/tsukumogami/tsuku/issues/570) | feat(validate): add ValidationRequirements computation | [#569](https://github.com/tsukumogami/tsuku/issues/569) |
+| [#571](https://github.com/tsukumogami/tsuku/issues/571) | refactor(validate): unify Validate and ValidateSourceBuild | [#570](https://github.com/tsukumogami/tsuku/issues/570) |
+| [#572](https://github.com/tsukumogami/tsuku/issues/572) | refactor(builders): use centralized validation | [#571](https://github.com/tsukumogami/tsuku/issues/571) |
+| [#573](https://github.com/tsukumogami/tsuku/issues/573) | feat(cli): add --container and --recipe flags to install | [#571](https://github.com/tsukumogami/tsuku/issues/571) |
+
+### Dependency Graph
+
+```mermaid
+graph LR
+    classDef done fill:#90EE90,stroke:#333
+    classDef ready fill:#87CEEB,stroke:#333
+    classDef blocked fill:#FFB6C1,stroke:#333
+
+    I568[#568: Add NetworkValidator interface]:::ready --> I569[#569: Implement RequiresNetwork]:::blocked
+    I569 --> I570[#570: Add ValidationRequirements]:::blocked
+    I570 --> I571[#571: Unify Validate methods]:::blocked
+    I571 --> I572[#572: Update builders]:::blocked
+    I571 --> I573[#573: Add CLI flags]:::blocked
+```
 
 ## Context and Problem Statement
 


### PR DESCRIPTION
## Summary

- Add design document for centralizing validation logic to be recipe-driven
- Proposes interface-based action metadata for network requirements
- Enables `tsuku install --container` for standalone container-based validation

## Key Decisions

**Option 1B (Interface Methods)**: Actions implement `RequiresNetwork()` method, with `BaseAction` providing default `false`. This co-locates metadata with action code and enables compile-time enforcement.

**Option 2C (Compute ValidationRequirements)**: Derive container configuration from plan at validation time, maintaining backwards compatibility with existing plans.

## Changes

- `docs/DESIGN-centralize-validation.md`: Complete design document with problem statement, options analysis, decision rationale, solution architecture, and implementation approach

## Implementation Phases

1. Add NetworkValidator interface and BaseAction
2. Implement RequiresNetwork on actions
3. Add ValidationRequirements computation
4. Refactor Executor to use requirements
5. Update builders to use centralized validation
6. Add --container and --recipe flags to install

## Test Plan

- [x] Review design document for completeness
- [x] Validate against design-doc skill requirements
- [x] Approve or request changes

Fixes #535
Fixes #259