### PR TITLE
chore(golden): verify perlcritic darwin-arm64 fix

### DIFF
--- a/testdata/golden/plans/p/perlcritic/v1.156-darwin-arm64.json
+++ b/testdata/golden/plans/p/perlcritic/v1.156-darwin-arm64.json
@@ -1,88 +1,88 @@
 {
-  "format_version": 3,
-  "tool": "perlcritic",
-  "version": "1.156",
-  "platform": {
-    "os": "darwin",
-    "arch": "arm64"
-  },
-  "recipe_hash": "3f73b6e9dd4c4cfe12acf2dfdc0896d5af6ef8edb6a7fcc3678d398d628f6cc8",
-  "deterministic": false,
   "dependencies": [
     {
-      "tool": "perl",
-      "version": "5.42.0.0",
       "recipe_hash": "b381fe61e7eab9a1a035e489bca6842940beed278d5da28d3c2e88620a472d5d",
       "steps": [
         {
           "action": "download_file",
+          "checksum": "ec30ef310a5b18015ca0102f15c2e223ef0e3cb224ea27c514a7fab95a4573f1",
+          "deterministic": true,
+          "evaluable": true,
           "params": {
             "checksum": "ec30ef310a5b18015ca0102f15c2e223ef0e3cb224ea27c514a7fab95a4573f1",
             "checksum_algo": "sha256",
             "dest": "perl-darwin-arm64.tar.xz",
             "url": "https://github.com/skaji/relocatable-perl/releases/download/5.42.0.0/perl-darwin-arm64.tar.xz"
           },
-          "evaluable": true,
-          "deterministic": true,
-          "url": "https://github.com/skaji/relocatable-perl/releases/download/5.42.0.0/perl-darwin-arm64.tar.xz",
-          "checksum": "ec30ef310a5b18015ca0102f15c2e223ef0e3cb224ea27c514a7fab95a4573f1",
-          "size": 10832668
+          "size": 10832668,
+          "url": "https://github.com/skaji/relocatable-perl/releases/download/5.42.0.0/perl-darwin-arm64.tar.xz"
         },
         {
           "action": "extract",
+          "deterministic": true,
+          "evaluable": true,
           "params": {
             "archive": "perl-darwin-arm64.tar.xz",
             "format": "tar.xz",
             "strip_dirs": 1
-          },
-          "evaluable": true,
-          "deterministic": true
+          }
         },
         {
           "action": "chmod",
+          "deterministic": true,
+          "evaluable": true,
           "params": {
             "files": [
               "bin/perl",
               "bin/cpanm"
             ]
-          },
-          "evaluable": true,
-          "deterministic": true
+          }
         },
         {
           "action": "install_binaries",
+          "deterministic": true,
+          "evaluable": true,
           "params": {
             "binaries": [
               "bin/perl",
               "bin/cpanm"
             ],
             "install_mode": "directory"
-          },
-          "evaluable": true,
-          "deterministic": true
+          }
         }
       ],
+      "tool": "perl",
       "verify": {
         "command": "{install_dir}/bin/perl -v",
         "pattern": "{version}"
-      }
+      },
+      "version": "5.42.0.0"
     }
   ],
+  "deterministic": false,
+  "format_version": 3,
+  "platform": {
+    "arch": "arm64",
+    "os": "darwin"
+  },
+  "recipe_hash": "3f73b6e9dd4c4cfe12acf2dfdc0896d5af6ef8edb6a7fcc3678d398d628f6cc8",
   "steps": [
     {
       "action": "cpan_install",
+      "deterministic": false,
+      "evaluable": false,
       "params": {
         "distribution": "Perl-Critic",
         "executables": [
           "perlcritic"
         ]
-      },
-      "evaluable": false,
-      "deterministic": false
+      }
     }
   ],
+  "tool": "perlcritic",
   "verify": {
     "command": "perlcritic --version",
     "pattern": "{version}"
-  }
+  },
+  "version": "1.156"
 }


### PR DESCRIPTION
Normalize JSON key ordering in perlcritic darwin-arm64 golden file to trigger
the validate-golden-execution CI workflow. This verifies that the ExecPaths
fallback fix from PR #902 works correctly.

---

## What This Accomplishes

This PR verifies that issue #890 (perlcritic darwin-arm64) is fixed by
triggering the golden file execution CI.

## CI Results

The perlcritic test passes:
- Perl dependency installed correctly to custom TSUKU_HOME
- `cpan_install` found perl via ExecPaths fallback
- perlcritic installed successfully

## Note on dlv (#889)

During testing, I discovered that issue #889 (dlv) is a **different problem**:
- The Go binary was found correctly via ExecPaths (the fix works)
- The failure is a compilation error: dlv v1.3.0 doesn't support darwin-arm64
- This is a recipe version issue, not an ExecPaths issue

I've updated issue #889 with these findings.

Fixes #890