### PR TITLE
feat(actions): add DMG extraction to app_bundle action

### DIFF
--- a/internal/actions/app_bundle_test.go
+++ b/internal/actions/app_bundle_test.go
@@ -130,3 +130,27 @@ func TestDetectArchiveFormatFromURL(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractDMG_NonMacOS(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("test only runs on non-macOS")
+	}
+
+	// On non-macOS, extractDMG should fail because hdiutil is not available
+	err := extractDMG("/nonexistent.dmg", "/tmp/dest")
+	if err == nil {
+		t.Error("extractDMG should fail on non-macOS")
+	}
+}
+
+func TestExtractDMG_NonExistentFile(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("test only runs on macOS")
+	}
+
+	// Even on macOS, should fail for non-existent file
+	err := extractDMG("/nonexistent/path/to/file.dmg", t.TempDir())
+	if err == nil {
+		t.Error("extractDMG should fail for non-existent file")
+	}
+}


### PR DESCRIPTION
Add DMG disk image extraction capability to the app_bundle action, enabling
installation of macOS applications distributed as disk images. This is the
primary archive format used by most Homebrew Casks (Firefox, Slack, etc.).

---

## What This Accomplishes

Before this change, the app_bundle action only supported ZIP archives. After
this change, it also supports DMG files, which are the most common distribution
format for macOS applications in Homebrew Casks.

## Changes

- **internal/actions/app_bundle.go**:
  - Add `extractDMG()` function using `hdiutil attach/detach`
  - Mount DMG read-only with `-nobrowse` to avoid Finder interference
  - Handle symlinks and nested directories in DMG contents
  - Proper cleanup with `defer` to ensure unmount even on errors
  - Update Execute() to route to extractDMG() or extractZIP() based on format

- **internal/actions/app_bundle_test.go**:
  - Add TestExtractDMG_NonMacOS (verifies graceful failure on Linux)
  - Add TestExtractDMG_NonExistentFile (macOS-only)

## Implementation Details

The DMG extraction follows the design specification:

```go
// Mount read-only without Finder interference
cmd := exec.Command("hdiutil", "attach", dmgPath,
    "-nobrowse", "-readonly", "-mountpoint", mountPoint)

// Ensure cleanup even on errors
defer exec.Command("hdiutil", "detach", mountPoint, "-quiet", "-force").Run()
```

The `-nobrowse` flag prevents Finder from opening the mounted volume, and
`-readonly` ensures we don't accidentally modify the DMG contents.

## Test Plan

- Unit tests pass on Linux (graceful failure when hdiutil not available)
- Integration testing requires macOS CI runner (future work)
- Manual verification: Install a DMG-based cask (Firefox) on macOS

Fixes #864