### PR TITLE
docs(design): finalize version sorting design as current

### DIFF
--- a/docs/designs/current/DESIGN-version-sorting.md
+++ b/docs/designs/current/DESIGN-version-sorting.md
@@ -1,6 +1,6 @@
 # DESIGN: Consistent Version Sorting
 
-**Status:** Proposed
+**Status:** Current
 
 ## Context and Problem Statement
 


### PR DESCRIPTION
Update status of version sorting design from Proposed to Current and move to current/ folder.

---

## What This Accomplishes

Finalizes DESIGN-version-sorting.md as a completed design:
- Updates status from "Proposed" to "Current"
- Moves from `docs/designs/` to `docs/designs/current/`

The implementation (unified version sorting algorithm, semver/calver handling, prerelease policy) was merged in #917.