### PR TITLE
docs: add fossil_archive to action guide and testdata README

### DIFF
--- a/docs/GUIDE-actions-and-primitives.md
+++ b/docs/GUIDE-actions-and-primitives.md
@@ -180,6 +180,7 @@ Composite actions are shortcuts for recipe authors. They decompose into primitiv
 | Composite | Decomposes To | Example Recipe Use |
 |-----------|---------------|--------------------|
 | `apply_patch` | download_file + apply_patch_file (or just apply_patch_file) | Apply patch from URL or inline data |
+| `fossil_archive` | download_file + extract | Download source archive from Fossil SCM repository |
 | `homebrew` | download_file + extract + homebrew_relocate | Install Homebrew GHCR bottles |
 
 ##### Patch Application

--- a/testdata/README.md
+++ b/testdata/README.md
@@ -56,3 +56,33 @@ tsuku list
 cat ~/.tsuku/state.json
 # Should show tool-b with is_explicit=true
 ```
+
+## Fossil Archive Test Recipes
+
+These recipes test the `fossil_archive` action for building tools from Fossil SCM repositories.
+
+| Recipe | Purpose |
+|--------|---------|
+| `sqlite-source.toml` | Basic `fossil_archive` usage with default tag format |
+| `fossil-source.toml` | Self-hosting demo (build Fossil from Fossil) |
+| `tcl-source.toml` | Tests `version_separator = "-"` for `core-X-Y-Z` tags |
+| `tk-source.toml` | Tests dependency chain (`dependencies = ["tcl-source"]`) |
+
+### Testing fossil_archive
+
+```bash
+# Build SQLite from source
+tsuku install sqlite-source
+
+# Verify installation
+sqlite3 --version
+
+# Build Tcl (demonstrates version_separator)
+tsuku install tcl-source
+
+# Build Tk (demonstrates dependency handling)
+tsuku install tk-source
+# Should install tcl-source first as dependency
+```
+
+See [BUILD-ESSENTIALS.md](../docs/BUILD-ESSENTIALS.md) for `fossil_archive` documentation.


### PR DESCRIPTION
## Summary

- Add `fossil_archive` to the Specialized Composites table in `GUIDE-actions-and-primitives.md`
- Document fossil_archive testdata recipes in `testdata/README.md`

These documentation updates were identified during M28 (Fossil Archive Action) milestone completion validation.