### PR TITLE
feat(recipe): add recipe family policy analysis

### DIFF
--- a/docs/DESIGN-golden-family-support.md
+++ b/docs/DESIGN-golden-family-support.md
@@ -62,9 +62,9 @@ graph TD
     classDef blocked fill:#fff9c4
     classDef needsDesign fill:#e1bee7
 
-    class I822,I823,I824,I825,I827 done
-    class I826 ready
-    class I828,I829,I830,I831 blocked
+    class I822,I823,I824,I825,I826,I827 done
+    class I828 ready
+    class I829,I830,I831 blocked
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design

--- a/internal/recipe/policy.go
+++ b/internal/recipe/policy.go
@@ -1,0 +1,189 @@
+package recipe
+
+import "fmt"
+
+// AllLinuxFamilies lists all supported Linux distribution families.
+// Used when a recipe requires files for all families (FamilyVarying, FamilyMixed).
+var AllLinuxFamilies = []string{"debian", "rhel", "arch", "alpine", "suse"}
+
+// RecipeFamilyPolicy describes how a recipe relates to Linux families.
+// This determines which platform+family combinations need golden files.
+type RecipeFamilyPolicy int
+
+const (
+	// FamilyNone: No Linux-applicable steps exist, so no family policy applies.
+	// Result: No Linux platforms at all (Darwin-only recipe)
+	FamilyNone RecipeFamilyPolicy = iota
+
+	// FamilyAgnostic: Has Linux steps, but no family constraints or variation.
+	// Result: Generic Linux platforms (no family qualifier in golden files)
+	FamilyAgnostic
+
+	// FamilyVarying: At least one step uses {{linux_family}} interpolation.
+	// Result: All families (each produces different output)
+	FamilyVarying
+
+	// FamilySpecific: All Linux steps target specific families, no unconstrained steps.
+	// Result: Only the families explicitly targeted
+	FamilySpecific
+
+	// FamilyMixed: Has both family-constrained and unconstrained Linux steps.
+	// Result: All families (some steps filtered per family)
+	FamilyMixed
+)
+
+// String returns the policy name for debugging and logging.
+func (p RecipeFamilyPolicy) String() string {
+	switch p {
+	case FamilyNone:
+		return "FamilyNone"
+	case FamilyAgnostic:
+		return "FamilyAgnostic"
+	case FamilyVarying:
+		return "FamilyVarying"
+	case FamilySpecific:
+		return "FamilySpecific"
+	case FamilyMixed:
+		return "FamilyMixed"
+	default:
+		return fmt.Sprintf("RecipeFamilyPolicy(%d)", p)
+	}
+}
+
+// RecipeAnalysis contains the full analysis of a recipe's platform support.
+// Returned by AnalyzeRecipe; used by SupportedPlatforms.
+type RecipeAnalysis struct {
+	Policy         RecipeFamilyPolicy
+	FamiliesUsed   map[string]bool // For FamilySpecific/FamilyMixed - tracks which families are used
+	SupportsDarwin bool            // Derived from step analysis, not hardcoded
+}
+
+// Platform represents a supported platform for a recipe.
+// Used in the supported_platforms output from tsuku info.
+type Platform struct {
+	OS          string `json:"os"`
+	Arch        string `json:"arch"`
+	LinuxFamily string `json:"linux_family,omitempty"` // Only set for family-aware recipes
+}
+
+// AnalyzeRecipe computes the family policy and OS support for a recipe.
+// It iterates all steps and aggregates their constraints to determine
+// which platforms the recipe supports and how it varies by family.
+func AnalyzeRecipe(recipe *Recipe) *RecipeAnalysis {
+	familiesUsed := make(map[string]bool)
+	hasFamilyVaryingStep := false
+	hasUnconstrainedLinuxSteps := false
+	hasAnyLinuxSteps := false
+	hasAnyDarwinSteps := false
+
+	for _, step := range recipe.Steps {
+		analysis := step.Analysis()
+
+		// If analysis is nil (backward compat when loader doesn't set it),
+		// treat as unconstrained
+		if analysis == nil {
+			hasAnyLinuxSteps = true
+			hasAnyDarwinSteps = true
+			hasUnconstrainedLinuxSteps = true
+			continue
+		}
+
+		// Track OS support from step constraints
+		// Unconstrained (nil or empty OS) means both OSes
+		// Explicit OS constraint means only that OS
+		if analysis.Constraint == nil || analysis.Constraint.OS == "" {
+			hasAnyLinuxSteps = true
+			hasAnyDarwinSteps = true
+		} else if analysis.Constraint.OS == "linux" {
+			hasAnyLinuxSteps = true
+		} else if analysis.Constraint.OS == "darwin" {
+			hasAnyDarwinSteps = true
+			continue // Skip family analysis for darwin-only steps
+		}
+
+		// Family analysis (only for Linux-applicable steps)
+		// Handle constrained+varying: interpolation within a family constraint
+		if analysis.FamilyVarying {
+			if analysis.Constraint != nil && analysis.Constraint.LinuxFamily != "" {
+				// Constrained+varying: interpolation only happens within this family
+				familiesUsed[analysis.Constraint.LinuxFamily] = true
+			} else {
+				// Unconstrained varying: needs all families
+				hasFamilyVaryingStep = true
+			}
+		} else if analysis.Constraint != nil && analysis.Constraint.LinuxFamily != "" {
+			familiesUsed[analysis.Constraint.LinuxFamily] = true
+		} else if analysis.Constraint == nil || analysis.Constraint.OS == "" || analysis.Constraint.OS == "linux" {
+			hasUnconstrainedLinuxSteps = true
+		}
+	}
+
+	// Determine policy - no nil sentinel, explicit enum for each case
+	var policy RecipeFamilyPolicy
+	if !hasAnyLinuxSteps {
+		policy = FamilyNone
+	} else if hasFamilyVaryingStep {
+		policy = FamilyVarying
+	} else if len(familiesUsed) == 0 {
+		policy = FamilyAgnostic
+	} else if hasUnconstrainedLinuxSteps {
+		policy = FamilyMixed
+	} else {
+		policy = FamilySpecific
+	}
+
+	return &RecipeAnalysis{
+		Policy:         policy,
+		FamiliesUsed:   familiesUsed,
+		SupportsDarwin: hasAnyDarwinSteps,
+	}
+}
+
+// SupportedPlatforms returns all platforms the recipe supports.
+// This is the list that should be used for golden file generation/validation.
+func SupportedPlatforms(recipe *Recipe) []Platform {
+	analysis := AnalyzeRecipe(recipe)
+
+	var platforms []Platform
+
+	// Add darwin platforms only if recipe supports darwin (derived from analysis)
+	if analysis.SupportsDarwin {
+		platforms = append(platforms,
+			Platform{OS: "darwin", Arch: "amd64"},
+			Platform{OS: "darwin", Arch: "arm64"},
+		)
+	}
+
+	// Add Linux platforms based on policy
+	switch analysis.Policy {
+	case FamilyNone:
+		// No Linux platforms - no family policy applies
+
+	case FamilyAgnostic:
+		// Generic Linux (no family qualifier)
+		platforms = append(platforms,
+			Platform{OS: "linux", Arch: "amd64"},
+			Platform{OS: "linux", Arch: "arm64"},
+		)
+
+	case FamilyVarying, FamilyMixed:
+		// All families needed
+		for _, family := range AllLinuxFamilies {
+			platforms = append(platforms,
+				Platform{OS: "linux", Arch: "amd64", LinuxFamily: family},
+				Platform{OS: "linux", Arch: "arm64", LinuxFamily: family},
+			)
+		}
+
+	case FamilySpecific:
+		// Only specific families
+		for family := range analysis.FamiliesUsed {
+			platforms = append(platforms,
+				Platform{OS: "linux", Arch: "amd64", LinuxFamily: family},
+				Platform{OS: "linux", Arch: "arm64", LinuxFamily: family},
+			)
+		}
+	}
+
+	return platforms
+}

