### PR TITLE
chore: move header validation design to current

### DIFF
--- a/docs/designs/current/DESIGN-library-verify-header.md
+++ b/docs/designs/current/DESIGN-library-verify-header.md
@@ -1,6 +1,6 @@
 # DESIGN: Library Verification Header Validation (Tier 1)
 
-**Status:** Accepted
+**Status:** Current
 
 ## Upstream Design Reference
 


### PR DESCRIPTION
## Summary

- Update status from Accepted to Current
- Move design doc to `docs/designs/current/`

This was missed when PR #962 was merged for issue #947.