### PR TITLE
docs: add recipe builders documentation for M4 completion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -191,6 +191,25 @@ gh pr checks --watch
 
 Recipes are embedded in the monorepo at `internal/recipe/recipes/`.
 
+### Using Recipe Builders
+
+For tools from supported package ecosystems, you can generate a recipe automatically:
+
+```bash
+# Generate a recipe from crates.io, rubygems, pypi, npm, GitHub releases, or Homebrew
+tsuku create <tool> --from <ecosystem>
+
+# Example: generate a recipe for a Rust tool
+tsuku create bat --from crates.io
+
+# Example: generate a recipe from Homebrew
+tsuku create jq --from homebrew:jq
+```
+
+Generated recipes are stored in `$TSUKU_HOME/recipes/` and can be used as a starting point. If you want to contribute the recipe to the registry, copy and adapt it to `internal/recipe/recipes/`.
+
+For tools not in supported ecosystems, or when you need more control, create a recipe manually.
+
 ### Recipe Format
 
 Recipes are TOML files with the following structure:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,45 @@ tsuku update kubectl
 tsuku remove kubectl
 ```
 
+### Create recipes from package ecosystems
+
+Generate recipes automatically from package registry metadata:
+
+```bash
+# From crates.io (Rust)
+tsuku create ripgrep --from crates.io
+
+# From RubyGems
+tsuku create jekyll --from rubygems
+
+# From PyPI (Python)
+tsuku create ruff --from pypi
+
+# From npm (Node.js)
+tsuku create prettier --from npm
+
+# From GitHub releases (uses LLM)
+tsuku create gh --from github:cli/cli
+
+# From Homebrew bottles (uses LLM)
+tsuku create jq --from homebrew:jq
+```
+
+Generated recipes are stored in `$TSUKU_HOME/recipes/` and take precedence over registry recipes. You can inspect and edit them before installation:
+
+```bash
+# View generated recipe
+cat ~/.tsuku/recipes/ripgrep.toml
+
+# Install the tool
+tsuku install ripgrep
+
+# List local recipes
+tsuku recipes --local
+```
+
+Use `--force` to overwrite an existing local recipe.
+
 ### Verbosity and Debugging
 
 tsuku supports multiple verbosity levels for troubleshooting:

--- a/docs/DESIGN-recipe-builders.md
+++ b/docs/DESIGN-recipe-builders.md
@@ -1,6 +1,6 @@
 # Design Document: Ecosystem-Specific Recipe Builders
 
-**Status**: Planned
+**Status**: Implemented
 
 ## Context and Problem Statement
 
@@ -548,8 +548,7 @@ Key characteristics:
 - Modify `Loader.Get()` to check `~/.tsuku/recipes/` before registry
 - `internal/builders/builder.go` - Interface and BuildResult types
 - `internal/builders/registry.go` - Builder registry
-- `internal/builders/cargo.go` - CargoBuilder implementation (crate name as executable initially)
-- `internal/builders/cargo_parser.go` - Cargo.toml `[[bin]]` parsing for executable discovery
+- `internal/builders/cargo.go` - CargoBuilder implementation with Cargo.toml `[[bin]]` parsing for executable discovery
 - `tsuku create <tool> --from crates.io` command
 
 **Validation**: `tsuku create ripgrep --from crates.io` generates valid recipe, `tsuku install ripgrep` works.


### PR DESCRIPTION
## Summary

- Update DESIGN-recipe-builders.md status from "Planned" to "Implemented"
- Add `tsuku create` command section to README.md with examples for all supported ecosystems
- Add "Using Recipe Builders" section to CONTRIBUTING.md explaining how to use builders for recipe contribution
- Fix cargo_parser.go reference in design doc (parsing is actually in cargo.go)

This PR addresses documentation debt identified during milestone 4 completion review. The recipe builders feature has been fully implemented but the documentation was not updated to reflect the new functionality.

## Test plan

- [ ] Verify README examples are accurate by running `tsuku create --help`
- [ ] Verify the design doc status change is correct
- [ ] Review CONTRIBUTING.md section for clarity