### PR TITLE
feat(install): extract and store sonames during library installation

### DIFF
--- a/docs/designs/DESIGN-library-verify-deps.md
+++ b/docs/designs/DESIGN-library-verify-deps.md
@@ -66,8 +66,8 @@ graph TD
     classDef blocked fill:#fff9c4
     classDef needsDesign fill:#e1bee7
 
-    class I978,I979,I980,I981,I983,I984,I986 done
-    class I982,I985 ready
+    class I978,I979,I980,I981,I983,I984,I985,I986 done
+    class I982 ready
     class I989,I990,I991 blocked
 ```
 


### PR DESCRIPTION
After library files are copied and checksums computed, call verify.ExtractSonames() on the library directory and store discovered sonames in state.json via the UpdateLibrary callback. This completes the soname auto-discovery pipeline from Track A of the Tier 2 dependency validation milestone.

The stored sonames will be consumed by #986 (SonameIndex) when building the reverse lookup index for dependency validation.

---

Fixes #985

### What This Accomplishes

- Connects the extraction logic (#983) to state storage (#978)
- Enables downstream dependency validation to map DT_NEEDED entries back to installed recipes
- Modified ExtractSonames to walk recursively, matching the checksum computation pattern

### Test Plan

- Unit test with real ELF binary (copies system libc.so.6) verifies sonames are stored in state
- Unit test with non-binary .so files verifies graceful handling
- Existing library installation tests continue to pass