### PR TITLE
fix(release): restore goreleaser default artifact naming

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -23,7 +23,6 @@ builds:
 
 archives:
   - format: binary
-    name_template: "{{ .Binary }}"
 
 checksum:
   name_template: checksums.txt


### PR DESCRIPTION
Remove `name_template` override that broke install script