### PR TITLE
fix(actions): search ExecPaths for pipx/python3 in pipx_install

### DIFF
--- a/internal/actions/pipx_install.go
+++ b/internal/actions/pipx_install.go
@@ -93,6 +93,16 @@ func (a *PipxInstallAction) Execute(ctx *ExecutionContext, params map[string]int
 		// Try to resolve pipx from tsuku's tools directory
 		pipxPath = ResolvePipx()
 		if pipxPath == "" {
+			// Check ExecPaths from dependencies (for golden file execution)
+			for _, p := range ctx.ExecPaths {
+				candidatePath := filepath.Join(p, "pipx")
+				if _, err := os.Stat(candidatePath); err == nil {
+					pipxPath = candidatePath
+					break
+				}
+			}
+		}
+		if pipxPath == "" {
 			// Fallback to pipx in PATH
 			pipxPath = "pipx"
 		}
@@ -105,6 +115,16 @@ func (a *PipxInstallAction) Execute(ctx *ExecutionContext, params map[string]int
 		// CRITICAL: Enforce Q2-B decision - always use python-standalone
 		// Look for python-standalone in tsuku's installation
 		pythonPath = ResolvePythonStandalone()
+		if pythonPath == "" {
+			// Check ExecPaths from dependencies (for golden file execution)
+			for _, p := range ctx.ExecPaths {
+				candidatePath := filepath.Join(p, "python3")
+				if _, err := os.Stat(candidatePath); err == nil {
+					pythonPath = candidatePath
+					break
+				}
+			}
+		}
 		if pythonPath != "" {
 			fmt.Printf("   Using python-standalone: %s\n", pythonPath)
 		}


### PR DESCRIPTION
Add fallback to search ctx.ExecPaths when ResolvePipx() or ResolvePythonStandalone() returns empty. This enables pipx_install to find pipx and python binaries installed as dependencies, which is necessary for golden file execution where dependencies are installed to a custom TSUKU_HOME.

The pattern follows pip_exec.go, go_build/go_install, and cpan_install.

---

## What This Accomplishes

This complements #901 (which fixed all Resolve* functions to respect TSUKU_HOME) by adding the ExecPaths fallback pattern to pipx_install.go. This matches the approach used in:

- `pip_exec.go` - searches ExecPaths for python3
- `go_build.go` / `go_install.go` - searches ExecPaths for go (PR #899)
- `cpan_install.go` - searches ExecPaths for perl/cpanm (PR #902)

The ExecPaths fallback provides an additional safety net: even if TSUKU_HOME isn't set or the resolve function fails for some reason, the action can still find binaries from its declared dependencies.

## Changes

- Add ExecPaths fallback for pipx binary in pipx_install.go Execute()
- Add ExecPaths fallback for python3 binary in pipx_install.go Execute()

Fixes #892