### PR TITLE
feat(recipes): add ack recipe for T51 test

### DIFF
--- a/internal/recipe/recipes/a/ack.toml
+++ b/internal/recipe/recipes/a/ack.toml
@@ -1,0 +1,20 @@
+[metadata]
+name = "ack"
+description = "A grep-like program for searching source code"
+homepage = "https://beyondgrep.com/"
+version_format = "semver"
+dependencies = ["perl"]
+
+[version]
+source = "metacpan"
+distribution = "ack"
+
+[[steps]]
+action = "cpan_install"
+distribution = "ack"
+module = "App::Ack"
+executables = ["ack"]
+
+[verify]
+command = "ack --version"
+pattern = "{version}"


### PR DESCRIPTION
## Summary

- Add ack.toml recipe for T51 test coverage

## Problem

T51 (ack) in the scheduled test matrix was failing with "recipe not found in registry". The cpan_install action was already implemented, but the ack recipe was missing.

## Solution

Create ack.toml recipe using:
- cpan_install action with App::Ack module
- MetaCPAN version detection (distribution: ack)
- Perl as dependency

## Testing

Local verification:
```bash
./tsuku install ack
ack --version
# ack v3.9.0 (standard build)
```

Fixes #449