### PR TITLE
fix(ci): migrate macOS Intel tests to macos-15-intel runner

### DIFF
--- a/.github/workflows/build-essentials.yml
+++ b/.github/workflows/build-essentials.yml
@@ -440,11 +440,9 @@ jobs:
           echo "All macOS Apple Silicon tests passed"
 
   # Aggregated macOS Intel tests (reduces runner queue pressure)
-  # SKIP: macos-13 runner is deprecated - see #896
   test-macos-intel:
-    if: false
     name: "macOS Intel (x86_64)"
-    runs-on: macos-13
+    runs-on: macos-15-intel
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Migrate the macOS Intel test job from the retired macos-13 runner to
macos-15-intel, which is the recommended replacement for x86_64
architecture tests.

---

## What This Accomplishes

GitHub retired the macos-13 runner (see actions/runner-images#13046). The
test-macos-intel job was disabled with `if: false` pending a fix.

This PR:
- Removes the `if: false` to re-enable the job
- Updates `runs-on` from `macos-13` to `macos-15-intel`
- Removes the SKIP comment referencing this issue

The macos-15-intel runner provides x86_64 architecture and will be
supported until August 2027.

Fixes #896