### PR TITLE
ci: add lint check for stdlib log imports

### DIFF
--- a/lint_test.go
+++ b/lint_test.go
@@ -3,7 +3,12 @@ package main_test
 import (
 	"bytes"
 	"errors"
+	"go/parser"
+	"go/token"
+	"os"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -61,5 +66,62 @@ func rungo(t *testing.T, args ...string) {
 			t.Fatalf("%v: %v\n%s", cmd, err, ee.Stderr)
 		}
 		t.Fatalf("%v: %v\n%s", cmd, err, output)
+	}
+}
+
+// TestNoStdlibLog ensures code uses the internal/log package instead of stdlib "log".
+// The stdlib log package lacks structured logging support.
+// Allowed: "log/slog" (stdlib structured logging), "github.com/tsukumogami/tsuku/internal/log"
+func TestNoStdlibLog(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short mode: skipping stdlib log check")
+	}
+
+	var violations []string
+
+	err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip non-Go files, test files, and vendor
+		if info.IsDir() {
+			if info.Name() == "vendor" || info.Name() == "testdata" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		// Skip test files - tests may legitimately use stdlib log
+		if strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		fset := token.NewFileSet()
+		node, parseErr := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if parseErr != nil {
+			return parseErr
+		}
+
+		for _, imp := range node.Imports {
+			importPath := strings.Trim(imp.Path.Value, `"`)
+
+			// Forbid stdlib "log" package (not "log/slog")
+			if importPath == "log" {
+				violations = append(violations, path+`: imports "log" - use "github.com/tsukumogami/tsuku/internal/log" instead`)
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("failed to walk directory: %v", err)
+	}
+
+	if len(violations) > 0 {
+		t.Errorf("found forbidden stdlib log imports:\n  %s", strings.Join(violations, "\n  "))
 	}
 }


### PR DESCRIPTION
## Summary

- Add `TestNoStdlibLog` lint check to prevent imports of stdlib `"log"` package
- Enforces use of structured logging via `internal/log` or `log/slog`
- Runs as part of the existing lint test suite in CI

This prevents new code from inadvertently using the unstructured stdlib log package, which was replaced by structured logging in milestone 16.