### PR TITLE
fix(recipe): include cargo actions in ExtractBinaries

### DIFF
--- a/.github/workflows/cargo-builder-tests.yml
+++ b/.github/workflows/cargo-builder-tests.yml
@@ -61,17 +61,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./tsuku install --force hyperfine
 
-      - name: Debug symlinks
-        run: |
-          echo "=== Current directory contents ==="
-          ls -la "$HOME/.tsuku/tools/current/" || echo "Directory doesn't exist"
-          echo ""
-          echo "=== PATH ==="
-          echo "$PATH"
-          echo ""
-          echo "=== which hyperfine ==="
-          which hyperfine || echo "hyperfine not found in PATH"
-
       - name: Verify hyperfine works
         run: hyperfine --version
 
@@ -114,17 +103,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./tsuku install --force hyperfine
-
-      - name: Debug symlinks
-        run: |
-          echo "=== Current directory contents ==="
-          ls -la "$HOME/.tsuku/tools/current/" || echo "Directory doesn't exist"
-          echo ""
-          echo "=== PATH ==="
-          echo "$PATH"
-          echo ""
-          echo "=== which hyperfine ==="
-          which hyperfine || echo "hyperfine not found in PATH"
 
       - name: Verify hyperfine works
         run: hyperfine --version

--- a/internal/recipe/types.go
+++ b/internal/recipe/types.go
@@ -706,6 +706,8 @@ func (r *Recipe) ExtractBinaries() []string {
 			"github_archive":   true,
 			"github_file":      true,
 			"npm_install":      true,
+			"cargo_install":    true, // Uses 'executables' parameter, installs to bin/
+			"cargo_build":      true, // Uses 'executables' parameter, installs to bin/
 			"configure_make":   true, // Uses 'executables' parameter
 			"cmake_build":      true, // Uses 'executables' parameter
 			"meson_build":      true, // Uses 'executables' parameter
@@ -767,12 +769,12 @@ func (r *Recipe) ExtractBinaries() []string {
 			}
 		}
 
-		// Check for 'executables' parameter (used by npm_install)
+		// Check for 'executables' parameter (used by npm_install, cargo_install, cargo_build)
 		if executablesRaw, ok := step.Params["executables"]; ok {
 			if executablesList, ok := executablesRaw.([]interface{}); ok {
 				for _, e := range executablesList {
 					if exeStr, ok := e.(string); ok {
-						// npm_install installs to bin/ directory
+						// These actions install executables to bin/ directory
 						binaryName := filepath.Base(exeStr)
 						destPath := filepath.Join("bin", binaryName)
 						if !seen[binaryName] {


### PR DESCRIPTION
The ExtractBinaries function was missing cargo_install and cargo_build from its installActions map. This caused binaries from cargo actions to not be processed correctly, resulting in symlinks pointing to the wrong location.

When tsuku installs a tool using cargo_build, it puts binaries in `$INSTALL_DIR/bin/<exe>`. However, ExtractBinaries didn't include cargo actions, so the executables list was not transformed to include the `bin/` prefix. This caused symlinks to point to `$TOOLS/hyperfine-1.20.0/hyperfine` instead of `$TOOLS/hyperfine-1.20.0/bin/hyperfine`.

---

## What This Accomplishes

Fixes the Cargo Builder CI tests by ensuring cargo-installed tools are correctly symlinked to `$TSUKU_HOME/tools/current`.

## Changes

- Add `cargo_install` and `cargo_build` to the `installActions` map in `ExtractBinaries`
- Update comments to reflect that the executables handler is used by multiple actions

Fixes #895