### PR TITLE
docs(design): move toolchain-dependency-pinning to Current status

### DIFF
--- a/docs/designs/current/DESIGN-toolchain-dependency-pinning.md
+++ b/docs/designs/current/DESIGN-toolchain-dependency-pinning.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Current
 
 ## Upstream Design Reference
 


### PR DESCRIPTION
Move DESIGN-toolchain-dependency-pinning.md from `docs/designs/` to
`docs/designs/current/` and update status from "Accepted" to "Current".

This design was fully implemented in PR #960 (feat(eval): add toolchain
dependency pinning for constrained evaluation). The implementation includes:
- `DependencyVersions` field in `EvalConstraints`
- `extractDependencyVersions()` in constraints.go
- Comprehensive test coverage in constraints_test.go

No associated GitHub issue - direct fix.