### PR TITLE
chore: remove stale dlv exclusion from golden tests

### DIFF
--- a/testdata/golden/exclusions.json
+++ b/testdata/golden/exclusions.json
@@ -195,12 +195,6 @@
       "reason": "configure auto-detects homebrew nghttp2/libidn2 but linker cannot find them"
     },
     {
-      "recipe": "dlv",
-      "platform": {"os": "linux", "arch": "amd64"},
-      "issue": "https://github.com/tsukumogami/tsuku/issues/964",
-      "reason": "go_install toolchain version drift (golden file references Go version not available in CI)"
-    },
-    {
       "recipe": "proj",
       "platform": {"os": "linux", "arch": "amd64"},
       "issue": "https://github.com/tsukumogami/tsuku/issues/931",


### PR DESCRIPTION
Remove the dlv (linux-amd64) exclusion from golden test exclusions since issue #964 is now closed.