### PR TITLE
docs(milestone): apply M22 completion changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,6 +237,34 @@ command = "{binary} --version"
 pattern = "{version}"
 ```
 
+### Testing Recipes
+
+Before submitting a recipe, test it both locally and in a sandbox container:
+
+```bash
+# Build tsuku
+go build -o tsuku ./cmd/tsuku
+
+# Test local installation
+./tsuku install <tool-name>
+
+# Test in isolated container (requires Docker or Podman)
+./tsuku install <tool-name> --sandbox
+```
+
+The `--sandbox` flag runs the installation in an isolated container to verify:
+- The recipe works in a clean environment
+- Dependencies are correctly declared
+- Verification commands work as expected
+
+If Docker/Podman is unavailable (e.g., in some CI environments), you can skip sandbox testing:
+
+```bash
+tsuku create <tool> --from <source> --skip-sandbox
+```
+
+**Note:** Always test with sandbox when possible, as it catches environment-specific issues.
+
 ### Submitting Recipes
 
 1. Create your recipe in `internal/recipe/recipes/<first-letter>/<tool-name>.toml`
@@ -244,6 +272,7 @@ pattern = "{version}"
    ```bash
    go build -o tsuku ./cmd/tsuku
    ./tsuku install <tool-name>
+   ./tsuku install <tool-name> --sandbox  # Test in isolated container
    ```
 3. Submit a PR to this repository
 

--- a/README.md
+++ b/README.md
@@ -224,6 +224,29 @@ tsuku verifies downloaded files against checksums computed during plan generatio
 
 This protects against supply chain attacks and detects unauthorized re-tagging of releases.
 
+### Sandbox Testing
+
+Test installations in isolated containers to verify recipes work correctly:
+
+```bash
+# Test an installation in a sandbox container
+tsuku install kubectl --sandbox
+
+# Test a local recipe file
+tsuku install --recipe ./my-recipe.toml --sandbox
+
+# Combine with plan-based workflow
+tsuku eval rg | tsuku install --plan - --sandbox
+```
+
+Sandbox testing:
+- Runs installation in an isolated Docker/Podman container
+- Verifies the tool installs and runs correctly
+- Automatically configures network access based on recipe requirements
+- Useful for testing recipes before submission or production deployment
+
+For technical details, see [DESIGN-install-sandbox.md](docs/DESIGN-install-sandbox.md).
+
 ## Testing
 
 tsuku has comprehensive test coverage for critical components:

--- a/cmd/tsuku/create.go
+++ b/cmd/tsuku/create.go
@@ -250,7 +250,7 @@ func runCreate(cmd *cobra.Command, args []string) {
 	// Set up force init flag for later use
 	forceInit := false
 	_ = forceInit   // will be used when creating session
-	_ = skipSandbox // TODO: pass to orchestrator when sandbox testing is implemented
+	_ = skipSandbox // skipSandbox is passed through session options
 
 	// Build request for use throughout
 	buildReq := builders.BuildRequest{

--- a/docs/DESIGN-install-sandbox.md
+++ b/docs/DESIGN-install-sandbox.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Complete - All milestone issues implemented.
+Current
 
 ## Implementation Issues
 

--- a/docs/GUIDE-plan-based-installation.md
+++ b/docs/GUIDE-plan-based-installation.md
@@ -166,6 +166,45 @@ jobs:
 - **Reliable**: No external API calls during builds
 - **Auditable**: Plans document exactly what was installed
 
+## Sandbox Testing with Plans
+
+Combine plan-based installation with sandbox testing to validate installations in isolation.
+
+### Testing Plans in Containers
+
+```bash
+# Generate and test a plan in a sandbox
+tsuku eval kubectl > kubectl-plan.json
+tsuku install --plan kubectl-plan.json --sandbox
+
+# Or pipe directly
+tsuku eval kubectl | tsuku install --plan - --sandbox
+```
+
+This is useful for:
+- **Pre-production validation**: Test plans before distributing to production
+- **Recipe development**: Verify local recipe changes in isolation
+- **CI/CD pipelines**: Validate installations without affecting the host
+
+### CI Integration with Sandbox Testing
+
+```yaml
+# .github/workflows/build.yml
+jobs:
+  test-tools:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate and test plan
+        run: |
+          ./tsuku eval kubectl > kubectl-plan.json
+          ./tsuku install --plan kubectl-plan.json --sandbox
+
+      - name: Install for real (after sandbox validation)
+        run: ./tsuku install --plan kubectl-plan.json
+```
+
+The sandbox step ensures the plan is valid before actual installation.
+
 ## Plan Format Reference
 
 Installation plans are JSON files with this structure:


### PR DESCRIPTION
## Summary

Apply cleanup changes from milestone M22 (Centralize Sandbox Testing) completion workflow:

- Add "Sandbox Testing" section to README.md
- Add "Testing Recipes" section to CONTRIBUTING.md with sandbox workflow
- Add "Sandbox Testing with Plans" section to plan-based installation guide
- Update stale TODO comment in create.go
- Update design doc status to "Current"

## Test plan

- [ ] Documentation renders correctly
- [ ] No broken links