### PR TITLE
docs: move constrained evaluation design to current

### DIFF
--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -57,6 +57,7 @@ These designs are implemented and represent the current system architecture.
 |--------|-------------|
 | [DESIGN-golden-plan-testing.md](current/DESIGN-golden-plan-testing.md) | CI-driven regression testing for recipe plans |
 | [DESIGN-hardcoded-version-detection.md](current/DESIGN-hardcoded-version-detection.md) | Recipe validation for version templating |
+| [DESIGN-non-deterministic-validation.md](current/DESIGN-non-deterministic-validation.md) | Constrained evaluation for ecosystem recipe validation |
 | [DESIGN-version-verification.md](current/DESIGN-version-verification.md) | Version format transforms and verification modes |
 
 ### Ecosystem Support

--- a/docs/designs/current/DESIGN-non-deterministic-validation.md
+++ b/docs/designs/current/DESIGN-non-deterministic-validation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Planned
+Current
 
 ## Implementation Issues
 
@@ -54,16 +54,11 @@ graph TD
     I928 --> I929
 
     classDef done fill:#c8e6c9
-    classDef ready fill:#bbdefb
-    classDef blocked fill:#fff9c4
-    classDef needsDesign fill:#e1bee7
 
-    class I921 done
-    class I922,I923,I924,I925,I926 ready
-    class I927,I928,I929 blocked
+    class I921,I922,I923,I924,I925,I926,I927,I928,I929 done
 ```
 
-**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design
+**Legend**: Green = done
 
 ## Context and Problem Statement
 


### PR DESCRIPTION
Move DESIGN-non-deterministic-validation.md to docs/designs/current/ and update status from Planned to Current now that all milestone issues are complete. Update the mermaid diagram to show all issues as done and add entry to the Golden Files & Validation section in README.md.

---

## What This Accomplishes

Completes Milestone 35 (Constrained Golden File Validation) by finalizing the documentation:

- Moves the design document to `current/` to reflect implementation completion
- Updates status from "Planned" to "Current"
- Updates the implementation issues diagram to show all issues as completed
- Adds the design to the README index under Golden Files & Validation

Fixes #929