### PR TITLE
chore: Complete milestone 23 cleanup

### DIFF
--- a/.github/workflows/homebrew-builder-tests.yml
+++ b/.github/workflows/homebrew-builder-tests.yml
@@ -33,7 +33,7 @@ jobs:
         run: go test -v ./internal/builders/ -run TestHomebrew
 
       - name: Run Homebrew action tests
-        run: go test -v ./internal/actions/ -run TestHomebrewBottle
+        run: go test -v ./internal/actions/ -run TestHomebrew
 
   # Integration test: install a Homebrew bottle on macOS
   macos-integration:

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Homebrew recipes are platform-agnostic - a single recipe works on:
 - Linux ARM64
 - Linux x86_64
 
-The `homebrew_bottle` action automatically selects the correct bottle for your platform at install time.
+The `homebrew` action automatically selects the correct bottle for your platform at install time.
 
 #### Recipe Validation
 

--- a/docs/DESIGN-dependency-provisioning.md
+++ b/docs/DESIGN-dependency-provisioning.md
@@ -158,7 +158,7 @@ graph LR
 
 Tsuku recipes need to declare dependencies on external tools and libraries. These dependencies have different provisioning strategies:
 
-1. **Downloadable**: Tools tsuku downloads and installs (pre-built binaries, Homebrew bottles)
+1. **Downloadable**: Tools tsuku downloads and installs (pre-built binaries, Homebrew)
 2. **Buildable**: Tools tsuku builds from source (using compilers it provides)
 3. **System-required**: Tools that must already exist on the system (Docker, CUDA, kernel modules)
 
@@ -177,7 +177,7 @@ This creates friction:
 
 **All dependencies should be recipes.** The recipe's *actions* determine how to provision:
 
-- `homebrew_bottle` → download and install pre-built binary
+- `homebrew` → download and install pre-built binary
 - `configure_make` → build from source
 - `require_system` → validate system has it, guide user if missing
 
@@ -238,7 +238,7 @@ This design extends that model:
 
 **In scope:**
 - **Unified Recipe Model**: All dependencies are recipes with appropriate actions
-  - Provisionable tools use `homebrew_bottle`, `configure_make`, etc.
+  - Provisionable tools use `homebrew`, `configure_make`, etc.
   - System-required tools use new `require_system` action
   - Recipe authors just declare `dependencies = ["docker", "gcc"]`
 - **Build Essentials**: Proactively provide compilers, build tools, and libraries
@@ -364,7 +364,7 @@ dependencies = ["docker", "gcc", "zlib"]  # No prefix needed
 
 ### Summary
 
-All dependencies are recipes. Provisionable tools (gcc, zlib) have recipes with `homebrew_bottle` or `configure_make` actions. System-required tools (Docker, CUDA) have recipes with the new `require_system` action. Recipe authors just declare `dependencies = ["docker", "gcc"]` without any special syntax - tsuku looks up each recipe and provisions according to its actions.
+All dependencies are recipes. Provisionable tools (gcc, zlib) have recipes with `homebrew` or `configure_make` actions. System-required tools (Docker, CUDA) have recipes with the new `require_system` action. Recipe authors just declare `dependencies = ["docker", "gcc"]` without any special syntax - tsuku looks up each recipe and provisions according to its actions.
 
 ### Rationale
 
@@ -646,7 +646,7 @@ name = "gpu-app"
 
 [[steps]]
 action = "cmake_build"
-dependencies = ["cuda", "zlib"]  # cuda = require_system, zlib = homebrew_bottle
+dependencies = ["cuda", "zlib"]  # cuda = require_system, zlib = homebrew
 
 [[steps]]
 action = "install_binaries"
@@ -716,7 +716,7 @@ tsuku install my-docker-tool
 ┌─────────────────────────────────────────┐
 │ 2. For each dependency, load its recipe │
 │    - docker.toml → has require_system   │
