### PR TITLE
docs: improve M30/M32 documentation coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,30 @@ To install on Linux:
   See https://docs.docker.com/engine/install/ for platform-specific installation
 ```
 
+#### Preview Instructions for Other Platforms
+
+Use `--target-family` to see system dependency instructions for a different Linux distribution family:
+
+```bash
+# See Fedora/RHEL instructions while on Ubuntu
+tsuku install docker --target-family rhel
+
+# See Arch Linux instructions
+tsuku install docker --target-family arch
+```
+
+Supported families: `debian`, `rhel`, `arch`, `alpine`, `suse`
+
+#### Query Platform Support
+
+Use `tsuku info` with JSON output to programmatically query which platforms a recipe supports:
+
+```bash
+# Get supported platforms for a recipe
+tsuku info docker --metadata-only --json | jq '.supported_platforms'
+```
+
+Output includes platform objects with `os`, `arch`, and optionally `linux_family` fields.
 
 ### Multi-Version Support
 

--- a/docs/DESIGN-system-dependency-actions.md
+++ b/docs/DESIGN-system-dependency-actions.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented
+Current
 
 ## Implementation Issues
 

--- a/docs/GUIDE-actions-and-primitives.md
+++ b/docs/GUIDE-actions-and-primitives.md
@@ -100,6 +100,22 @@ System dependency primitives generate instructions for platform package managers
 | `require_command` | Verify a command is available after installation |
 | `manual` | Display manual installation instructions |
 
+#### Optional Fields for Package Actions
+
+Package manager actions support these optional fields:
+
+| Field | Description | Example |
+|-------|-------------|---------|
+| `unless_command` | Skip action if command already exists | `unless_command = "docker"` |
+| `fallback` | Message shown if installation fails | `fallback = "Visit https://docs.docker.com/get-docker/"` |
+
+Example with optional fields:
+```toml
+[[steps]]
+action = "apt_install"
+params = { packages = ["docker-ce"], unless_command = "docker", fallback = "For manual installation, visit https://docs.docker.com/engine/install/" }
+```
+
 **Key properties**:
 - Actions with implicit constraints are automatically filtered by platform
 - Instructions are displayed to the user (tsuku does not execute privileged commands)

--- a/docs/GUIDE-system-dependencies.md
+++ b/docs/GUIDE-system-dependencies.md
@@ -113,28 +113,27 @@ Recipes use different action types for different package managers and configurat
 [metadata]
 name = "docker"
 
-# For Ubuntu/Debian
+# For Ubuntu/Debian - apt_repo needs explicit when clause
 [[steps]]
 action = "apt_repo"
 params = { name = "docker", url = "https://download.docker.com/linux/ubuntu", key_url = "https://download.docker.com/linux/ubuntu/gpg" }
 when = { linux_family = "debian" }
 
+# Package manager actions have IMPLICIT platform constraints
+# apt_install automatically applies to debian family - no when clause needed
 [[steps]]
 action = "apt_install"
 params = { packages = ["docker-ce", "docker-ce-cli", "containerd.io"] }
-when = { linux_family = "debian" }
 
-# For Fedora/RHEL
+# dnf_install automatically applies to rhel family - no when clause needed
 [[steps]]
 action = "dnf_install"
 params = { packages = ["docker-ce", "docker-ce-cli", "containerd.io"] }
-when = { linux_family = "rhel" }
 
-# For macOS
+# brew_cask automatically applies to darwin - no when clause needed
 [[steps]]
 action = "brew_cask"
 params = { cask = "docker" }
-when = { platform = "darwin/*" }
 
 # Common configuration
 [[steps]]


### PR DESCRIPTION
## Summary

- Add `--target-family` flag documentation to README's System Dependencies section
- Add `supported_platforms` JSON query example to README
- Document `fallback` and `unless_command` optional fields in GUIDE-actions-and-primitives.md
- Fix recipe examples in GUIDE-system-dependencies.md to show PM actions without explicit `when` clauses (per design decision D6 - implicit constraints)
- Update DESIGN-system-dependency-actions.md status from "Implemented" to "Current"