### PR TITLE
fix(install): configure both .bashrc and .bash_profile for bash users

### DIFF
--- a/website/install.sh
+++ b/website/install.sh
@@ -136,7 +136,6 @@ fi
 if [ "$MODIFY_PATH" = true ]; then
     # Determine shell config file based on $SHELL
     SHELL_NAME=$(basename "$SHELL")
-    SHELL_CONFIG=""
 
     # Helper function to add source line to a config file (idempotent)
     add_to_config() {


### PR DESCRIPTION
On Linux, most terminal emulators start interactive non-login shells, which source `.bashrc` but not `.bash_profile`. The install script only modified `.bash_profile`, so new terminals didn't have tsuku in PATH.

For bash users, we now add the source line to both `.bashrc` (for interactive non-login shells) and `.bash_profile` or `.profile` (for login shells). This matches rustup's approach.

---

Fixes the install script for Linux + bash users where new terminals didn't pick up PATH changes.

| Platform | Shell | Before | After |
|----------|-------|--------|-------|
| Linux | bash | broken | works |
| Linux | zsh | works | works |
| macOS | bash | works | works |
| macOS | zsh | works | works |