### PR TITLE
feat(cli): expose supported platforms in tsuku info metadata

### DIFF
--- a/cmd/tsuku/helpers.go
+++ b/cmd/tsuku/helpers.go
@@ -18,10 +18,15 @@ import (
 // loader holds the recipe loader (shared across all commands)
 var loader *recipe.Loader
 
+// constraintLookup holds the constraint lookup function (shared across all commands).
+// This is set during initialization and used by loadLocalRecipe for step analysis.
+var constraintLookup recipe.ConstraintLookup
+
 // loadLocalRecipe loads a recipe from a local file path.
 // This is a thin wrapper around recipe.ParseFile for use in CLI commands.
+// It uses the global constraintLookup for step analysis (same as loader).
 func loadLocalRecipe(path string) (*recipe.Recipe, error) {
-	return recipe.ParseFile(path)
+	return recipe.ParseFile(path, constraintLookup)
 }
 
 // printInfo prints an informational message unless quiet mode is enabled
@@ -78,7 +83,7 @@ func generateInstallPlan(
 
 	// Load recipe from file or registry
 	if recipePath != "" {
-		r, err = recipe.ParseFile(recipePath)
+		r, err = recipe.ParseFile(recipePath, constraintLookup)
 		recipeSource = "local"
 	} else {
 		r, err = loader.Get(toolName)

--- a/cmd/tsuku/info.go
+++ b/cmd/tsuku/info.go
@@ -104,23 +104,23 @@ var infoCmd = &cobra.Command{
 		// JSON output mode
 		if jsonOutput {
 			type infoOutput struct {
-				Name                 string   `json:"name"`
-				Description          string   `json:"description"`
-				Homepage             string   `json:"homepage,omitempty"`
-				VersionFormat        string   `json:"version_format"`
-				VersionSource        string   `json:"version_source"`
-				SupportedOS          []string `json:"supported_os,omitempty"`
-				SupportedArch        []string `json:"supported_arch,omitempty"`
-				UnsupportedPlatforms []string `json:"unsupported_platforms,omitempty"`
-				SupportedPlatforms   []string `json:"supported_platforms"`
-				Tier                 int      `json:"tier"`
-				Type                 string   `json:"type"`
-				Status               string   `json:"status,omitempty"`
-				InstalledVersion     string   `json:"installed_version,omitempty"`
-				Location             string   `json:"location,omitempty"`
-				VerifyCommand        string   `json:"verify_command,omitempty"`
-				InstallDependencies  []string `json:"install_dependencies,omitempty"`
-				RuntimeDependencies  []string `json:"runtime_dependencies,omitempty"`
+				Name                 string            `json:"name"`
+				Description          string            `json:"description"`
+				Homepage             string            `json:"homepage,omitempty"`
+				VersionFormat        string            `json:"version_format"`
+				VersionSource        string            `json:"version_source"`
+				SupportedOS          []string          `json:"supported_os,omitempty"`
+				SupportedArch        []string          `json:"supported_arch,omitempty"`
+				UnsupportedPlatforms []string          `json:"unsupported_platforms,omitempty"`
+				SupportedPlatforms   []recipe.Platform `json:"supported_platforms"`
+				Tier                 int               `json:"tier"`
+				Type                 string            `json:"type"`
+				Status               string            `json:"status,omitempty"`
+				InstalledVersion     string            `json:"installed_version,omitempty"`
+				Location             string            `json:"location,omitempty"`
+				VerifyCommand        string            `json:"verify_command,omitempty"`
+				InstallDependencies  []string          `json:"install_dependencies,omitempty"`
+				RuntimeDependencies  []string          `json:"runtime_dependencies,omitempty"`
 			}
 			output := infoOutput{
 				Name:                 r.Metadata.Name,
@@ -131,7 +131,7 @@ var infoCmd = &cobra.Command{
 				SupportedOS:          r.Metadata.SupportedOS,
 				SupportedArch:        r.Metadata.SupportedArch,
 				UnsupportedPlatforms: r.Metadata.UnsupportedPlatforms,
-				SupportedPlatforms:   r.GetSupportedPlatforms(),
+				SupportedPlatforms:   recipe.SupportedPlatforms(r),
 				Tier:                 r.Metadata.Tier,
 				Type:                 r.Metadata.Type,
 				Status:               status,

--- a/cmd/tsuku/main.go
+++ b/cmd/tsuku/main.go
@@ -63,7 +63,8 @@ func init() {
 	loader = recipe.NewWithLocalRecipes(reg, cfg.RecipesDir)
 
 	// Configure constraint lookup for step analysis (enables platform constraint validation)
-	loader.SetConstraintLookup(defaultConstraintLookup())
+	constraintLookup = defaultConstraintLookup()
+	loader.SetConstraintLookup(constraintLookup)
 
 	// Register all commands
 	rootCmd.AddCommand(activateCmd)

--- a/docs/DESIGN-golden-family-support.md
+++ b/docs/DESIGN-golden-family-support.md
@@ -62,9 +62,9 @@ graph TD
     classDef blocked fill:#fff9c4
     classDef needsDesign fill:#e1bee7
 
-    class I822,I823,I824,I825,I826,I827 done
-    class I828 ready
-    class I829,I830,I831 blocked
+    class I822,I823,I824,I825,I826,I827,I828 done
+    class I829 ready
+    class I830,I831 blocked
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design


### PR DESCRIPTION
Update `tsuku info --metadata-only --json` to return `supported_platforms`
as an array of structured platform objects instead of the previous string
tuples. This enables golden file tooling to query platform support
programmatically, including Linux family information for family-aware recipes.

- Change SupportedPlatforms from []string to []recipe.Platform
- Use recipe.SupportedPlatforms(r) which returns platforms with linux_family
  for family-aware recipes
- Pass constraintLookup to loadLocalRecipe so step analysis works with --recipe

---

## What This Accomplishes

This implements Phase 4 (Metadata Aggregation) from the golden family support
design. The `tsuku info` command now exposes structured platform metadata that
includes Linux family information when relevant.

## Output Format

**Family-agnostic recipes** (no family-specific actions):
```json
[
  {"os": "linux", "arch": "amd64"},
  {"os": "linux", "arch": "arm64"},
  {"os": "darwin", "arch": "amd64"},
  {"os": "darwin", "arch": "arm64"}
]
```

**Family-aware recipes** (have package manager actions or `{{linux_family}}`):
```json
[
  {"os": "linux", "arch": "amd64", "linux_family": "debian"},
  {"os": "linux", "arch": "amd64", "linux_family": "rhel"},
  ...
  {"os": "darwin", "arch": "amd64"},
  {"os": "darwin", "arch": "arm64"}
]
```

## What This Enables

With this in place, Issue #829 (script updates for family-aware recipes) can:
1. Query `tsuku info --metadata-only --json | jq '.supported_platforms'`
2. Check for `linux_family` field to determine if recipe is family-aware
3. Generate correct golden filenames based on platform metadata

Fixes #828