### PR TITLE
ci(golden): add workflow to validate golden files on recipe changes

### DIFF
--- a/.github/workflows/validate-golden-recipes.yml
+++ b/.github/workflows/validate-golden-recipes.yml
@@ -1,0 +1,121 @@
+name: Validate Golden Files (Recipes)
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'internal/recipe/recipes/**/*.toml'
+      - '.github/workflows/validate-golden-recipes.yml'
+  workflow_dispatch:
+
+jobs:
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      recipes: ${{ steps.changed.outputs.recipes }}
+      has_changes: ${{ steps.changed.outputs.has_changes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed recipes
+        id: changed
+        run: |
+          # Get list of changed recipe files (exclude deleted files)
+          CHANGED=$(git diff --name-only --diff-filter=d origin/main...HEAD -- 'internal/recipe/recipes/**/*.toml')
+
+          if [ -z "$CHANGED" ]; then
+            echo "No recipe files changed"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "recipes=[]" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "Changed recipes:"
+          echo "$CHANGED"
+
+          # Build JSON array of recipe names
+          # Only include recipes that have golden files
+          JSON="["
+          FIRST=true
+          for path in $CHANGED; do
+            # Skip if file doesn't exist (deleted in later commit)
+            if [ ! -f "$path" ]; then
+              echo "Skipping deleted recipe: $path"
+              continue
+            fi
+
+            recipe=$(basename "$path" .toml)
+            first_letter="${recipe:0:1}"
+            golden_dir="testdata/golden/plans/$first_letter/$recipe"
+
+            # Only validate if golden files exist for this recipe
+            # TODO(#745): Remove this skip once all recipes have golden files
+            if [ ! -d "$golden_dir" ]; then
+              echo "No golden files for $recipe, skipping"
+              continue
+            fi
+
+            if [ "$FIRST" = true ]; then
+              FIRST=false
+            else
+              JSON="$JSON,"
+            fi
+            JSON="$JSON\"$recipe\""
+          done
+          JSON="$JSON]"
+
+          if [ "$JSON" = "[]" ]; then
+            echo "No recipes with golden files changed"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+          echo "recipes=$JSON" >> $GITHUB_OUTPUT
+
+  validate-golden:
+    name: "Validate: ${{ matrix.recipe }}"
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        recipe: ${{ fromJson(needs.detect-changes.outputs.recipes) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache-dependency-path: go.sum
+
+      - name: Cache downloads
+        uses: actions/cache@v4
+        with:
+          path: ~/.tsuku/cache/downloads
+          key: golden-downloads-${{ matrix.recipe }}-${{ hashFiles(format('testdata/golden/plans/{0}/{1}/*.json', 'a]b]c]d]e]f]g]h]i]j]k]l]m]n]o]p]q]r]s]t]u]v]w]x]y]z', matrix.recipe)) }}
+          restore-keys: |
+            golden-downloads-${{ matrix.recipe }}-
+            golden-downloads-
+
+      - name: Build tsuku
+        run: go build -o tsuku ./cmd/tsuku
+
+      - name: Validate golden files
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Validating golden files for ${{ matrix.recipe }}..."
+          if ! ./scripts/validate-golden.sh "${{ matrix.recipe }}"; then
+            echo ""
+            echo "::error::Golden files are out of date for recipe '${{ matrix.recipe }}'."
+            echo "::error::Run './scripts/regenerate-golden.sh ${{ matrix.recipe }}' and commit the changes."
+            exit 1
+          fi

--- a/docs/DESIGN-golden-plan-testing.md
+++ b/docs/DESIGN-golden-plan-testing.md
@@ -40,6 +40,7 @@ Planned
 
 | Issue | Title | Dependencies |
 |-------|-------|--------------|
+| [#745](https://github.com/tsukumogami/tsuku/issues/745) | chore(golden): enforce golden files for all recipes | [#721](https://github.com/tsukumogami/tsuku/issues/721), [#722](https://github.com/tsukumogami/tsuku/issues/722) |
 | [#722](https://github.com/tsukumogami/tsuku/issues/722) | docs(design): create design for structured install_guide | None |
 
 ### Dependency Graph
@@ -68,6 +69,10 @@ graph TD
         I721["#721: Documentation"]
     end
 
+    subgraph M29["Milestone 29: Full Golden Coverage"]
+        I745["#745: Enforce all recipes"]
+    end
+
     subgraph Future["Future Work"]
         I722["#722: Structured install_guide"]
     end
@@ -84,6 +89,8 @@ graph TD
     I717 --> I721
     I718 --> I721
     I720 --> I721
+    I721 --> I745
+    I722 --> I745
 
     classDef done fill:#c8e6c9
     classDef ready fill:#bbdefb
@@ -92,7 +99,7 @@ graph TD
 
     class I712,I713,I714,I715,I716,I720 done
     class I717 ready
-    class I718,I719,I721 blocked
+    class I718,I719,I721,I745 blocked
     class I722 needsDesign
 ```
 


### PR DESCRIPTION
Add CI workflow that validates golden files when recipe TOML files change
in PRs. Uses matrix strategy for parallel per-recipe validation with
download caching for efficiency.

Also adds #745 to the design doc to track future enforcement of golden
files for all recipes.

---

## What This Accomplishes

Implements CI enforcement for golden file consistency when recipes change:

- **Change Detection**: Identifies modified recipe files in PRs, filters for those with golden files
- **Per-Recipe Validation**: Matrix job runs `validate-golden.sh` for each changed recipe
- **Actionable Errors**: Clear messages with regeneration instructions on mismatch
- **Efficient Caching**: Downloads cached via `actions/cache` for repeat validations

## Implementation Notes

Chose matrix strategy over simple loop (design doc showed simpler approach) because:
- Parallel execution across recipes
- Per-recipe job visibility in GitHub Actions UI
- Better failure isolation
- Consistent with existing `test-changed-recipes.yml` pattern

## Workflow Triggers

- PR changes to `internal/recipe/recipes/**/*.toml`
- Manual dispatch via workflow_dispatch

## Future Work

Created #745 to track enforcing golden files for ALL recipes (removing the
skip clause for recipes without golden files). Added to design doc with
new milestone M29 "Full Golden Coverage".

Fixes #717