### PR TITLE
docs: complete milestone 31 (Sandbox Container Building)

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,18 @@ Sandbox testing:
 - Automatically configures network access based on recipe requirements
 - Useful for testing recipes before submission or production deployment
 
+**System dependency handling:** When a recipe declares system dependencies (e.g., `apt_install`, `dnf_install`), sandbox mode builds a custom container image with those packages pre-installed. This allows testing recipes that require system packages without modifying your host system. Container images are cached based on their dependency fingerprint for efficient re-use.
+
+**Multi-family support:** Use `--linux-family` to test recipes on different distribution families:
+
+```bash
+# Test on Debian-based container
+tsuku install cmake --sandbox --linux-family debian
+
+# Test on Fedora-based container
+tsuku install cmake --sandbox --linux-family rhel
+```
+
 For technical details, see [DESIGN-install-sandbox.md](docs/DESIGN-install-sandbox.md).
 
 ## Testing

--- a/docs/DESIGN-structured-install-guide.md
+++ b/docs/DESIGN-structured-install-guide.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Planned
+Implemented
 
 ## Implementation Issues
 

--- a/docs/DESIGN-system-dependency-actions.md
+++ b/docs/DESIGN-system-dependency-actions.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Planned
+Implemented
 
 ## Implementation Issues
 

--- a/docs/GUIDE-system-dependencies.md
+++ b/docs/GUIDE-system-dependencies.md
@@ -173,6 +173,43 @@ tsuku install docker --quiet
 
 In quiet mode, tsuku only shows errors. This is useful for scripted installations where you've already handled system dependencies.
 
+## Sandbox Testing with System Dependencies
+
+When using `--sandbox` mode, tsuku automatically builds container images with system dependencies pre-installed. This allows you to test recipes that require system packages without modifying your host system.
+
+### How It Works
+
+1. tsuku extracts system dependency actions from the recipe (e.g., `apt_install`, `dnf_install`)
+2. A container image is built with those packages installed
+3. The recipe installation runs inside the container
+4. Container images are cached based on their dependency fingerprint
+
+### Example
+
+```bash
+# Test a recipe with apt dependencies in a Debian container
+tsuku install cmake --sandbox
+
+# Test on a specific Linux family
+tsuku install cmake --sandbox --linux-family rhel
+```
+
+### Multi-Family Testing
+
+Use the `--linux-family` flag to test recipes on different distribution families:
+
+```bash
+# Test on all supported families
+for family in debian rhel arch alpine suse; do
+  tsuku install cmake --sandbox --linux-family $family
+done
+```
+
+This is useful for:
+- Validating recipes work across distributions
+- CI/CD pipelines that test on multiple platforms
+- Recipe authors testing cross-platform compatibility
+
 ## Troubleshooting
 
 ### "Invalid target-family" Error


### PR DESCRIPTION
Update user-facing documentation to explain sandbox container building with system dependencies pre-installed. Also update design document status fields from "Planned" to "Implemented".

---

## What This PR Accomplishes

Milestone M31 (Sandbox Container Building) implemented dynamic container building for sandbox testing. This PR adds the documentation updates identified during milestone completion validation:

1. **README.md**: Added sandbox system dependency handling explanation and multi-family testing examples
2. **GUIDE-system-dependencies.md**: New section explaining how sandbox mode handles system dependencies with examples
3. **DESIGN-structured-install-guide.md**: Updated status from "Planned" to "Implemented"
4. **DESIGN-system-dependency-actions.md**: Updated status from "Planned" to "Implemented"

## Milestone Closure

After this PR merges, close milestone M31 via:
```bash
gh api repos/:owner/:repo/milestones/31 --method PATCH -f state=closed
```