### PR TITLE
test(verify): add Tier 2 dependency validation integration tests

### DIFF
--- a/docs/designs/DESIGN-library-verify-deps.md
+++ b/docs/designs/DESIGN-library-verify-deps.md
@@ -66,8 +66,7 @@ graph TD
     classDef blocked fill:#fff9c4
     classDef needsDesign fill:#e1bee7
 
-    class I978,I979,I980,I981,I982,I983,I984,I985,I986,I989,I990 done
-    class I991 ready
+    class I978,I979,I980,I981,I982,I983,I984,I985,I986,I989,I990,I991 done
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design

--- a/internal/verify/deps_test.go
+++ b/internal/verify/deps_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/tsukumogami/tsuku/internal/install"
+	"github.com/tsukumogami/tsuku/internal/recipe"
 )
 
 func TestValidateDependencies_StaticBinary(t *testing.T) {
@@ -339,6 +340,63 @@ func TestMaxTransitiveDepth(t *testing.T) {
 	}
 }
 
+// =============================================================================
+// Mock types for integration tests
+// =============================================================================
+
+// mockRecipeLoader implements RecipeLoader for testing externally-managed scenarios.
+type mockRecipeLoader struct {
+	recipes map[string]*recipe.Recipe
+}
+
+func newMockRecipeLoader() *mockRecipeLoader {
+	return &mockRecipeLoader{
+		recipes: make(map[string]*recipe.Recipe),
+	}
+}
+
+func (m *mockRecipeLoader) LoadRecipe(name string) (*recipe.Recipe, error) {
+	if r, ok := m.recipes[name]; ok {
+		return r, nil
+	}
+	return nil, nil
+}
+
+func (m *mockRecipeLoader) addExternallyManagedRecipe(name string) {
+	m.recipes[name] = &recipe.Recipe{
+		Steps: []recipe.Step{
+			{Action: "apt_install", Params: map[string]interface{}{"packages": []string{name}}},
+		},
+	}
+}
+
+// mockExternalAction implements recipe.SystemActionChecker with IsExternallyManaged() == true.
+type mockExternalAction struct{}
+
+func (m mockExternalAction) IsExternallyManaged() bool { return true }
+
+// mockNonExternalAction implements recipe.SystemActionChecker with IsExternallyManaged() == false.
+type mockNonExternalAction struct{}
+
+func (m mockNonExternalAction) IsExternallyManaged() bool { return false }
+
+// mockDownloadAction represents a non-system action (like download, extract).
+type mockDownloadAction struct{}
+
+// mockActionLookup returns mock actions based on action names.
+func mockActionLookup(name string) interface{} {
+	switch name {
+	case "apt_install", "brew_install", "dnf_install":
+		return mockExternalAction{}
+	case "manual", "require_command":
+		return mockNonExternalAction{}
+	case "download", "extract":
+		return mockDownloadAction{}
+	default:
+		return nil
+	}
+}
+
 func TestValidateSingleDependency_SystemLib(t *testing.T) {
 	tmpDir := t.TempDir()
 	binaryPath := filepath.Join(tmpDir, "bin", "myapp")
@@ -441,5 +499,415 @@ func TestValidateSingleDependency_TsukuManaged(t *testing.T) {
 	}
 	if result.Version != "3.2.1" {
 		t.Errorf("expected version 3.2.1, got %q", result.Version)
+	}
+}
+
+// =============================================================================
+// Integration Tests - Scenario-based tests per issue #991
+// =============================================================================
+
+// TestValidateDependencies_Integration_SystemDepsOnly verifies scenario 3:
+// A binary that depends only on system libraries (libc, libm, etc.) should pass.
+func TestValidateDependencies_Integration_SystemDepsOnly(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Integration test requires Linux")
+	}
+
+	// Find a real system binary that depends only on system libs
+	// /bin/true is typically a simple binary with only libc dependency
+	candidates := []string{
+		"/bin/true",
+		"/bin/false",
+		"/usr/bin/true",
+		"/usr/bin/false",
+	}
+
+	var binaryPath string
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			binaryPath = c
+			break
+		}
+	}
+
+	if binaryPath == "" {
+		t.Skip("No suitable system binary found for testing")
+	}
+
+	tmpDir := t.TempDir()
+	state := &install.State{
+		Libs: make(map[string]map[string]install.LibraryVersionState),
+	}
+
+	results, err := ValidateDependencies(
+		binaryPath,
+		state,
+		nil, // no recipe loader
+		nil, // no action lookup
+		make(map[string]bool),
+		true, // recurse
+		runtime.GOOS,
+		runtime.GOARCH,
+		tmpDir,
+	)
+
+	if err != nil {
+		t.Fatalf("ValidateDependencies failed: %v", err)
+	}
+
+	// Check that all dependencies are system libraries
+	for _, r := range results {
+		if r.Category != DepPureSystem {
+			t.Errorf("expected all deps to be DepPureSystem, got %v for %s", r.Category, r.Soname)
+		}
+		if r.Status != ValidationPass {
+			t.Errorf("expected all deps to pass, got %v for %s: %s", r.Status, r.Soname, r.Error)
+		}
+	}
+}
+
+// TestValidateDependencies_Integration_TsukuManagedDeps verifies scenario 2:
+// A binary with tsuku-managed dependencies should validate them recursively.
+func TestValidateDependencies_Integration_TsukuManagedDeps(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create state with openssl as a tsuku-managed library
+	state := &install.State{
+		Libs: map[string]map[string]install.LibraryVersionState{
+			"openssl": {
+				"3.2.1": {
+					UsedBy:  []string{"ruby-3.4.0"},
+					Sonames: []string{"libssl.so.3", "libcrypto.so.3"},
+				},
+			},
+		},
+	}
+
+	// Build index from state
+	index := BuildSonameIndex(state)
+
+	// Validate a dependency that's in our index
+	result := validateSingleDependency(
+		"libssl.so.3",
+		filepath.Join(tmpDir, "bin", "ruby"),
+		nil,
+		tmpDir,
+		state,
+		index,
+		nil, nil,
+		make(map[string]bool),
+		false, // no deep recursion for this test
+		"linux", "amd64", tmpDir,
+	)
+
+	if result.Category != DepTsukuManaged {
+		t.Errorf("expected DepTsukuManaged, got %v", result.Category)
+	}
+	if result.Recipe != "openssl" {
+		t.Errorf("expected recipe openssl, got %q", result.Recipe)
+	}
+	if result.Version != "3.2.1" {
+		t.Errorf("expected version 3.2.1, got %q", result.Version)
+	}
+	if result.Status != ValidationPass {
+		t.Errorf("expected ValidationPass, got %v: %s", result.Status, result.Error)
+	}
+}
+
+// TestValidateDependencies_Integration_MissingDependency verifies scenario 4:
+// A dependency that can't be classified should result in ValidationFail with DepUnknown.
+func TestValidateDependencies_Integration_MissingDependency(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	state := &install.State{
+		Libs: make(map[string]map[string]install.LibraryVersionState),
+	}
+
+	index := NewSonameIndex()
+
+	// Validate a dependency that's not in the index and not a system library
+	result := validateSingleDependency(
+		"libnonexistent.so.1",
+		filepath.Join(tmpDir, "bin", "myapp"),
+		nil,
+		tmpDir,
+		state,
+		index,
+		nil, nil,
+		make(map[string]bool),
+		false,
+		"linux", "amd64", tmpDir,
+	)
+
+	if result.Category != DepUnknown {
+		t.Errorf("expected DepUnknown, got %v", result.Category)
+	}
+	if result.Status != ValidationFail {
+		t.Errorf("expected ValidationFail, got %v", result.Status)
+	}
+	if result.Error == "" {
+		t.Error("expected error message for missing dependency")
+	}
+}
+
+// TestValidateDependencies_Integration_ExternallyManaged verifies scenario 7:
+// A tsuku recipe that delegates to system package manager should be classified
+// as EXTERNALLY_MANAGED and not recursed into.
+func TestValidateDependencies_Integration_ExternallyManaged(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create state with openssl as a library with sonames
+	state := &install.State{
+		Libs: map[string]map[string]install.LibraryVersionState{
+			"openssl": {
+				"3.2.1": {
+					UsedBy:  []string{"ruby-3.4.0"},
+					Sonames: []string{"libssl.so.3", "libcrypto.so.3"},
+				},
+			},
+		},
+	}
+
+	// Create mock recipe loader that returns an externally-managed recipe
+	loader := newMockRecipeLoader()
+	loader.addExternallyManagedRecipe("openssl")
+
+	// Build index from state
+	index := BuildSonameIndex(state)
+
+	// Validate libssl.so.3 which is in openssl recipe
+	result := validateSingleDependency(
+		"libssl.so.3",
+		filepath.Join(tmpDir, "bin", "ruby"),
+		nil,
+		tmpDir,
+		state,
+		index,
+		loader,
+		mockActionLookup,
+		make(map[string]bool),
+		true, // recurse would happen, but externally-managed shouldn't recurse
+		"linux", "amd64", tmpDir,
+	)
+
+	// Should be classified as EXTERNALLY_MANAGED (refined from TSUKU_MANAGED)
+	if result.Category != DepExternallyManaged {
+		t.Errorf("expected DepExternallyManaged, got %v", result.Category)
+	}
+	if result.Status != ValidationPass {
+		t.Errorf("expected ValidationPass, got %v: %s", result.Status, result.Error)
+	}
+	// Should NOT have transitive deps (no recursion for externally-managed)
+	if len(result.Transitive) > 0 {
+		t.Errorf("expected no transitive deps for externally-managed, got %d", len(result.Transitive))
+	}
+}
+
+// TestValidateDependencies_Integration_CycleWithTransitive tests that cycles are
+// properly detected during recursive validation.
+func TestValidateDependencies_Integration_CycleWithTransitive(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Simulate circular dependency: libssl depends on libcrypto, libcrypto depends on libssl
+	// In practice, this scenario tests the visited map handling
+
+	state := &install.State{
+		Libs: map[string]map[string]install.LibraryVersionState{
+			"openssl": {
+				"3.2.1": {
+					UsedBy:  []string{"ruby-3.4.0"},
+					Sonames: []string{"libssl.so.3", "libcrypto.so.3"},
+				},
+			},
+		},
+	}
+
+	// Pre-populate visited to simulate already having seen a library
+	visited := map[string]bool{
+		"/fake/path/libssl.so.3": true,
+	}
+
+	// Try to validate the same path - should return nil (already visited)
+	results, err := ValidateDependencies(
+		"/fake/path/libssl.so.3",
+		state,
+		nil, nil,
+		visited,
+		true,
+		"linux", "amd64",
+		tmpDir,
+	)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if results != nil {
+		t.Errorf("expected nil for already-visited, got %d results", len(results))
+	}
+}
+
+// TestValidateDependencies_Integration_ABIMismatch verifies scenario 5:
+// A binary with musl interpreter on glibc system should fail ABI validation.
+// Note: This test only verifies the error category constant is correct,
+// as creating a musl binary for testing requires special build environment.
+func TestValidateDependencies_Integration_ABIMismatch(t *testing.T) {
+	// Verify ErrABIMismatch has correct value per design decision #2
+	if ErrABIMismatch != 10 {
+		t.Errorf("ErrABIMismatch = %d, want 10", ErrABIMismatch)
+	}
+
+	// Verify error formatting
+	err := &ValidationError{
+		Category: ErrABIMismatch,
+		Path:     "/path/to/binary",
+		Message:  `interpreter "/lib/ld-musl-x86_64.so.1" not found (binary may be built for different libc)`,
+	}
+
+	if err.Category != ErrABIMismatch {
+		t.Errorf("expected ErrABIMismatch category")
+	}
+	if err.Error() == "" {
+		t.Error("expected non-empty error message")
+	}
+}
+
+// TestValidateDependencies_Integration_RealBinary_SystemLibs tests validation
+// against a real system binary to ensure end-to-end flow works.
+func TestValidateDependencies_Integration_RealBinary_SystemLibs(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("Integration test requires Linux")
+	}
+
+	// Find a dynamically linked binary
+	candidates := []string{
+		"/bin/ls",
+		"/bin/cat",
+		"/usr/bin/ls",
+		"/usr/bin/cat",
+	}
+
+	var binaryPath string
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			binaryPath = c
+			break
+		}
+	}
+
+	if binaryPath == "" {
+		t.Skip("No suitable dynamic binary found for testing")
+	}
+
+	tmpDir := t.TempDir()
+	state := &install.State{
+		Libs: make(map[string]map[string]install.LibraryVersionState),
+	}
+
+	results, err := ValidateDependenciesSimple(binaryPath, state, tmpDir)
+
+	if err != nil {
+		t.Fatalf("ValidateDependenciesSimple failed: %v", err)
+	}
+
+	// Dynamic binary should have at least libc as a dependency
+	if len(results) == 0 {
+		// Might be statically linked - that's okay too
+		t.Log("Binary appears to be statically linked (no dependencies)")
+		return
+	}
+
+	// All system-binary deps should be classified as system libs
+	hasLibc := false
+	for _, r := range results {
+		if r.Category != DepPureSystem {
+			t.Errorf("expected system binary dep to be DepPureSystem, got %v for %s", r.Category, r.Soname)
+		}
+		if r.Status != ValidationPass {
+			t.Errorf("expected system dep to pass, got %v for %s: %s", r.Status, r.Soname, r.Error)
+		}
+		if r.Soname == "libc.so.6" {
+			hasLibc = true
+		}
+	}
+
+	if len(results) > 0 && !hasLibc {
+		t.Logf("Binary has %d deps but no libc.so.6 (may use different naming)", len(results))
+	}
+}
+
+// TestValidateDependencies_Integration_NonRecursive verifies that when recurse=false,
+// transitive dependencies are not validated.
+func TestValidateDependencies_Integration_NonRecursive(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	state := &install.State{
+		Libs: map[string]map[string]install.LibraryVersionState{
+			"openssl": {
+				"3.2.1": {
+					UsedBy:  []string{"ruby-3.4.0"},
+					Sonames: []string{"libssl.so.3"},
+				},
+			},
+		},
+	}
+
+	index := BuildSonameIndex(state)
+
+	// Validate with recurse=false
+	result := validateSingleDependency(
+		"libssl.so.3",
+		filepath.Join(tmpDir, "bin", "ruby"),
+		nil,
+		tmpDir,
+		state,
+		index,
+		nil, nil,
+		make(map[string]bool),
+		false, // no recursion
+		"linux", "amd64", tmpDir,
+	)
+
+	if result.Category != DepTsukuManaged {
+		t.Errorf("expected DepTsukuManaged, got %v", result.Category)
+	}
+	// No transitive results when recurse=false
+	if len(result.Transitive) > 0 {
+		t.Errorf("expected no transitive deps with recurse=false, got %d", len(result.Transitive))
+	}
+}
+
+// TestValidateDependencies_Integration_PathVariables tests that path variables
+// like $ORIGIN are handled correctly in dependency paths.
+func TestValidateDependencies_Integration_PathVariables(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	state := &install.State{
+		Libs: make(map[string]map[string]install.LibraryVersionState),
+	}
+
+	index := NewSonameIndex()
+
+	// Test with $ORIGIN variable - should be recognized as system pattern
+	// (path variables are treated as system patterns per classify_test.go)
+	result := validateSingleDependency(
+		"$ORIGIN/../lib/libfoo.so",
+		filepath.Join(tmpDir, "bin", "myapp"),
+		nil,
+		filepath.Join(tmpDir, "tools"),
+		state,
+		index,
+		nil, nil,
+		make(map[string]bool),
+		false,
+		"linux", "amd64", tmpDir,
+	)
+
+	// Path variables that can't be expanded should fail
+	// (the expand function will fail when path doesn't resolve to allowed prefix)
+	if result.Status == ValidationPass {
+		// If it passed, verify it was recognized as a system pattern
+		if result.Category != DepPureSystem {
+			t.Errorf("expected DepPureSystem for path variable, got %v", result.Category)
+		}
 	}
 }

