### PR TITLE
docs: add design for go_install version inference

### DIFF
--- a/docs/DESIGN-go-install-inference.md
+++ b/docs/DESIGN-go-install-inference.md
@@ -1,6 +1,6 @@
 # Design: go_install Version Inference
 
-**Status**: Proposed
+**Status**: Accepted
 
 ## Context and Problem Statement
 


### PR DESCRIPTION
Design document for adding version inference to go_install action. This design
addresses issue #691 and builds on the version inference work from PR #688.

Key insight from architecture review: The existing Recipe.Version.Module field
already handles the module path distinction correctly. No new schema fields are
needed - just add the inference mapping and InferredGoProxyStrategy.

---

## What This Accomplishes

PR #688 implemented version inference for ecosystem installers (cargo, pipx, npm, etc.)
but excluded `go_install` due to Go's distinction between install paths and module paths.
This design addresses that gap.

## Summary

Go tools often have different install paths vs. module paths:
- `dlv`: install path `github.com/go-delve/delve/cmd/dlv`, module `github.com/go-delve/delve`
- `gofumpt`: install path equals module path `mvdan.cc/gofumpt`

**Chosen approach**: Leverage existing `Recipe.Version.Module` field instead of adding new
schema. The `InferredGoProxyStrategy` will:
1. Check `Recipe.Version.Module` first (for differing paths)
2. Fall back to step's `module` param (for matching paths)

## Recipe Migration

**Simple cases (remove `[version]` entirely):**
- gofumpt, gopls, cobra-cli

**Complex cases (remove only `source = "goproxy"`, keep `module = "..."`):**
- dlv, goimports, staticcheck, gore

Before:
```toml
[version]
source = "goproxy"
module = "github.com/go-delve/delve"
```

After:
```toml
[version]
module = "github.com/go-delve/delve"
```

## Implementation Phases

1. Add `go_install` to actionInference map in redundancy.go
2. Add InferredGoProxyStrategy to provider_factory.go
3. Update recipes
4. Update documentation

Relates to #691