### PR TITLE
feat(actions): implement pipx_install decomposition for deterministic installation

### DIFF
--- a/.github/workflows/sandbox-tests.yml
+++ b/.github/workflows/sandbox-tests.yml
@@ -33,8 +33,6 @@ jobs:
           - test: { id: "T16" }  # golang
           - test: { id: "T19" }  # nodejs
           - test: { id: "T50" }  # perl
-          # pipx_install not yet evaluable - see #609
-          - test: { id: "T25" }
           # gem_install not yet evaluable - see #610
           - test: { id: "T30" }
     steps:

--- a/internal/actions/action.go
+++ b/internal/actions/action.go
@@ -148,6 +148,7 @@ func init() {
 	Register(&NixRealizeAction{})
 	Register(&ConfigureMakeAction{})
 	Register(&CMakeBuildAction{})
+	Register(&PipExecAction{})
 
 	// Homebrew actions
 	Register(&HomebrewAction{})

--- a/internal/actions/decomposable.go
+++ b/internal/actions/decomposable.go
@@ -95,6 +95,7 @@ var primitives = map[string]bool{
 	"go_build":       true,
 	"nix_realize":    true,
 	"npm_exec":       true,
+	"pip_exec":       true,
 	"pip_install":    true,
 }
 

--- a/internal/actions/decomposable_test.go
+++ b/internal/actions/decomposable_test.go
@@ -99,9 +99,9 @@ func TestIsPrimitive(t *testing.T) {
 func TestPrimitives(t *testing.T) {
 	prims := Primitives()
 
-	// Should have exactly 20 primitives (11 core + 9 ecosystem)
-	if len(prims) != 20 {
-		t.Errorf("len(Primitives()) = %d, want 20", len(prims))
+	// Should have exactly 21 primitives (11 core + 10 ecosystem)
+	if len(prims) != 21 {
+		t.Errorf("len(Primitives()) = %d, want 21", len(prims))
 	}
 
 	// Sort for deterministic comparison
@@ -124,6 +124,7 @@ func TestPrimitives(t *testing.T) {
 		"link_dependencies",
 		"nix_realize",
 		"npm_exec",
+		"pip_exec",
 		"pip_install",
 		"set_env",
 		"set_rpath",

--- a/internal/actions/dependencies_test.go
+++ b/internal/actions/dependencies_test.go
@@ -13,7 +13,7 @@ func TestActionDependencies_EcosystemActions(t *testing.T) {
 		wantRuntime     []string
 	}{
 		{"npm_install", []string{"nodejs"}, []string{"nodejs"}},
-		{"pipx_install", []string{"pipx"}, []string{"python"}},
+		{"pipx_install", []string{"python-standalone"}, []string{"python-standalone"}},
 		{"gem_install", []string{"ruby"}, []string{"ruby"}},
 		{"cpan_install", []string{"perl"}, []string{"perl"}},
 	}

--- a/internal/actions/pip_exec.go
+++ b/internal/actions/pip_exec.go
@@ -1,0 +1,238 @@
+package actions
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// PipExecAction is the primitive execution action for Python packages.
+// It installs packages from a locked requirements.txt with hash verification
+// into an isolated virtual environment.
+//
+// This is an ecosystem primitive that achieves determinism through
+// lockfile enforcement and reproducible build configuration.
+type PipExecAction struct{ BaseAction }
+
+// Dependencies returns python-standalone as both install-time and runtime dependency.
+func (PipExecAction) Dependencies() ActionDeps {
+	return ActionDeps{InstallTime: []string{"python-standalone"}, Runtime: []string{"python-standalone"}}
+}
+
+// RequiresNetwork returns true because pip needs to download packages from PyPI.
+func (PipExecAction) RequiresNetwork() bool {
+	return true
+}
+
+// Name returns the action name
+func (a *PipExecAction) Name() string {
+	return "pip_exec"
+}
+
+// IsDeterministic returns false because pip installation has residual non-determinism.
+// While hash verification ensures identical packages, bytecode generation and
+// platform-specific wheel selection introduce variance.
+func (a *PipExecAction) IsDeterministic() bool {
+	return false
+}
+
+// Execute installs Python packages from locked requirements into an isolated venv.
+//
+// Parameters:
+//   - package (required): Primary package name (informational)
+//   - version (required): Primary package version (informational)
+//   - executables (required): List of executable names to verify and symlink
+//   - locked_requirements (required): Full requirements.txt content with hashes
+//   - python_version (optional): Expected Python version for validation
+//   - has_native_addons (optional): Whether package includes native extensions
+//
+// Installation process:
+//  1. Verify Python interpreter version (if python_version specified)
+//  2. Create isolated venv in installDir/venvs/<package>/
+//  3. Write locked_requirements to venv/requirements.txt
+//  4. Install with pip --require-hashes --no-deps --only-binary :all:
+//  5. Verify executables exist
+//  6. Create symlinks in installDir/bin/
+func (a *PipExecAction) Execute(ctx *ExecutionContext, params map[string]interface{}) error {
+	// Get package name (required)
+	packageName, ok := GetString(params, "package")
+	if !ok {
+		return fmt.Errorf("pip_exec action requires 'package' parameter")
+	}
+
+	// Get version (required for info)
+	version, _ := GetString(params, "version")
+	if version == "" {
+		version = ctx.Version
+	}
+
+	// Get executables list (required)
+	executables, ok := GetStringSlice(params, "executables")
+	if !ok || len(executables) == 0 {
+		return fmt.Errorf("pip_exec action requires 'executables' parameter with at least one executable")
+	}
+
+	// Get locked requirements (required)
+	lockedRequirements, ok := GetString(params, "locked_requirements")
+	if !ok || lockedRequirements == "" {
+		return fmt.Errorf("pip_exec action requires 'locked_requirements' parameter")
+	}
+
+	// Get optional parameters
+	expectedPythonVersion, _ := GetString(params, "python_version")
+	hasNativeAddons, _ := GetBool(params, "has_native_addons")
+
+	// Find Python interpreter from python-standalone installation
+	pythonPath := ResolvePythonStandalone()
+	if pythonPath == "" {
+		// Check ExecPaths from dependencies
+		for _, p := range ctx.ExecPaths {
+			candidatePath := filepath.Join(p, "python3")
+			if _, err := os.Stat(candidatePath); err == nil {
+				pythonPath = candidatePath
+				break
+			}
+		}
+	}
+	if pythonPath == "" {
+		return fmt.Errorf("python not found: install python-standalone first (tsuku install python-standalone)")
+	}
+
+	fmt.Printf("   Package: %s@%s\n", packageName, version)
+	fmt.Printf("   Executables: %v\n", executables)
+	fmt.Printf("   Using python: %s\n", pythonPath)
+	if hasNativeAddons {
+		fmt.Printf("   Warning: Package contains native addons (may have platform-specific behavior)\n")
+	}
+
+	// Step 1: Verify Python version if specified
+	if expectedPythonVersion != "" {
+		actualVersion, err := getPythonVersion(pythonPath)
+		if err != nil {
+			return fmt.Errorf("failed to get Python version: %w", err)
+		}
+		if !strings.HasPrefix(actualVersion, expectedPythonVersion) {
+			fmt.Printf("   Warning: Python version mismatch - expected %s, got %s\n",
+				expectedPythonVersion, actualVersion)
+		}
+	}
+
+	// Step 2: Create isolated venv
+	venvDir := filepath.Join(ctx.InstallDir, "venvs", packageName)
+	fmt.Printf("   Creating venv: %s\n", venvDir)
+
+	if err := os.MkdirAll(filepath.Dir(venvDir), 0755); err != nil {
+		return fmt.Errorf("failed to create venvs directory: %w", err)
+	}
+
+	venvCmd := exec.CommandContext(ctx.Context, pythonPath, "-m", "venv", venvDir)
+	if output, err := venvCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to create venv: %w\nOutput: %s", err, string(output))
+	}
+
+	// Step 3: Write locked requirements
+	reqFile := filepath.Join(venvDir, "requirements.txt")
+	if err := os.WriteFile(reqFile, []byte(lockedRequirements), 0644); err != nil {
+		return fmt.Errorf("failed to write requirements.txt: %w", err)
+	}
+
+	// Count packages for progress reporting
+	packageCount := countRequirementsPackages(lockedRequirements)
+	fmt.Printf("   Installing %d packages with hash verification\n", packageCount)
+
+	// Step 4: Install with safety flags
+	pipBin := filepath.Join(venvDir, "bin", "pip")
+
+	// Build pip install command with security flags
+	pipArgs := []string{
+		"install",
+		"--require-hashes",
+		"--no-deps",
+		"--only-binary", ":all:",
+		"--disable-pip-version-check",
+		"-r", reqFile,
+	}
+
+	pipCmd := exec.CommandContext(ctx.Context, pipBin, pipArgs...)
+	pipCmd.Dir = venvDir
+
+	// Set up environment - filter out PIP_USER which conflicts with venv installs
+	var env []string
+	for _, e := range os.Environ() {
+		if !strings.HasPrefix(e, "PIP_USER=") {
+			env = append(env, e)
+		}
+	}
+	// Set PYTHONHASHSEED for deterministic bytecode
+	env = append(env, "PYTHONHASHSEED=0")
+	pipCmd.Env = env
+
+	output, err := pipCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("pip install failed: %w\nOutput: %s", err, string(output))
+	}
+
+	// Step 5: Verify executables exist in venv
+	venvBinDir := filepath.Join(venvDir, "bin")
+	for _, exe := range executables {
+		exePath := filepath.Join(venvBinDir, exe)
+		if _, err := os.Stat(exePath); err != nil {
+			return fmt.Errorf("expected executable %s not found at %s", exe, exePath)
+		}
+	}
+
+	// Step 6: Create symlinks at root level (where executor expects them)
+	for _, exe := range executables {
+		// Create relative symlink: <exe> -> venvs/<package>/bin/<exe>
+		srcPath := filepath.Join("venvs", packageName, "bin", exe)
+		dstPath := filepath.Join(ctx.InstallDir, exe)
+
+		// Remove existing symlink if present
+		os.Remove(dstPath)
+
+		if err := os.Symlink(srcPath, dstPath); err != nil {
+			return fmt.Errorf("failed to create symlink for %s: %w", exe, err)
+		}
+	}
+
+	fmt.Printf("   Package installed successfully\n")
+	fmt.Printf("   Verified %d executable(s)\n", len(executables))
+
+	return nil
+}
+
+// getPythonVersion returns the Python version string (e.g., "3.11.7")
+func getPythonVersion(pythonPath string) (string, error) {
+	cmd := exec.Command(pythonPath, "--version")
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	// Output is "Python 3.11.7" - extract version
+	versionStr := strings.TrimSpace(string(output))
+	parts := strings.SplitN(versionStr, " ", 2)
+	if len(parts) < 2 {
+		return "", fmt.Errorf("unexpected Python version output: %s", versionStr)
+	}
+	return parts[1], nil
+}
+
+// countRequirementsPackages counts the number of packages in requirements.txt
+func countRequirementsPackages(requirements string) int {
+	count := 0
+	for _, line := range strings.Split(requirements, "\n") {
+		line = strings.TrimSpace(line)
+		// Skip empty lines, comments, and continuation lines
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "--") || strings.HasPrefix(line, "\\") {
+			continue
+		}
+		// Count lines that look like package specs (contain == or @ for URL)
+		if strings.Contains(line, "==") || strings.Contains(line, " @ ") {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/actions/pip_exec_test.go
+++ b/internal/actions/pip_exec_test.go
@@ -1,0 +1,199 @@
+package actions
+
+import (
+	"context"
+	"testing"
+)
+
+func TestPipExecAction_Name(t *testing.T) {
+	t.Parallel()
+	action := &PipExecAction{}
+	if action.Name() != "pip_exec" {
+		t.Errorf("Name() = %q, want %q", action.Name(), "pip_exec")
+	}
+}
+
+func TestPipExecAction_Registration(t *testing.T) {
+	t.Parallel()
+	action := Get("pip_exec")
+	if action == nil {
+		t.Fatal("pip_exec action not registered")
+	}
+	if action.Name() != "pip_exec" {
+		t.Errorf("registered action Name() = %q, want %q", action.Name(), "pip_exec")
+	}
+}
+
+func TestPipExecAction_IsPrimitive(t *testing.T) {
+	t.Parallel()
+	if !IsPrimitive("pip_exec") {
+		t.Error("pip_exec should be registered as a primitive")
+	}
+}
+
+func TestPipExecAction_IsDeterministic(t *testing.T) {
+	t.Parallel()
+	action := &PipExecAction{}
+	if action.IsDeterministic() {
+		t.Error("pip_exec should not be deterministic (has residual non-determinism)")
+	}
+}
+
+func TestPipExecAction_Dependencies(t *testing.T) {
+	t.Parallel()
+	action := &PipExecAction{}
+	deps := action.Dependencies()
+
+	// Should require python-standalone at install time
+	if len(deps.InstallTime) != 1 || deps.InstallTime[0] != "python-standalone" {
+		t.Errorf("InstallTime = %v, want [python-standalone]", deps.InstallTime)
+	}
+
+	// Should require python-standalone at runtime
+	if len(deps.Runtime) != 1 || deps.Runtime[0] != "python-standalone" {
+		t.Errorf("Runtime = %v, want [python-standalone]", deps.Runtime)
+	}
+}
+
+func TestPipExecAction_RequiresNetwork(t *testing.T) {
+	t.Parallel()
+	action := &PipExecAction{}
+
+	// pip_exec needs network to download packages from PyPI
+	nv, ok := interface{}(action).(NetworkValidator)
+	if !ok {
+		t.Fatal("pip_exec should implement NetworkValidator")
+	}
+	if !nv.RequiresNetwork() {
+		t.Error("pip_exec should require network")
+	}
+}
+
+func TestPipExecAction_Execute_MissingParams(t *testing.T) {
+	t.Parallel()
+	action := &PipExecAction{}
+	ctx := &ExecutionContext{
+		Context: context.Background(),
+		WorkDir: t.TempDir(),
+	}
+
+	tests := []struct {
+		name   string
+		params map[string]interface{}
+		errMsg string
+	}{
+		{
+			name:   "missing package",
+			params: map[string]interface{}{},
+			errMsg: "pip_exec action requires 'package' parameter",
+		},
+		{
+			name: "missing executables",
+			params: map[string]interface{}{
+				"package": "ruff",
+			},
+			errMsg: "pip_exec action requires 'executables' parameter with at least one executable",
+		},
+		{
+			name: "empty executables",
+			params: map[string]interface{}{
+				"package":     "ruff",
+				"executables": []string{},
+			},
+			errMsg: "pip_exec action requires 'executables' parameter with at least one executable",
+		},
+		{
+			name: "missing locked_requirements",
+			params: map[string]interface{}{
+				"package":     "ruff",
+				"executables": []string{"ruff"},
+			},
+			errMsg: "pip_exec action requires 'locked_requirements' parameter",
+		},
+		{
+			name: "empty locked_requirements",
+			params: map[string]interface{}{
+				"package":             "ruff",
+				"executables":         []string{"ruff"},
+				"locked_requirements": "",
+			},
+			errMsg: "pip_exec action requires 'locked_requirements' parameter",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := action.Execute(ctx, tc.params)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if err.Error() != tc.errMsg {
+				t.Errorf("error = %q, want %q", err.Error(), tc.errMsg)
+			}
+		})
+	}
+}
+
+func TestCountRequirementsPackages(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		requirements string
+		want         int
+	}{
+		{
+			name:         "empty",
+			requirements: "",
+			want:         0,
+		},
+		{
+			name:         "single package",
+			requirements: "ruff==0.1.0 --hash=sha256:abc123",
+			want:         1,
+		},
+		{
+			name: "multiple packages",
+			requirements: `ruff==0.1.0 --hash=sha256:abc123
+click==8.1.0 --hash=sha256:def456
+typing-extensions==4.8.0 --hash=sha256:ghi789`,
+			want: 3,
+		},
+		{
+			name: "with comments",
+			requirements: `# This is a comment
+ruff==0.1.0 --hash=sha256:abc123
+# Another comment
+click==8.1.0 --hash=sha256:def456`,
+			want: 2,
+		},
+		{
+			name: "with empty lines",
+			requirements: `ruff==0.1.0 --hash=sha256:abc123
+
+click==8.1.0 --hash=sha256:def456
+
+`,
+			want: 2,
+		},
+		{
+			name: "with pip options",
+			requirements: `--no-binary :all:
+ruff==0.1.0 --hash=sha256:abc123`,
+			want: 1,
+		},
+		{
+			name:         "url-based package",
+			requirements: `ruff @ https://files.pythonhosted.org/packages/ruff-0.1.0.whl --hash=sha256:abc123`,
+			want:         1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := countRequirementsPackages(tc.requirements)
+			if got != tc.want {
+				t.Errorf("countRequirementsPackages() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/actions/pipx_install_test.go
+++ b/internal/actions/pipx_install_test.go
@@ -1,6 +1,9 @@
 package actions
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestIsValidPyPIVersion(t *testing.T) {
 	t.Parallel()
@@ -67,5 +70,327 @@ func TestPipxInstallAction_Name(t *testing.T) {
 	action := &PipxInstallAction{}
 	if action.Name() != "pipx_install" {
 		t.Errorf("Name() = %q, want %q", action.Name(), "pipx_install")
+	}
+}
+
+func TestPipxInstallAction_ImplementsDecomposable(t *testing.T) {
+	t.Parallel()
+	var _ Decomposable = (*PipxInstallAction)(nil)
+
+	// Also verify via IsDecomposable
+	if !IsDecomposable("pipx_install") {
+		t.Error("pipx_install should implement Decomposable")
+	}
+}
+
+func TestPipxInstallAction_Dependencies(t *testing.T) {
+	t.Parallel()
+	action := &PipxInstallAction{}
+	deps := action.Dependencies()
+
+	// Should require python-standalone at install time
+	if len(deps.InstallTime) != 1 || deps.InstallTime[0] != "python-standalone" {
+		t.Errorf("InstallTime = %v, want [python-standalone]", deps.InstallTime)
+	}
+
+	// Should require python-standalone at runtime
+	if len(deps.Runtime) != 1 || deps.Runtime[0] != "python-standalone" {
+		t.Errorf("Runtime = %v, want [python-standalone]", deps.Runtime)
+	}
+
+	// Should require python-standalone at eval time for Decompose
+	if len(deps.EvalTime) != 1 || deps.EvalTime[0] != "python-standalone" {
+		t.Errorf("EvalTime = %v, want [python-standalone]", deps.EvalTime)
+	}
+}
+
+func TestPipxInstallAction_RequiresNetwork(t *testing.T) {
+	t.Parallel()
+	action := &PipxInstallAction{}
+
+	// pipx_install needs network to download packages from PyPI
+	nv, ok := interface{}(action).(NetworkValidator)
+	if !ok {
+		t.Fatal("pipx_install should implement NetworkValidator")
+	}
+	if !nv.RequiresNetwork() {
+		t.Error("pipx_install should require network")
+	}
+}
+
+func TestPipxInstallAction_Decompose_MissingParams(t *testing.T) {
+	t.Parallel()
+	action := &PipxInstallAction{}
+	ctx := &EvalContext{
+		Context: context.Background(),
+		Version: "1.0.0",
+	}
+
+	tests := []struct {
+		name   string
+		params map[string]interface{}
+		errMsg string
+	}{
+		{
+			name:   "missing package",
+			params: map[string]interface{}{},
+			errMsg: "pipx_install action requires 'package' parameter",
+		},
+		{
+			name: "missing executables",
+			params: map[string]interface{}{
+				"package": "ruff",
+			},
+			errMsg: "pipx_install action requires 'executables' parameter with at least one executable",
+		},
+		{
+			name: "empty executables",
+			params: map[string]interface{}{
+				"package":     "ruff",
+				"executables": []string{},
+			},
+			errMsg: "pipx_install action requires 'executables' parameter with at least one executable",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := action.Decompose(ctx, tc.params)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if err.Error() != tc.errMsg {
+				t.Errorf("error = %q, want %q", err.Error(), tc.errMsg)
+			}
+		})
+	}
+}
+
+func TestPipxInstallAction_Decompose_MissingVersion(t *testing.T) {
+	t.Parallel()
+	action := &PipxInstallAction{}
+	ctx := &EvalContext{
+		Context: context.Background(),
+		Version: "", // Missing version
+	}
+
+	params := map[string]interface{}{
+		"package":     "ruff",
+		"executables": []string{"ruff"},
+	}
+
+	_, err := action.Decompose(ctx, params)
+	if err == nil {
+		t.Fatal("expected error for missing version")
+	}
+	if err.Error() != "pipx_install decomposition requires a resolved version" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestPipxInstallAction_Decompose_InvalidPackage(t *testing.T) {
+	t.Parallel()
+	action := &PipxInstallAction{}
+	ctx := &EvalContext{
+		Context: context.Background(),
+		Version: "1.0.0",
+	}
+
+	tests := []struct {
+		name     string
+		package_ string
+	}{
+		{"command injection", "ruff; rm -rf /"},
+		{"subshell", "$(evil)"},
+		{"pipe", "ruff|cat"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			params := map[string]interface{}{
+				"package":     tc.package_,
+				"executables": []string{"ruff"},
+			}
+
+			_, err := action.Decompose(ctx, params)
+			if err == nil {
+				t.Fatal("expected error for invalid package name")
+			}
+		})
+	}
+}
+
+func TestIsValidPyPIPackage(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		package_ string
+		expected bool
+	}{
+		// Valid package names
+		{"simple", "ruff", true},
+		{"with hyphen", "black-macchiato", true},
+		{"with underscore", "typing_extensions", true},
+		{"with dot", "zope.interface", true},
+		{"with numbers", "python3-openid", true},
+		{"numeric start after first", "oauth2client", true},
+
+		// Invalid package names
+		{"empty", "", false},
+		{"too long", string(make([]byte, 201)), false},
+		{"command injection", "ruff; rm -rf /", false},
+		{"subshell", "$(evil)", false},
+		{"pipe", "ruff|cat", false},
+		{"ampersand", "ruff&cmd", false},
+		{"backtick", "`evil`", false},
+		{"newline", "ruff\nevil", false},
+		{"space", "ruff evil", false},
+		{"starts with hyphen", "-ruff", false},
+		{"starts with dot", ".ruff", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// For too long test, generate proper string
+			pkg := tc.package_
+			if tc.name == "too long" {
+				pkg = "a"
+				for i := 0; i < 200; i++ {
+					pkg += "a"
+				}
+			}
+
+			result := isValidPyPIPackage(pkg)
+			if result != tc.expected {
+				t.Errorf("isValidPyPIPackage(%q) = %v, want %v", tc.package_, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestParseWheelFilename(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		filename string
+		want     *wheelInfo
+	}{
+		{
+			name:     "simple wheel",
+			filename: "ruff-0.1.0-py3-none-any.whl",
+			want: &wheelInfo{
+				name:     "ruff",
+				version:  "0.1.0",
+				python:   "py3",
+				abi:      "none",
+				platform: "any",
+			},
+		},
+		{
+			name:     "wheel with underscore in name",
+			filename: "typing_extensions-4.8.0-py3-none-any.whl",
+			want: &wheelInfo{
+				name:     "typing-extensions", // normalized
+				version:  "4.8.0",
+				python:   "py3",
+				abi:      "none",
+				platform: "any",
+			},
+		},
+		{
+			name:     "platform-specific wheel",
+			filename: "numpy-1.26.0-cp311-cp311-manylinux_2_17_x86_64.whl",
+			want: &wheelInfo{
+				name:     "numpy",
+				version:  "1.26.0",
+				python:   "cp311",
+				abi:      "cp311",
+				platform: "manylinux_2_17_x86_64",
+			},
+		},
+		{
+			name:     "not a wheel",
+			filename: "package-1.0.0.tar.gz",
+			want:     nil,
+		},
+		{
+			name:     "too few parts",
+			filename: "invalid.whl",
+			want:     nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseWheelFilename(tc.filename)
+			if tc.want == nil {
+				if got != nil {
+					t.Errorf("parseWheelFilename(%q) = %+v, want nil", tc.filename, got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("parseWheelFilename(%q) = nil, want %+v", tc.filename, tc.want)
+			}
+			if got.name != tc.want.name || got.version != tc.want.version ||
+				got.python != tc.want.python || got.abi != tc.want.abi ||
+				got.platform != tc.want.platform {
+				t.Errorf("parseWheelFilename(%q) = %+v, want %+v", tc.filename, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetectPythonNativeAddons(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		requirements string
+		want         bool
+	}{
+		{
+			name:         "pure python",
+			requirements: "click==8.1.0\ntyping-extensions==4.8.0",
+			want:         false,
+		},
+		{
+			name:         "manylinux wheel",
+			requirements: "numpy==1.26.0 # manylinux_2_17_x86_64",
+			want:         true,
+		},
+		{
+			name:         "macosx wheel",
+			requirements: "pillow==10.0.0 # macosx_10_10_x86_64",
+			want:         true,
+		},
+		{
+			name:         "win_amd64 wheel",
+			requirements: "package==1.0.0 # win_amd64",
+			want:         true,
+		},
+		{
+			name:         "known native package",
+			requirements: "numpy==1.26.0\nclick==8.1.0",
+			want:         true,
+		},
+		{
+			name:         "scipy",
+			requirements: "scipy==1.11.0",
+			want:         true,
+		},
+		{
+			name:         "cryptography",
+			requirements: "cryptography==41.0.0",
+			want:         true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := detectPythonNativeAddons(tc.requirements)
+			if got != tc.want {
+				t.Errorf("detectPythonNativeAddons() = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/test-matrix.json
+++ b/test-matrix.json
@@ -30,11 +30,10 @@
     "T53": { "tool": "gofumpt",      "tier": 5, "desc": "go_install with dependency", "features": ["action:go_install", "version_detection:goproxy", "dependency:go"] }
   },
   "ci": {
-    "linux": ["T1", "T2", "T3", "T5", "T16", "T19", "T23", "T50"],
+    "linux": ["T1", "T2", "T3", "T5", "T16", "T19", "T23", "T25", "T50"],
     "macos": ["T1", "T3", "T16", "T19"],
     "scheduled": ["T18", "T27", "T51", "T52", "T53"],
     "blocked": {
-      "T25": { "arrays": ["linux", "macos"], "issue": "https://github.com/tsukumogami/tsuku/issues/609" },
       "T30": { "arrays": ["linux", "macos"], "issue": "https://github.com/tsukumogami/tsuku/issues/610" }
     }
   }


### PR DESCRIPTION
## Summary

- Add `pip_exec` ecosystem primitive action for installing Python packages from locked requirements with hash verification
- Implement `Decompose()` on `pipx_install` to generate requirements with SHA256 hashes at eval time
- Use `pip download` to resolve dependencies and compute hashes
- Install with `--require-hashes --no-deps --only-binary :all:` flags for security
- Detect native addons for reproducibility warnings
- Update dependencies from `pipx` to `python-standalone`
- Enable T25 (ruff) in sandbox tests

The decomposition follows the pattern established in npm_install (#620): composite actions generate locked requirements at eval time, primitive actions execute with hash verification at install time.

Fixes #609