### PR TITLE
fix(actions): make ResolvePerl and ResolveCpanm respect TSUKU_HOME

### DIFF
--- a/internal/actions/cpan_install.go
+++ b/internal/actions/cpan_install.go
@@ -151,10 +151,30 @@ func (a *CpanInstallAction) Execute(ctx *ExecutionContext, params map[string]int
 	// Find perl and cpanm from tsuku's tools directory
 	perlPath := ResolvePerl()
 	if perlPath == "" {
+		// Check ExecPaths from dependencies (for golden file execution)
+		for _, p := range ctx.ExecPaths {
+			candidatePath := filepath.Join(p, "perl")
+			if _, err := os.Stat(candidatePath); err == nil {
+				perlPath = candidatePath
+				break
+			}
+		}
+	}
+	if perlPath == "" {
 		return fmt.Errorf("perl not found: install perl first (tsuku install perl)")
 	}
 
 	cpanmPath := ResolveCpanm()
+	if cpanmPath == "" {
+		// Check ExecPaths from dependencies (for golden file execution)
+		for _, p := range ctx.ExecPaths {
+			candidatePath := filepath.Join(p, "cpanm")
+			if _, err := os.Stat(candidatePath); err == nil {
+				cpanmPath = candidatePath
+				break
+			}
+		}
+	}
 	if cpanmPath == "" {
 		return fmt.Errorf("cpanm not found: install perl first (tsuku install perl)")
 	}


### PR DESCRIPTION
Add fallback to search ctx.ExecPaths when ResolvePerl() or ResolveCpanm() returns empty. This provides a defense-in-depth mechanism for finding perl binaries when they're installed as dependencies to a custom TSUKU_HOME.

The pattern follows pip_exec.go and go_build/go_install which already have this fallback.

---

## What This Accomplishes

This complements #901 (which fixed all Resolve* functions to respect TSUKU_HOME) by adding the ExecPaths fallback pattern to cpan_install.go. This matches the approach used in:

- `pip_exec.go` - searches ExecPaths for python3
- `go_build.go` - searches ExecPaths for go (PR #899)
- `go_install.go` - searches ExecPaths for go (PR #899)

The ExecPaths fallback provides an additional safety net: even if TSUKU_HOME isn't set or the resolve function fails for some reason, the action can still find binaries from its declared dependencies.

## Changes

- Add ExecPaths fallback for perl binary in cpan_install.go Execute()
- Add ExecPaths fallback for cpanm binary in cpan_install.go Execute()

Fixes #891