-│    - curl.toml → has homebrew_bottle    │
+│    - curl.toml → has homebrew           │
 └─────────────────────────────────────────┘
         │
         ▼
@@ -726,7 +726,7 @@ tsuku install my-docker-tool
 │      → Check: docker --version          │
 │      → Found? Continue                  │
 │      → Missing? Show guide, FAIL        │
-│    - curl: Execute homebrew_bottle      │
+│    - curl: Execute homebrew             │
 │      → Download and install             │
 └─────────────────────────────────────────┘
         │
@@ -864,7 +864,7 @@ Each build essential must pass these tests on all 4 platforms:
 
 | Step | Description |
 |------|-------------|
-| 1 | Create `internal/recipe/recipes/z/zlib.toml` using `homebrew_bottle` action |
+| 1 | Create `internal/recipe/recipes/z/zlib.toml` using `homebrew` action |
 | 2 | Validate bottle availability on all 4 platforms |
 | 3 | Test relocation: verify no hardcoded paths in `libz.so`/`libz.dylib` |
 | 4 | Create `internal/recipe/recipes/e/expat.toml` that declares `dependencies = ["zlib"]` |
@@ -883,7 +883,7 @@ Each build essential must pass these tests on all 4 platforms:
 
 | Step | Description |
 |------|-------------|
-| 1 | Create `internal/recipe/recipes/m/make.toml` using `homebrew_bottle` action |
+| 1 | Create `internal/recipe/recipes/m/make.toml` using `homebrew` action |
 | 2 | Validate make executable works from relocated path |
 | 3 | Create `internal/recipe/recipes/g/gdbm.toml` using `configure_make` action |
 | 4 | Implement basic `configure_make` action (uses system gcc temporarily) |
@@ -913,7 +913,7 @@ Each build essential must pass these tests on all 4 platforms:
 
 **Gate**: m4 compiles and runs on all 4 platforms using zig (no system compiler).
 
-**Future**: If edge cases accumulate, add `internal/recipe/recipes/g/gcc.toml` using `homebrew_bottle` as alternative.
+**Future**: If edge cases accumulate, add `internal/recipe/recipes/g/gcc.toml` using `homebrew` as alternative.
 
 ### Phase 4: pkg-config + Build Environment
 
@@ -925,7 +925,7 @@ Each build essential must pass these tests on all 4 platforms:
 
 | Step | Description |
 |------|-------------|
-| 1 | Create `internal/recipe/recipes/p/pkg-config.toml` using `homebrew_bottle` action |
+| 1 | Create `internal/recipe/recipes/p/pkg-config.toml` using `homebrew` action |
 | 2 | Update `buildAutotoolsEnv()` to set `PKG_CONFIG_PATH` from tsuku deps |
 | 3 | Update `buildAutotoolsEnv()` to set `CPPFLAGS`, `LDFLAGS` for tsuku deps |
 | 4 | Create `internal/recipe/recipes/n/ncurses.toml` using `configure_make` |
@@ -943,7 +943,7 @@ Each build essential must pass these tests on all 4 platforms:
 
 | Step | Description |
 |------|-------------|
-| 1 | Create `internal/recipe/recipes/o/openssl.toml` using `homebrew_bottle` action |
+| 1 | Create `internal/recipe/recipes/o/openssl.toml` using `homebrew` action |
 | 2 | Validate openssl libraries relocate correctly (complex RPATH) |
 | 3 | Create `internal/recipe/recipes/c/curl.toml` with `dependencies = ["openssl", "zlib"]` |
 | 4 | CI: Build curl from source, verify `curl --version` shows OpenSSL |
@@ -961,7 +961,7 @@ Each build essential must pass these tests on all 4 platforms:
 
 | Step | Description |
 |------|-------------|
