### PR TITLE
fix(tests): initialize Context field in ExecutionContext test fixtures

### DIFF
--- a/internal/actions/gem_exec_test.go
+++ b/internal/actions/gem_exec_test.go
@@ -40,6 +40,7 @@ func TestGemExecAction_RequiresCommand(t *testing.T) {
 	}
 
 	ctx := &ExecutionContext{
+		Context: context.Background(),
 		WorkDir: workDir,
 	}
 
@@ -57,6 +58,7 @@ func TestGemExecAction_ValidatesGemfileExists(t *testing.T) {
 	workDir := t.TempDir()
 
 	ctx := &ExecutionContext{
+		Context: context.Background(),
 		WorkDir: workDir,
 	}
 
@@ -81,6 +83,7 @@ func TestGemExecAction_ValidatesLockfileWhenRequired(t *testing.T) {
 	}
 
 	ctx := &ExecutionContext{
+		Context: context.Background(),
 		WorkDir: workDir,
 	}
 
@@ -120,6 +123,7 @@ func TestGemExecAction_RejectsShellMetacharacters(t *testing.T) {
 	}
 
 	ctx := &ExecutionContext{
+		Context: context.Background(),
 		WorkDir: workDir,
 	}
 
@@ -294,6 +298,7 @@ func TestGemExecAction_RelativeSourceDir(t *testing.T) {
 	}
 
 	ctx := &ExecutionContext{
+		Context: context.Background(),
 		WorkDir: workDir,
 	}
 
@@ -323,6 +328,7 @@ func TestGemExecAction_RelativeOutputDir(t *testing.T) {
 	}
 
 	ctx := &ExecutionContext{
+		Context: context.Background(),
 		WorkDir: workDir,
 	}
 
@@ -640,6 +646,7 @@ func TestGemExecAction_WithRubyVersionValidation(t *testing.T) {
 	}
 
 	ctx := &ExecutionContext{
+		Context: context.Background(),
 		WorkDir: workDir,
 	}
 
@@ -676,6 +683,7 @@ func TestGemExecAction_WithBundlerVersionValidation(t *testing.T) {
 	}
 
 	ctx := &ExecutionContext{
+		Context: context.Background(),
 		WorkDir: workDir,
 	}
 

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/tsukumogami/tsuku/internal/actions"
@@ -984,7 +985,7 @@ func TestExecutePlan_EmptyPlan(t *testing.T) {
 		FormatVersion: PlanFormatVersion,
 		Tool:          "empty-tool",
 		Version:       "1.0.0",
-		Platform:      Platform{OS: "linux", Arch: "amd64"},
+		Platform:      Platform{OS: runtime.GOOS, Arch: runtime.GOARCH},
 		Steps:         []ResolvedStep{},
 	}
 
@@ -1057,7 +1058,7 @@ func TestExecutePlan_ContextCancellation(t *testing.T) {
 		FormatVersion: PlanFormatVersion,
 		Tool:          "test-tool",
 		Version:       "1.0.0",
-		Platform:      Platform{OS: "linux", Arch: "amd64"},
+		Platform:      Platform{OS: runtime.GOOS, Arch: runtime.GOARCH},
 		Steps: []ResolvedStep{
 			{
 				Action: "chmod",
@@ -1108,7 +1109,7 @@ func TestExecutePlan_NonDownloadSteps(t *testing.T) {
 		FormatVersion: PlanFormatVersion,
 		Tool:          "test-tool",
 		Version:       "1.0.0",
-		Platform:      Platform{OS: "linux", Arch: "amd64"},
+		Platform:      Platform{OS: runtime.GOOS, Arch: runtime.GOARCH},
 		Steps: []ResolvedStep{
 			{
 				Action: "chmod",


### PR DESCRIPTION
## Summary

- Fixed nil Context panics in gem_exec tests by initializing the Context field with context.Background()
- Fixed platform validation failures in executor tests by using runtime.GOOS/GOARCH instead of hardcoded linux-amd64

## Test plan

All previously failing tests now pass:
- `go test -v ./internal/actions -run TestGemExecAction` - all pass
- `go test -v ./internal/executor -run "TestExecutePlan_EmptyPlan|TestExecutePlan_ContextCancellation|TestExecutePlan_NonDownloadSteps"` - all pass