--- a/internal/verify/system_libs.go
+++ b/internal/verify/system_libs.go
@@ -26,10 +26,10 @@ type SystemLibraryRegistry struct {
 	pathVariablePrefixes []string
 }
 
-// DefaultRegistry is the default system library registry with 47 patterns
+// DefaultRegistry is the default system library registry with 54 patterns
 // covering Linux and macOS system libraries.
 var DefaultRegistry = &SystemLibraryRegistry{
-	// Linux soname patterns (18 patterns)
+	// Linux soname patterns (25 patterns)
 	// These match libraries that are part of the base Linux system.
 	linuxSonamePatterns: []string{
 		// Virtual dynamic shared objects (kernel-provided, no files on disk)
@@ -59,6 +59,15 @@ var DefaultRegistry = &SystemLibraryRegistry{
 		"libstdc++.so", // C++ standard library (GNU implementation)
 		"libatomic.so", // Atomic operations library (for architectures without native support)
 		"libgomp.so",   // OpenMP runtime library
+
+		// Security and policy libraries (commonly used by coreutils)
+		"libselinux.so", // SELinux library (used by ls, cat, etc. on SELinux-enabled systems)
+		"libpcre2-8.so", // PCRE2 library (used by libselinux and grep)
+		"libacl.so",     // POSIX ACL library (used by ls, cp, etc.)
+		"libattr.so",    // Extended attributes library
+		"libcap.so",     // POSIX capabilities library
+		"libcap-ng.so",  // Capabilities library (alternate implementation)
+		"libaudit.so",   // Linux Audit library
 	},
 
 	// macOS library patterns (10 patterns)

--- a/internal/verify/system_libs_test.go
+++ b/internal/verify/system_libs_test.go
@@ -263,7 +263,7 @@ func TestDefaultRegistry_PatternCount(t *testing.T) {
 	// Verify the pattern counts match what the design specifies
 	t.Run("linux soname patterns", func(t *testing.T) {
 		got := len(DefaultRegistry.linuxSonamePatterns)
-		want := 18
+		want := 25
 		if got != want {
 			t.Errorf("len(linuxSonamePatterns) = %d, want %d", got, want)
 		}
@@ -307,7 +307,7 @@ func TestDefaultRegistry_PatternCount(t *testing.T) {
 			len(DefaultRegistry.linuxPathPatterns) +
 			len(DefaultRegistry.darwinPathPatterns) +
 			len(DefaultRegistry.pathVariablePrefixes)
-		want := 47
+		want := 54
 		if total != want {
 			t.Errorf("total patterns = %d, want %d", total, want)
 		}


### PR DESCRIPTION
Add integration tests for dependency validation, covering the core scenarios needed to ensure the dependency validation pipeline works correctly end-to-end.

The tests exercise the complete validation flow from `ValidateDependencies()` using both mocked state and real system binaries.

---

## What This Accomplishes

Nine integration tests covering the full validation pipeline:
- System-only deps on real binaries (/bin/true, /bin/ls)
- Tsuku-managed dependency classification and validation
- Missing dependency detection (DepUnknown -> ValidationFail)
- Externally-managed recipe handling (no recursion)
- Cycle detection via visited map
- ABI mismatch error formatting
- Non-recursive validation mode
- Path variable handling

Discovered and fixed missing system library patterns:
- libselinux.so (SELinux, used by coreutils)
- libpcre2-8.so (used by libselinux, grep)
- libacl.so, libattr.so (extended attributes)
- libcap.so, libcap-ng.so, libaudit.so (capabilities)

## Test Plan

- All new tests pass locally
- Full test suite passes including lint
- Linux-specific tests properly skip on other platforms

Fixes #991