-| 1 | Create `internal/recipe/recipes/c/cmake.toml` using `homebrew_bottle` action |
+| 1 | Create `internal/recipe/recipes/c/cmake.toml` using `homebrew` action |
 | 2 | Implement `cmake_build` action |
 | 3 | Create `internal/recipe/recipes/n/ninja.toml` using `cmake_build` action |
 | 4 | CI: Build ninja from source using tsuku cmake/gcc/make |

--- a/docs/DESIGN-relocatable-library-deps.md
+++ b/docs/DESIGN-relocatable-library-deps.md
@@ -449,7 +449,7 @@ Security best practices for RPATH:
 - `set_rpath` action implementation
 - Platform-specific: patchelf for Linux, install_name_tool for macOS
 
-**Rationale:** RPATH utilities are foundational for both library installation and homebrew_bottle. Moving them earlier reduces rework.
+**Rationale:** RPATH utilities are foundational for both library installation and homebrew. Moving them earlier reduces rework.
 
 ### Phase 3: Library Installation Actions
 
@@ -459,7 +459,7 @@ Security best practices for RPATH:
 ### Phase 4: Homebrew Integration
 
 - Homebrew version provider for `source = "homebrew"`
-- `homebrew_bottle` action: GHCR auth, download, extract, placeholder relocation
+- `homebrew` action: GHCR auth, download, extract, placeholder relocation
 
 ### Phase 5: Ruby Recipe Migration
 
@@ -519,7 +519,7 @@ Security best practices for RPATH:
 - [#219](https://github.com/tsukumogami/tsuku/issues/219): feat(action): implement install_libraries action
 - [#220](https://github.com/tsukumogami/tsuku/issues/220): feat(action): implement link_dependencies action
 - [#221](https://github.com/tsukumogami/tsuku/issues/221): feat(install): resolve library dependencies during tool installation
-- [#222](https://github.com/tsukumogami/tsuku/issues/222): feat(action): implement homebrew_bottle action
+- [#222](https://github.com/tsukumogami/tsuku/issues/222): feat(action): implement homebrew action
 
 **Migration (blocked by actions):**
 - [#223](https://github.com/tsukumogami/tsuku/issues/223): feat(recipe): add libyaml library recipe


### PR DESCRIPTION
## Summary

Completes milestone #23 (Homebrew and Legacy Action Cleanup) by updating all remaining references to renamed/removed actions throughout the codebase.

## Changes

### Milestone Description
- Updated milestone #23 description to reference `docs/DESIGN-homebrew.md` (the deleted `docs/DESIGN-homebrew-cleanup.md` was consolidated into this file)

### CI/CD
- Fixed `.github/workflows/homebrew-builder-tests.yml` test name: `TestHomebrewBottle` → `TestHomebrew`

### Documentation Updates
- **README.md**: Updated `homebrew_bottle` → `homebrew` 
- **recipes/CLAUDE.local.md**: 
  - Removed obsolete `hashicorp_release` action reference
  - Updated `homebrew_bottle` → `homebrew`
- **docs/DESIGN-dependency-provisioning.md**: Updated 11 instances of `homebrew_bottle` → `homebrew`
- **docs/DESIGN-relocatable-library-deps.md**: Updated 3 instances of `homebrew_bottle` → `homebrew`

## Related Issues

Closes #23 (Milestone)

Related: #671 (test suite improvements created as follow-up)

## Test Plan

- [x] All Go tests pass (`go test ./...`)
- [x] Documentation is consistent with current action names
- [x] CI workflow references correct test names
- [x] All milestone issues are closed (9/9)

## Milestone Status

All 9 issues in milestone 23 are complete:
- #580: Rename homebrew_bottle to homebrew
- #582: Migrate HashiCorp recipes to primitives
- #583: Move and convert source build fixtures
- #584: Remove hashicorp_release action
- #586: Remove homebrew_source action
- #587: Remove HomebrewBuilder source build code
- #588: Close obsolete Homebrew source build issues
- #589: Consolidate Homebrew design documentation
- #590: Implement deterministic bottle inspection with LLM fallback

Milestone 23 is now closed.