### PR TITLE
chore(ci): update design doc validation

### DIFF
--- a/.github/scripts/checks/frontmatter.sh
+++ b/.github/scripts/checks/frontmatter.sh
@@ -47,8 +47,6 @@ if ! has_frontmatter "$DOC_PATH"; then
     exit $EXIT_FAIL
 fi
 
-emit_pass "Frontmatter: present"
-
 # Extract frontmatter content
 FRONTMATTER=$(extract_frontmatter "$DOC_PATH")
 
@@ -67,10 +65,6 @@ for field in "${REQUIRED_FIELDS[@]}"; do
     fi
 done
 
-if [[ "$FAILED" -eq 0 ]]; then
-    emit_pass "FM01: all required fields present"
-fi
-
 # FM02: Validate status value
 FM_STATUS=$(get_field "status")
 if [[ -n "$FM_STATUS" ]]; then
@@ -84,16 +78,12 @@ if [[ -n "$FM_STATUS" ]]; then
     if [[ "$valid" -eq 0 ]]; then
         emit_fail "Invalid frontmatter status: $FM_STATUS. Must be: Proposed, Accepted, Planned, Current, Superseded"
         FAILED=1
-    else
-        emit_pass "FM02: status value valid ($FM_STATUS)"
     fi
 fi
 
 # FM03: Check frontmatter status matches body status
 # Skip for Superseded docs (per design: "validation is relaxed to not block archival of legacy formats")
-if [[ "$FM_STATUS" == "Superseded" ]]; then
-    emit_pass "FM03: skipped for Superseded status (legacy format allowed)"
-else
+if [[ "$FM_STATUS" != "Superseded" ]]; then
     # Body status is in "## Status" section, formatted as **Status** (preferred) or just Status
     # Also handles inline **Status: Value** format
     extract_body_status() {
@@ -154,8 +144,6 @@ else
     elif [[ -n "$FM_STATUS" && "$FM_STATUS" != "$BODY_STATUS" ]]; then
         emit_fail "Frontmatter status '$FM_STATUS' doesn't match body status '$BODY_STATUS'"
         FAILED=1
-    elif [[ -n "$FM_STATUS" ]]; then
-        emit_pass "FM03: frontmatter and body status match ($FM_STATUS)"
     fi
 fi
 

--- a/.github/scripts/checks/sections.sh
+++ b/.github/scripts/checks/sections.sh
@@ -64,7 +64,6 @@ FM_STATUS=$(get_frontmatter_status "$DOC_PATH")
 
 # Skip validation for Superseded documents (legacy format allowed per design)
 if [[ "$FM_STATUS" == "Superseded" ]]; then
-    emit_pass "Sections: skipped for Superseded status (legacy format allowed)"
     exit $EXIT_PASS
 fi
 
@@ -118,9 +117,7 @@ for section in "${REQUIRED_SECTIONS[@]}"; do
     fi
 done
 
-if [[ "$MISSING_COUNT" -eq 0 ]]; then
-    emit_pass "SC01: all 9 required sections present"
-else
+if [[ "$MISSING_COUNT" -gt 0 ]]; then
     emit_fail "SC01: Missing $MISSING_COUNT of 9 required sections:"
     for section in "${MISSING_SECTIONS[@]}"; do
         echo "       - ## $section" >&2
@@ -146,9 +143,6 @@ if [[ "$MISSING_COUNT" -eq 0 ]]; then
         PREV_SECTION=$section
     done
 
-    if [[ "$ORDER_FAILED" -eq 0 ]]; then
-        emit_pass "SC02: sections appear in correct order"
-    fi
 fi
 
 # SC03: Security Considerations section has meaningful content
@@ -180,8 +174,6 @@ if [[ -n "${FOUND_SECTIONS["Security Considerations"]:-}" ]]; then
     elif [[ "${STRIPPED_CONTENT,,}" =~ ^n/?a\.?$ ]]; then
         emit_fail "SC03: Security Considerations section contains only 'N/A' (must provide analysis or justification)"
         FAILED=1
-    else
-        emit_pass "SC03: Security Considerations section has content"
     fi
 fi
 


### PR DESCRIPTION
Update design document validation scripts and workflow.

---

## What This Changes

- `.github/scripts/validate-design-doc.sh` - Orchestrator that runs modular validation checks
- `.github/scripts/checks/` - Modular check scripts (common.sh, frontmatter.sh, etc.)
- `.github/workflows/validate-design-docs.yml` - Runs validation on all PRs

## How It Works

The workflow finds all DESIGN-*.md files in the repo and validates each one:
- Location: must be under docs/designs/
- Naming: must start with DESIGN-
- Frontmatter: must have valid YAML frontmatter