--- a/internal/recipe/policy_test.go
+++ b/internal/recipe/policy_test.go
@@ -1,0 +1,470 @@
+package recipe
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestRecipeFamilyPolicy_String(t *testing.T) {
+	tests := []struct {
+		policy RecipeFamilyPolicy
+		want   string
+	}{
+		{FamilyNone, "FamilyNone"},
+		{FamilyAgnostic, "FamilyAgnostic"},
+		{FamilyVarying, "FamilyVarying"},
+		{FamilySpecific, "FamilySpecific"},
+		{FamilyMixed, "FamilyMixed"},
+		{RecipeFamilyPolicy(99), "RecipeFamilyPolicy(99)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := tt.policy.String(); got != tt.want {
+				t.Errorf("String() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Helper to create a recipe with steps that have pre-set analysis
+func makeRecipeWithAnalysis(steps []stepWithAnalysis) *Recipe {
+	recipe := &Recipe{
+		Metadata: MetadataSection{Name: "test"},
+		Verify:   VerifySection{Command: "test --version"},
+	}
+	for _, s := range steps {
+		step := Step{
+			Action: s.action,
+			When:   s.when,
+			Params: s.params,
+		}
+		step.SetAnalysis(s.analysis)
+		recipe.Steps = append(recipe.Steps, step)
+	}
+	return recipe
+}
+
+type stepWithAnalysis struct {
+	action   string
+	when     *WhenClause
+	params   map[string]interface{}
+	analysis *StepAnalysis
+}
+
+func TestAnalyzeRecipe_FamilyNone(t *testing.T) {
+	// Darwin-only recipe (when.os: darwin)
+	recipe := makeRecipeWithAnalysis([]stepWithAnalysis{
+		{
+			action:   "download",
+			analysis: &StepAnalysis{Constraint: &Constraint{OS: "darwin"}},
+		},
+	})
+
+	analysis := AnalyzeRecipe(recipe)
+
+	if analysis.Policy != FamilyNone {
+		t.Errorf("expected FamilyNone, got %s", analysis.Policy)
+	}
+	if !analysis.SupportsDarwin {
+		t.Error("expected SupportsDarwin=true")
+	}
+	if len(analysis.FamiliesUsed) != 0 {
+		t.Errorf("expected empty FamiliesUsed, got %v", analysis.FamiliesUsed)
+	}
+}
+
+func TestAnalyzeRecipe_FamilyAgnostic(t *testing.T) {
+	// Recipe with download action, no family refs
+	recipe := makeRecipeWithAnalysis([]stepWithAnalysis{
+		{
+			action:   "download",
+			analysis: &StepAnalysis{Constraint: nil, FamilyVarying: false},
+		},
+	})
+
+	analysis := AnalyzeRecipe(recipe)
+
+	if analysis.Policy != FamilyAgnostic {
+		t.Errorf("expected FamilyAgnostic, got %s", analysis.Policy)
+	}
+	if !analysis.SupportsDarwin {
+		t.Error("expected SupportsDarwin=true for unconstrained step")
+	}
+}
+
+func TestAnalyzeRecipe_FamilyVarying(t *testing.T) {
+	// Recipe with {{linux_family}} in URL template
+	recipe := makeRecipeWithAnalysis([]stepWithAnalysis{
+		{
+			action: "download",
+			params: map[string]interface{}{
+				"url": "https://example.com/{{linux_family}}/tool.tar.gz",
+			},
+			analysis: &StepAnalysis{Constraint: nil, FamilyVarying: true},
+		},
+	})
+
+	analysis := AnalyzeRecipe(recipe)
+
+	if analysis.Policy != FamilyVarying {
+		t.Errorf("expected FamilyVarying, got %s", analysis.Policy)
+	}
+}
+
+func TestAnalyzeRecipe_FamilySpecific_Single(t *testing.T) {
+	// Recipe with only apt_install
+	recipe := makeRecipeWithAnalysis([]stepWithAnalysis{
+		{
+			action:   "apt_install",
+			analysis: &StepAnalysis{Constraint: &Constraint{OS: "linux", LinuxFamily: "debian"}},
+		},
+	})
+
+	analysis := AnalyzeRecipe(recipe)
+
+	if analysis.Policy != FamilySpecific {
+		t.Errorf("expected FamilySpecific, got %s", analysis.Policy)
+	}
+	if !analysis.FamiliesUsed["debian"] {
+		t.Error("expected debian in FamiliesUsed")
+	}
+	if len(analysis.FamiliesUsed) != 1 {
+		t.Errorf("expected 1 family, got %d", len(analysis.FamiliesUsed))
+	}
+	// apt_install is linux-only, so no darwin
+	if analysis.SupportsDarwin {
+		t.Error("expected SupportsDarwin=false for linux-only step")
+	}
+}
+
+func TestAnalyzeRecipe_FamilySpecific_Multi(t *testing.T) {
+	// Recipe with apt_install + dnf_install
+	recipe := makeRecipeWithAnalysis([]stepWithAnalysis{
+		{
+			action:   "apt_install",
+			analysis: &StepAnalysis{Constraint: &Constraint{OS: "linux", LinuxFamily: "debian"}},
+		},
+		{
+			action:   "dnf_install",
+			analysis: &StepAnalysis{Constraint: &Constraint{OS: "linux", LinuxFamily: "rhel"}},
+		},
+	})
+
+	analysis := AnalyzeRecipe(recipe)
+
+	if analysis.Policy != FamilySpecific {
+		t.Errorf("expected FamilySpecific, got %s", analysis.Policy)
+	}
+	if !analysis.FamiliesUsed["debian"] {
+		t.Error("expected debian in FamiliesUsed")
+	}
+	if !analysis.FamiliesUsed["rhel"] {
+		t.Error("expected rhel in FamiliesUsed")
+	}
+	if len(analysis.FamiliesUsed) != 2 {
+		t.Errorf("expected 2 families, got %d", len(analysis.FamiliesUsed))
+	}
+}
+
+func TestAnalyzeRecipe_FamilyMixed(t *testing.T) {
+	// Recipe with download + apt_install
+	recipe := makeRecipeWithAnalysis([]stepWithAnalysis{
+		{
+			action:   "download",
+			analysis: &StepAnalysis{Constraint: nil, FamilyVarying: false},
+		},
+		{
+			action:   "apt_install",
+			analysis: &StepAnalysis{Constraint: &Constraint{OS: "linux", LinuxFamily: "debian"}},
+		},
+	})
+
+	analysis := AnalyzeRecipe(recipe)
+
+	if analysis.Policy != FamilyMixed {
+		t.Errorf("expected FamilyMixed, got %s", analysis.Policy)
+	}
+	if !analysis.FamiliesUsed["debian"] {
+		t.Error("expected debian in FamiliesUsed")
+	}
+}
+
+func TestAnalyzeRecipe_ConstrainedPlusVarying(t *testing.T) {
+	// Step with both family constraint AND {{linux_family}} interpolation
+	// This step only runs on debian but uses interpolation
+	recipe := makeRecipeWithAnalysis([]stepWithAnalysis{
+		{
+			action: "download",
+			params: map[string]interface{}{
+				"url": "https://example.com/{{linux_family}}-tool.tar.gz",
+			},
+			analysis: &StepAnalysis{
+				Constraint:    &Constraint{LinuxFamily: "debian"},
+				FamilyVarying: true,
+			},
+		},
+	})
+
+	analysis := AnalyzeRecipe(recipe)
+
+	// Should be FamilySpecific because the interpolation is constrained to debian
+	if analysis.Policy != FamilySpecific {
+		t.Errorf("expected FamilySpecific for constrained+varying, got %s", analysis.Policy)
+	}
+	if !analysis.FamiliesUsed["debian"] {
+		t.Error("expected debian in FamiliesUsed")
+	}
+	if len(analysis.FamiliesUsed) != 1 {
+		t.Errorf("expected 1 family (not all families), got %d", len(analysis.FamiliesUsed))
+	}
+}
+
+func TestAnalyzeRecipe_LinuxOnlyStep(t *testing.T) {
+	// Step with when.os: linux (no family constraint)
+	recipe := makeRecipeWithAnalysis([]stepWithAnalysis{
+		{
+			action:   "download",
+			analysis: &StepAnalysis{Constraint: &Constraint{OS: "linux"}},
+		},
+	})
+
+	analysis := AnalyzeRecipe(recipe)
+
+	if analysis.Policy != FamilyAgnostic {
+		t.Errorf("expected FamilyAgnostic, got %s", analysis.Policy)
+	}
+	if analysis.SupportsDarwin {
+		t.Error("expected SupportsDarwin=false for linux-only step")
+	}
+}
+
+func TestAnalyzeRecipe_NilAnalysis(t *testing.T) {
+	// Recipe with step that has nil analysis (backward compat)
+	recipe := &Recipe{
+		Metadata: MetadataSection{Name: "test"},
+		Steps: []Step{
+			{Action: "download"},
+		},
+		Verify: VerifySection{Command: "test --version"},
+	}
+
+	analysis := AnalyzeRecipe(recipe)
+
+	// Should treat as unconstrained
+	if analysis.Policy != FamilyAgnostic {
+		t.Errorf("expected FamilyAgnostic for nil analysis, got %s", analysis.Policy)
+	}
+	if !analysis.SupportsDarwin {
+		t.Error("expected SupportsDarwin=true for nil analysis")
+	}
+}
+
+func TestSupportedPlatforms_FamilyNone(t *testing.T) {
+	// Darwin-only recipe
+	recipe := makeRecipeWithAnalysis([]stepWithAnalysis{
+		{
+			action:   "brew_install",
+			analysis: &StepAnalysis{Constraint: &Constraint{OS: "darwin"}},
+		},
+	})
+
+	platforms := SupportedPlatforms(recipe)
+
+	// Should only have darwin platforms
+	if len(platforms) != 2 {
+		t.Errorf("expected 2 platforms, got %d", len(platforms))
+	}
+	for _, p := range platforms {
+		if p.OS != "darwin" {
+			t.Errorf("expected only darwin platforms, got %s", p.OS)
+		}
+		if p.LinuxFamily != "" {
+			t.Errorf("expected no LinuxFamily for darwin, got %s", p.LinuxFamily)
+		}
+	}
+}
+
+func TestSupportedPlatforms_FamilyAgnostic(t *testing.T) {
+	// Generic recipe
+	recipe := makeRecipeWithAnalysis([]stepWithAnalysis{
+		{
+			action:   "download",
+			analysis: &StepAnalysis{Constraint: nil},
+		},
+	})
+
+	platforms := SupportedPlatforms(recipe)
+
+	// Should have darwin + generic linux (4 total)
+	if len(platforms) != 4 {
+		t.Errorf("expected 4 platforms, got %d", len(platforms))
+	}
+
+	// Check no linux_family is set
+	for _, p := range platforms {
+		if p.OS == "linux" && p.LinuxFamily != "" {
+			t.Errorf("expected no LinuxFamily for FamilyAgnostic, got %s", p.LinuxFamily)
+		}
+	}
+}
+
+func TestSupportedPlatforms_FamilyVarying(t *testing.T) {
+	// Recipe with {{linux_family}} interpolation
+	recipe := makeRecipeWithAnalysis([]stepWithAnalysis{
+		{
+			action:   "download",
+			analysis: &StepAnalysis{Constraint: nil, FamilyVarying: true},
+		},
+	})
+
+	platforms := SupportedPlatforms(recipe)
+
+	// Should have darwin (2) + all linux families (5 * 2 = 10) = 12
+	expectedCount := 2 + len(AllLinuxFamilies)*2
+	if len(platforms) != expectedCount {
+		t.Errorf("expected %d platforms, got %d", expectedCount, len(platforms))
+	}
+
+	// Verify all families are present
+	familiesFound := make(map[string]bool)
+	for _, p := range platforms {
+		if p.OS == "linux" && p.LinuxFamily != "" {
+			familiesFound[p.LinuxFamily] = true
+		}
+	}
+	for _, family := range AllLinuxFamilies {
+		if !familiesFound[family] {
+			t.Errorf("expected family %s to be present", family)
+		}
+	}
+}
+
+func TestSupportedPlatforms_FamilySpecific(t *testing.T) {
+	// apt_install only
+	recipe := makeRecipeWithAnalysis([]stepWithAnalysis{
+		{
+			action:   "apt_install",
+			analysis: &StepAnalysis{Constraint: &Constraint{OS: "linux", LinuxFamily: "debian"}},
+		},
+	})
+
+	platforms := SupportedPlatforms(recipe)
+
+	// Should have only debian linux (2 arches) = 2
+	if len(platforms) != 2 {
+		t.Errorf("expected 2 platforms, got %d", len(platforms))
+	}
+
+	for _, p := range platforms {
+		if p.OS != "linux" {
+			t.Errorf("expected only linux platforms, got %s", p.OS)
+		}
+		if p.LinuxFamily != "debian" {
+			t.Errorf("expected LinuxFamily=debian, got %s", p.LinuxFamily)
+		}
+	}
+}
+
+func TestSupportedPlatforms_FamilyMixed(t *testing.T) {
+	// download + apt_install
+	recipe := makeRecipeWithAnalysis([]stepWithAnalysis{
+		{
+			action:   "download",
+			analysis: &StepAnalysis{Constraint: nil},
+		},
+		{
+			action:   "apt_install",
+			analysis: &StepAnalysis{Constraint: &Constraint{OS: "linux", LinuxFamily: "debian"}},
+		},
+	})
+
+	platforms := SupportedPlatforms(recipe)
+
+	// Should have darwin (2) + all linux families (5 * 2 = 10) = 12
+	expectedCount := 2 + len(AllLinuxFamilies)*2
+	if len(platforms) != expectedCount {
+		t.Errorf("expected %d platforms, got %d", expectedCount, len(platforms))
+	}
+}
+
+func TestSupportedPlatforms_Architectures(t *testing.T) {
+	// Verify both amd64 and arm64 are included
+	recipe := makeRecipeWithAnalysis([]stepWithAnalysis{
+		{
+			action:   "download",
+			analysis: &StepAnalysis{Constraint: nil},
+		},
+	})
+
+	platforms := SupportedPlatforms(recipe)
+
+	archCounts := make(map[string]int)
+	for _, p := range platforms {
+		archCounts[p.Arch]++
+	}
+
+	if archCounts["amd64"] == 0 {
+		t.Error("expected amd64 architecture")
+	}
+	if archCounts["arm64"] == 0 {
+		t.Error("expected arm64 architecture")
+	}
+}
+
+func TestAllLinuxFamilies(t *testing.T) {
+	// Verify the expected families are present
+	expected := []string{"debian", "rhel", "arch", "alpine", "suse"}
+
+	if len(AllLinuxFamilies) != len(expected) {
+		t.Errorf("expected %d families, got %d", len(expected), len(AllLinuxFamilies))
+	}
+
+	// Sort for comparison
+	sortedExpected := make([]string, len(expected))
+	copy(sortedExpected, expected)
+	sort.Strings(sortedExpected)
+
+	sortedActual := make([]string, len(AllLinuxFamilies))
+	copy(sortedActual, AllLinuxFamilies)
+	sort.Strings(sortedActual)
+
+	for i := range sortedExpected {
+		if sortedExpected[i] != sortedActual[i] {
+			t.Errorf("family mismatch at %d: expected %s, got %s", i, sortedExpected[i], sortedActual[i])
+		}
+	}
+}
+
+func TestAnalyzeRecipe_EmptyRecipe(t *testing.T) {
+	// Recipe with no steps
+	recipe := &Recipe{
+		Metadata: MetadataSection{Name: "empty"},
+		Steps:    []Step{},
+		Verify:   VerifySection{Command: "test --version"},
+	}
+
+	analysis := AnalyzeRecipe(recipe)
+
+	// Empty recipe has no Linux or Darwin steps
+	if analysis.Policy != FamilyNone {
+		t.Errorf("expected FamilyNone for empty recipe, got %s", analysis.Policy)
+	}
+	if analysis.SupportsDarwin {
+		t.Error("expected SupportsDarwin=false for empty recipe")
+	}
+}
+
+func TestSupportedPlatforms_EmptyRecipe(t *testing.T) {
+	recipe := &Recipe{
+		Metadata: MetadataSection{Name: "empty"},
+		Steps:    []Step{},
+		Verify:   VerifySection{Command: "test --version"},
+	}
+
+	platforms := SupportedPlatforms(recipe)
+
+	if len(platforms) != 0 {
+		t.Errorf("expected 0 platforms for empty recipe, got %d", len(platforms))
+	}
+}


### PR DESCRIPTION
Add recipe-level analysis that aggregates step constraints to determine
the recipe's family policy and supported platforms. This is Phase 3 of
the golden family support design.

- RecipeFamilyPolicy enum with 5 policy values (FamilyNone, FamilyAgnostic, FamilyVarying, FamilySpecific, FamilyMixed)
- RecipeAnalysis struct aggregating step-level analysis into recipe-level policy
- AnalyzeRecipe() iterates steps to compute policy and OS support
- SupportedPlatforms() converts policy to concrete platform list
- AllLinuxFamilies constant for platform expansion
- Comprehensive test coverage for all policy types and edge cases

---

## What This Accomplishes

This implements Phase 3 (Recipe Family Policy) from the golden family support design. Given a recipe with pre-analyzed steps (from #825), this aggregates step-level constraints into a recipe-level policy that determines which platforms need golden files.

## Policy Determination

The `AnalyzeRecipe()` function applies precedence rules to determine policy:

| Recipe Pattern | Policy | Darwin? | Linux Platforms |
|----------------|--------|---------|-----------------|
| Darwin-only steps | FamilyNone | Yes | None |
| Linux steps, no family refs | FamilyAgnostic | Depends | Generic linux |
| Uses `{{linux_family}}` | FamilyVarying | Depends | All 5 families |
| Only family-specific actions | FamilySpecific | No | Only targeted families |
| Mix of agnostic + specific | FamilyMixed | Yes | All 5 families |

## What This Enables

With this in place, Issue #828 (Info metadata aggregation) can now:
1. Call `SupportedPlatforms(recipe)` to get the exact platforms needing golden files
2. Include this in `tsuku info --json` output for tooling consumption
3. Drive the golden file generation scripts in Milestone 33

## Test Coverage

- `TestAnalyzeRecipe_*` - all 5 policy types plus edge cases
- `TestSupportedPlatforms_*` - platform expansion for each policy
- `TestAllLinuxFamilies` - validates family list
- Backward compatibility: nil analysis treated as unconstrained

Fixes #826