### PR TITLE
docs(milestone): complete M44 - Embedded Recipe List Validation

### DIFF
--- a/docs/designs/DESIGN-recipe-registry-separation.md
+++ b/docs/designs/DESIGN-recipe-registry-separation.md
@@ -80,8 +80,9 @@ graph TD
     classDef blocked fill:#fff9c4
     classDef needsDesign fill:#e1bee7
 
-    class ERLV ready
-    class I1033,I1034,I1035,I1036,I1038 blocked
+    class ERLV done
+    class I1033 ready
+    class I1034,I1035,I1036,I1038 blocked
     class I1037 needsDesign
     class I1039 needsDesign
 ```

--- a/docs/designs/current/DESIGN-embedded-recipe-list.md
+++ b/docs/designs/current/DESIGN-embedded-recipe-list.md
@@ -1,5 +1,5 @@
 ---
-status: Planned
+status: Current
 problem: The recipe registry separation design requires a validated embedded recipe list, but there's no runtime enforcement that action dependencies can actually be resolved from embedded recipes.
 decision: Add a --require-embedded flag to the loader that fails if action dependencies can't be resolved from the embedded registry. Use CI with this flag to iteratively discover and validate the embedded recipe list.
 rationale: Runtime validation is the ground truth - it uses the actual loader to verify embedded recipes work. This enables incremental migration with an exclusions file to track known gaps, rather than building a separate static analysis tool.


### PR DESCRIPTION
Milestone M44 (Embedded Recipe List Validation) is now complete. This PR updates design documents to reflect the completion: the tactical design moves to the current/ directory with status updated to Current, and the parent strategic design's dependency graph shows M44 as done with its dependent issue (#1033) now unblocked.

---

## Summary

| Change | Details |
|--------|---------|
| Design doc status | Planned → Current |
| Design doc location | `docs/designs/` → `docs/designs/current/` |
| Dependency graph | ERLV=done, #1033=ready |