### PR TITLE
docs(design): finalize libtool zig-cc design as current

### DIFF
--- a/docs/designs/current/DESIGN-libtool-zig-cc.md
+++ b/docs/designs/current/DESIGN-libtool-zig-cc.md
@@ -1,6 +1,6 @@
 # DESIGN: Libtool Compatibility with Zig CC
 
-**Status:** Accepted
+**Status:** Current
 
 **Upstream Tracking:** [ziglang/zig#17273](https://github.com/ziglang/zig/issues/17273) - When this is resolved, we can remove our wrapper workaround.
 


### PR DESCRIPTION
The libtool compatibility implementation (-print-prog-name workaround) was delivered in the same PR as the design. Update status from Accepted to Current and move to current/ folder.

---

## What This Accomplishes

Finalizes DESIGN-libtool-zig-cc.md as a completed design:
- Updates status from "Accepted" to "Current"
- Moves from `docs/designs/` to `docs/designs/current/`

## Implementation Verification

The design has been fully implemented:

1. **-print-prog-name handling** in `internal/actions/util.go:540-575`:
   - cc wrapper handles `-print-prog-name=ld`, `ar`, `ranlib`
   - c++ wrapper has matching handling

2. **No-GCC Container test** re-enabled in `.github/workflows/build-essentials.yml`:
   - `test-no-gcc` job validates zig cc fallback with libtool
   - Tests gdbm-source build in container without system gcc