### PR TITLE
docs(design): replace closed #1020 with milestone 43 reference

### DIFF
--- a/docs/designs/DESIGN-library-verify-dlopen.md
+++ b/docs/designs/DESIGN-library-verify-dlopen.md
@@ -21,7 +21,7 @@ rationale: Rust provides memory-safe dlopen bindings, simpler cross-compilation 
 | [#1017](https://github.com/tsukumogami/tsuku/issues/1017) | feat(verify): add environment sanitization and path validation | [#1014](https://github.com/tsukumogami/tsuku/issues/1014) | critical |
 | [#1018](https://github.com/tsukumogami/tsuku/issues/1018) | feat(verify): add --skip-dlopen flag and fallback behavior | [#1014](https://github.com/tsukumogami/tsuku/issues/1014), [#1016](https://github.com/tsukumogami/tsuku/issues/1016), [#1017](https://github.com/tsukumogami/tsuku/issues/1017) | testable |
 | [#1019](https://github.com/tsukumogami/tsuku/issues/1019) | test(verify): add integration tests for dlopen verification | [#1014](https://github.com/tsukumogami/tsuku/issues/1014), [#1015](https://github.com/tsukumogami/tsuku/issues/1015), [#1016](https://github.com/tsukumogami/tsuku/issues/1016), [#1017](https://github.com/tsukumogami/tsuku/issues/1017), [#1018](https://github.com/tsukumogami/tsuku/issues/1018) | testable |
-| [#1020](https://github.com/tsukumogami/tsuku/issues/1020) | docs: design native binary release workflow | None | simple |
+| [Native Binary Release Workflow](https://github.com/tsukumogami/tsuku/milestone/43) | Design and implement native binary release process | None | milestone |
 
 ### Dependency Graph
 
@@ -29,7 +29,7 @@ rationale: Rust provides memory-safe dlopen bindings, simpler cross-compilation 
 graph TD
     subgraph Foundation["Foundation"]
         I1014["#1014: Minimal dlopen skeleton"]
-        I1020["#1020: Release workflow design"]
+        NBRW["Native Binary Release Workflow"]
     end
 
     subgraph Refinements["Refinements"]
@@ -60,7 +60,7 @@ graph TD
     classDef needsDesign fill:#e1bee7
 
     class I1014 ready
-    class I1020 needsDesign
+    class NBRW ready
     class I1015,I1016,I1017,I1018,I1019 blocked
 ```
 


### PR DESCRIPTION
Update DESIGN-library-verify-dlopen.md to reference the open "Native Binary
Release Workflow" milestone instead of closed issue #1020. The issue resulted
in DESIGN-release-workflow-native.md which spawned milestone 43.

---

No issue for this change - trivial documentation update.