### PR TITLE
chore(ci): update design doc validation

### DIFF
--- a/.github/scripts/checks/frontmatter.sh
+++ b/.github/scripts/checks/frontmatter.sh
@@ -2,12 +2,10 @@
 #
 # frontmatter.sh - Validate design document frontmatter
 #
-# This is a stub implementation for the modular check framework skeleton.
-# It validates basic frontmatter presence. Full FM01-FM03 rules are
-# implemented in issue #380.
-#
-# Current checks:
-#   - Frontmatter exists (--- delimiters present)
+# Implements frontmatter validation rules from DESIGN-enhanced-validation-rules.md:
+#   FM01: All 4 required fields present (status, problem, decision, rationale)
+#   FM02: Status is valid value (Proposed, Accepted, Planned, Current, Superseded)
+#   FM03: Frontmatter status matches body status section
 #
 # Usage:
 #   frontmatter.sh <doc-path>
@@ -21,6 +19,10 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
+
+# Constants
+readonly REQUIRED_FIELDS=(status problem decision rationale)
+readonly VALID_STATUSES=(Proposed Accepted Planned Current Superseded)
 
 # Validate arguments
 if [[ $# -lt 1 ]]; then
@@ -39,12 +41,113 @@ fi
 # Run checks
 FAILED=0
 
-# Check: Frontmatter exists
-if has_frontmatter "$DOC_PATH"; then
-    emit_pass "Frontmatter: present"
-else
+# Check: Frontmatter exists (prerequisite for other checks)
+if ! has_frontmatter "$DOC_PATH"; then
     emit_fail "Frontmatter: missing or malformed (must start with --- and have closing ---)"
-    FAILED=1
+    exit $EXIT_FAIL
+fi
+
+emit_pass "Frontmatter: present"
+
+# Extract frontmatter content
+FRONTMATTER=$(extract_frontmatter "$DOC_PATH")
+
+# Helper: get field value from frontmatter
+get_field() {
+    local field="$1"
+    echo "$FRONTMATTER" | awk -F': ' -v field="$field" '$1 == field { print substr($0, index($0, ": ") + 2) }'
+}
+
+# FM01: Check all required fields are present
+for field in "${REQUIRED_FIELDS[@]}"; do
+    value=$(get_field "$field")
+    if [[ -z "$value" ]]; then
+        emit_fail "Missing frontmatter field: $field. Required: status, problem, decision, rationale"
+        FAILED=1
+    fi
+done
+
+if [[ "$FAILED" -eq 0 ]]; then
+    emit_pass "FM01: all required fields present"
+fi
+
+# FM02: Validate status value
+FM_STATUS=$(get_field "status")
+if [[ -n "$FM_STATUS" ]]; then
+    valid=0
+    for status in "${VALID_STATUSES[@]}"; do
+        if [[ "$FM_STATUS" == "$status" ]]; then
+            valid=1
+            break
+        fi
+    done
+    if [[ "$valid" -eq 0 ]]; then
+        emit_fail "Invalid frontmatter status: $FM_STATUS. Must be: Proposed, Accepted, Planned, Current, Superseded"
+        FAILED=1
+    else
+        emit_pass "FM02: status value valid ($FM_STATUS)"
+    fi
+fi
+
+# FM03: Check frontmatter status matches body status
+# Skip for Superseded docs (per design: "validation is relaxed to not block archival of legacy formats")
+if [[ "$FM_STATUS" == "Superseded" ]]; then
+    emit_pass "FM03: skipped for Superseded status (legacy format allowed)"
+else
+    # Body status is in "## Status" section, formatted as **Status** (preferred) or just Status
+    # Also handles inline **Status: Value** format
+    extract_body_status() {
+        local doc="$1"
+        # Method 1: Look for ## Status section, then find status value
+        local status
+        status=$(awk '
+            /^## Status/ { in_status = 1; next }
+            in_status && /^\*\*[A-Za-z]+\*\*/ {
+                # Bold format: **Proposed**
+                gsub(/^\*\*/, "")
+                gsub(/\*\*.*$/, "")
+                print
+                exit
+            }
+            in_status && /^[A-Za-z]+$/ {
+                # Plain format: Proposed (on its own line)
+                print
+                exit
+            }
+            in_status && /^Superseded by/ {
+                # Superseded with link format
+                print "Superseded"
+                exit
+            }
+            in_status && /^## / { exit }  # Hit next section
+        ' "$doc")
+
+        if [[ -n "$status" ]]; then
+            echo "$status"
+            return
+        fi
+
+        # Method 2: Look for inline **Status: Value** format
+        awk '
+            /^\*\*Status: [A-Za-z]+\*\*/ {
+                gsub(/^\*\*Status: /, "")
+                gsub(/\*\*.*$/, "")
+                print
+                exit
+            }
+        ' "$doc"
+    }
+
+    BODY_STATUS=$(extract_body_status "$DOC_PATH")
+    if [[ -z "$BODY_STATUS" ]]; then
+        emit_fail "Could not extract body status from ## Status section (expected **Status** format)"
+        FAILED=1
+    elif [[ -n "$FM_STATUS" && "$FM_STATUS" != "$BODY_STATUS" ]]; then
+        emit_fail "Frontmatter status '$FM_STATUS' doesn't match body status '$BODY_STATUS'"
+        FAILED=1
+    elif [[ -n "$FM_STATUS" ]]; then
+        emit_pass "FM03: frontmatter and body status match ($FM_STATUS)"
+    fi
 fi
 
 # Return appropriate exit code


### PR DESCRIPTION
Update design document validation scripts and workflow.

---

## What This Changes

- `.github/scripts/validate-design-doc.sh` - Orchestrator that runs modular validation checks
- `.github/scripts/checks/` - Modular check scripts (common.sh, frontmatter.sh, etc.)
- `.github/workflows/validate-design-docs.yml` - Runs validation on all PRs

## How It Works

The workflow finds all DESIGN-*.md files in the repo and validates each one:
- Location: must be under docs/designs/
- Naming: must start with DESIGN-
- Frontmatter: must have valid YAML frontmatter