### PR TITLE
feat(ci): add issue status validation for design docs

### DIFF
--- a/.github/scripts/checks/issue-status.sh
+++ b/.github/scripts/checks/issue-status.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# issue-status.sh - Validate strikethrough formatting matches GitHub issue status
+#
+# Validates that issues/milestones marked with strikethrough in the Implementation
+# Issues table are actually closed in GitHub, and vice versa.
+#
+# Usage:
+#   issue-status.sh <doc-path> [--pr <number>]
+#
+# Options:
+#   --pr <number>   Consider issues that will be closed by this PR as "closed"
+#
+# Exit codes:
+#   0 - All checks passed
+#   1 - One or more checks failed
+#   2 - Operational error
+#
+# Environment:
+#   GH_TOKEN - GitHub token for API access (optional but recommended)
+#
+# Notes:
+#   - Requires gh CLI and jq
+#   - Graceful degradation: warns but doesn't fail if GitHub API unavailable
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+# Validate arguments
+if [[ $# -lt 1 ]]; then
+    echo "Error: missing required argument <doc-path>" >&2
+    exit $EXIT_ERROR
+fi
+
+DOC_PATH="$1"
+shift
+
+PR_NUMBER=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --pr requires a PR number" >&2
+                exit $EXIT_ERROR
+            fi
+            PR_NUMBER="$2"
+            shift 2
+            ;;
+        *)
+            echo "Error: unknown option: $1" >&2
+            exit $EXIT_ERROR
+            ;;
+    esac
+done
+
+# Check file exists
+if [[ ! -f "$DOC_PATH" ]]; then
+    echo "Error: file not found: $DOC_PATH" >&2
+    exit $EXIT_ERROR
+fi
+
+# Check for required tools
+if ! command -v gh &> /dev/null; then
+    echo "Warning: gh CLI not found, skipping issue status validation" >&2
+    exit $EXIT_PASS
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq required but not found" >&2
+    exit $EXIT_ERROR
+fi
+
+# Get sibling scripts directory
+CI_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Extract issues from design doc
+DESIGN_ISSUES=$("$CI_DIR/extract-design-issues.sh" "$DOC_PATH" 2>/dev/null) || {
+    # No Implementation Issues section - nothing to validate
+    exit $EXIT_PASS
+}
+
+# Get list of issues that will be closed by the PR
+CLOSING_ISSUES="[]"
+if [[ -n "$PR_NUMBER" ]]; then
+    CLOSING_ISSUES=$("$CI_DIR/extract-closing-issues.sh" --pr "$PR_NUMBER" 2>/dev/null) || CLOSING_ISSUES="[]"
+fi
+
+# Get GitHub status for all issues/milestones (batch query)
+GITHUB_STATUS=$("$CI_DIR/get-github-status.sh" --from-doc "$DOC_PATH") || {
+    echo "Error: could not query GitHub API" >&2
+    exit $EXIT_FAIL
+}
+
+FAILED=0
+
+# Process each entry in the design doc
+ENTRIES=$(echo "$DESIGN_ISSUES" | jq -c '.entries[]')
+
+while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+
+    TYPE=$(echo "$entry" | jq -r '.type')
+    NUMBER=$(echo "$entry" | jq -r '.number')
+    TITLE=$(echo "$entry" | jq -r '.title')
+    COMPLETED=$(echo "$entry" | jq -r '.completed')
+
+    # Skip entries without a number (named milestones without ID)
+    if [[ "$NUMBER" == "null" || -z "$NUMBER" ]]; then
+        continue
+    fi
+
+    # Get actual status from cached GitHub data
+    if [[ "$TYPE" == "issue" ]]; then
+        ACTUAL_STATUS=$(echo "$GITHUB_STATUS" | jq -r ".issues[\"$NUMBER\"] // \"unknown\"")
+    else
+        ACTUAL_STATUS=$(echo "$GITHUB_STATUS" | jq -r ".milestones[\"$NUMBER\"] // \"unknown\"")
+    fi
+
+    # Skip if we couldn't get status
+    if [[ "$ACTUAL_STATUS" == "unknown" ]]; then
+        continue
+    fi
+
+    # Check if issue will be closed by this PR
+    WILL_BE_CLOSED="false"
+    if [[ "$TYPE" == "issue" && "$CLOSING_ISSUES" != "[]" ]]; then
+        if echo "$CLOSING_ISSUES" | jq -e "index($NUMBER)" > /dev/null 2>&1; then
+            WILL_BE_CLOSED="true"
+        fi
+    fi
+
+    # Determine effective status (considering PR closures)
+    EFFECTIVE_STATUS="$ACTUAL_STATUS"
+    if [[ "$WILL_BE_CLOSED" == "true" ]]; then
+        EFFECTIVE_STATUS="closed"
+    fi
+
+    # Validate: strikethrough should match closed status
+    if [[ "$COMPLETED" == "true" ]]; then
+        # Marked complete - should be closed
+        if [[ "$EFFECTIVE_STATUS" != "closed" ]]; then
+            emit_fail "IS01: #$NUMBER marked complete but is $ACTUAL_STATUS in GitHub. See: .github/scripts/docs/IS01.md"
+            FAILED=1
+        fi
+    else
+        # Not marked complete - should be open
+        if [[ "$EFFECTIVE_STATUS" == "closed" ]]; then
+            if [[ "$WILL_BE_CLOSED" == "true" ]]; then
+                emit_fail "IS02: #$NUMBER will be closed by this PR but is not marked complete. See: .github/scripts/docs/IS02.md"
+            else
+                emit_fail "IS02: #$NUMBER is closed in GitHub but not marked complete. See: .github/scripts/docs/IS02.md"
+            fi
+            FAILED=1
+        fi
+    fi
+done <<< "$ENTRIES"
+
+# Return appropriate exit code
+if [[ "$FAILED" -eq 0 ]]; then
+    exit $EXIT_PASS
+else
+    exit $EXIT_FAIL
+fi

--- a/.github/scripts/docs/IS01.md
+++ b/.github/scripts/docs/IS01.md
@@ -1,0 +1,25 @@
+# IS01: Strikethrough item is not closed
+
+An issue or milestone in the Implementation Issues table is marked as completed (with strikethrough formatting) but is still open in GitHub.
+
+## Expected Format
+
+Strikethrough uses double tildes `~~` around the entire cell content:
+
+```markdown
+| ~~[#123](https://github.com/org/repo/issues/123)~~ | ~~Issue title~~ | ~~None~~ | ~~testable~~ |
+```
+
+## How to Fix
+
+Either:
+1. **Remove strikethrough** if the issue is not actually complete:
+   ```markdown
+   | [#123](https://github.com/org/repo/issues/123) | Issue title | None | testable |
+   ```
+
+2. **Close the issue in GitHub** if the work is complete
+
+## Note on PRs
+
+If your PR will close the issue (via `Fixes #123` in PR body or commit message), the strikethrough is correct and validation will pass.

--- a/.github/scripts/docs/IS02.md
+++ b/.github/scripts/docs/IS02.md
@@ -1,0 +1,34 @@
+# IS02: Closed item missing strikethrough
+
+An issue or milestone in the Implementation Issues table is closed in GitHub (or will be closed by this PR) but is not marked as completed with strikethrough formatting.
+
+## Expected Format
+
+Strikethrough uses double tildes `~~` around the entire cell content:
+
+**Before (incorrect):**
+```markdown
+| [#123](https://github.com/org/repo/issues/123) | Issue title | None | testable |
+```
+
+**After (correct):**
+```markdown
+| ~~[#123](https://github.com/org/repo/issues/123)~~ | ~~Issue title~~ | ~~None~~ | ~~testable~~ |
+```
+
+## How to Fix
+
+Add `~~` around each cell in the row for the closed issue:
+
+1. Issue column: `~~[#123](url)~~`
+2. Title column: `~~Issue title~~`
+3. Dependencies column: `~~None~~` or `~~[#456](url)~~`
+4. Tier column: `~~testable~~`
+
+## Mermaid Diagram
+
+Also update the diagram's class assignment to mark the issue as done:
+
+```mermaid
+class I123 done
+```

--- a/.github/scripts/extract-closing-issues.sh
+++ b/.github/scripts/extract-closing-issues.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+#
+# extract-closing-issues.sh - Extract issue numbers that a PR will close on merge
+#
+# Parses PR body (and optionally commit messages) for GitHub closing keywords
+# (Fixes, Closes, Resolves and variants) and extracts the referenced issue numbers.
+#
+# Usage:
+#   extract-closing-issues.sh --pr <number>    # Fetch PR and extract closing issues
+#   extract-closing-issues.sh --stdin          # Read text from stdin
+#
+# Output (JSON array):
+#   [123, 456]
+#
+# Exit codes:
+#   0 - Success (array may be empty)
+#   1 - PR not found (--pr mode only)
+#   2 - Operational error (missing argument, invalid usage)
+#
+# Supported closing keywords (case-insensitive):
+#   close, closes, closed
+#   fix, fixes, fixed
+#   resolve, resolves, resolved
+#
+# Supported reference formats:
+#   #N                                    - Issue number
+#   https://github.com/owner/repo/issues/N - Full URL
+#
+# Example:
+#   echo "Fixes #123 and closes #456" | ./extract-closing-issues.sh --stdin
+#   # Output: [123, 456]
+#
+#   ./extract-closing-issues.sh --pr 42
+#   # Output: [123, 456] (from PR body and commit messages)
+
+set -euo pipefail
+
+# Show usage
+usage() {
+    echo "Usage: extract-closing-issues.sh --pr <number> | --stdin" >&2
+    echo "" >&2
+    echo "Options:" >&2
+    echo "  --pr <number>   Fetch PR body and commits via gh" >&2
+    echo "  --stdin         Read text from stdin" >&2
+    exit 2
+}
+
+# Extract closing issue numbers from text
+# Outputs one issue number per line (for later deduplication)
+extract_issues() {
+    local text="$1"
+
+    # Pattern for closing keywords (case-insensitive)
+    # Matches: close, closes, closed, fix, fixes, fixed, resolve, resolves, resolved
+    # Followed by whitespace and either #N or a GitHub URL
+
+    # Extract #N format
+    echo "$text" | grep -oiE '(close[sd]?|fix(es|ed)?|resolve[sd]?)\s+#[0-9]+' | grep -oE '[0-9]+' || true
+
+    # Extract URL format: github.com/owner/repo/issues/N
+    echo "$text" | grep -oiE '(close[sd]?|fix(es|ed)?|resolve[sd]?)\s+https?://github\.com/[^/]+/[^/]+/issues/[0-9]+' | grep -oE 'issues/[0-9]+' | grep -oE '[0-9]+' || true
+}
+
+# Main
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+MODE=""
+PR_NUMBER=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pr)
+            MODE="pr"
+            if [[ $# -lt 2 ]]; then
+                echo "Error: --pr requires a PR number" >&2
+                usage
+            fi
+            PR_NUMBER="$2"
+            shift 2
+            ;;
+        --stdin)
+            MODE="stdin"
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Error: unknown option: $1" >&2
+            usage
+            ;;
+    esac
+done
+
+if [[ -z "$MODE" ]]; then
+    usage
+fi
+
+TEXT=""
+
+if [[ "$MODE" == "pr" ]]; then
+    # Fetch PR body and commit messages via gh
+    if ! command -v gh &> /dev/null; then
+        echo "Error: gh CLI not found" >&2
+        exit 2
+    fi
+
+    # Get PR body and commit messages as combined text
+    PR_DATA=$(gh pr view "$PR_NUMBER" --json body,commits 2>/dev/null) || {
+        echo "Error: PR #$PR_NUMBER not found" >&2
+        exit 1
+    }
+
+    # Extract body and all commit message headlines/bodies, join with newlines
+    TEXT=$(echo "$PR_DATA" | jq -r '([.body // ""] + [.commits[]? | .messageHeadline, .messageBody] | map(select(. != null))) | join("\n")')
+
+elif [[ "$MODE" == "stdin" ]]; then
+    TEXT=$(cat)
+fi
+
+# Extract issue numbers, deduplicate, sort, and output as JSON array
+ISSUES=$(extract_issues "$TEXT" | sort -n | uniq)
+
+if [[ -z "$ISSUES" ]]; then
+    echo "[]"
+else
+    # Convert newline-separated numbers to JSON array
+    echo "$ISSUES" | jq -R -s 'split("\n") | map(select(length > 0) | tonumber)'
+fi

--- a/.github/scripts/extract-design-issues.sh
+++ b/.github/scripts/extract-design-issues.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+#
+# extract-design-issues.sh - Extract Implementation Issues from a design doc as JSON
+#
+# Parses the Implementation Issues table from a design document and outputs
+# structured JSON with all issues and milestones, their status, dependencies, and tier.
+#
+# Usage:
+#   extract-design-issues.sh <doc-path>
+#
+# Output (JSON):
+#   {
+#     "milestone": { "name": "...", "url": "..." },
+#     "entries": [
+#       { "type": "issue", "number": 123, "url": "...", "title": "...", ... }
+#     ]
+#   }
+#
+# Exit codes:
+#   0 - Success
+#   1 - No Implementation Issues section found
+#   2 - Operational error (missing argument, file not found)
+#
+# Example:
+#   ./extract-design-issues.sh docs/designs/DESIGN-feature.md
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Error: missing required argument <doc-path>" >&2
+    echo "Usage: extract-design-issues.sh <doc-path>" >&2
+    exit 2
+fi
+
+DOC_PATH="$1"
+
+if [[ ! -f "$DOC_PATH" ]]; then
+    echo "Error: file not found: $DOC_PATH" >&2
+    exit 2
+fi
+
+# Check for Implementation Issues section
+if ! grep -q "^## Implementation Issues" "$DOC_PATH"; then
+    echo "Error: no Implementation Issues section found in $DOC_PATH" >&2
+    exit 1
+fi
+
+# Extract the Implementation Issues section content
+ISSUES_SECTION=$(awk '
+    /^## Implementation Issues/ { in_section = 1; next }
+    in_section && /^## / { exit }
+    in_section { print }
+' "$DOC_PATH")
+
+# Extract milestone info from heading: ### Milestone: [Name](url)
+MILESTONE_LINE=$(echo "$ISSUES_SECTION" | grep -E "^### Milestone:" | head -1 || true)
+MILESTONE_JSON="null"
+
+if [[ -n "$MILESTONE_LINE" ]]; then
+    # Extract [Name](url) pattern
+    MILESTONE_NAME=$(echo "$MILESTONE_LINE" | sed -n 's/.*\[\([^]]*\)\].*/\1/p')
+    MILESTONE_URL=$(echo "$MILESTONE_LINE" | sed -n 's/.*(\([^)]*\)).*/\1/p')
+    if [[ -n "$MILESTONE_NAME" && -n "$MILESTONE_URL" ]]; then
+        MILESTONE_JSON=$(jq -n --arg name "$MILESTONE_NAME" --arg url "$MILESTONE_URL" \
+            '{ "name": $name, "url": $url }')
+    fi
+fi
+
+# Find the issues table (first table after section heading)
+TABLE_HEADER=$(echo "$ISSUES_SECTION" | grep -E "^\| *Issue" | head -1 || true)
+
+if [[ -z "$TABLE_HEADER" ]]; then
+    # No table found, output with empty entries
+    jq -n --argjson milestone "$MILESTONE_JSON" \
+        '{ "milestone": $milestone, "entries": [] }'
+    exit 0
+fi
+
+# Get column positions
+get_column_position() {
+    local header="$1"
+    local col_name="$2"
+    echo "$header" | awk -v col="$col_name" '
+    BEGIN { FS = "|" }
+    {
+        for (i = 1; i <= NF; i++) {
+            gsub(/^[ \t]+|[ \t]+$/, "", $i)
+            if (tolower($i) == tolower(col)) {
+                print i
+                exit
+            }
+        }
+    }
+    '
+}
+
+ISSUE_COL=$(get_column_position "$TABLE_HEADER" "Issue")
+TITLE_COL=$(get_column_position "$TABLE_HEADER" "Title")
+DEP_COL=$(get_column_position "$TABLE_HEADER" "Dependencies")
+TIER_COL=$(get_column_position "$TABLE_HEADER" "Tier")
+
+# Extract table data rows (skip header and separator)
+TABLE_ROWS=$(echo "$ISSUES_SECTION" | awk '
+    /^\|/ && !/^\| *-/ && !/^\| *Issue/ { print }
+')
+
+# Helper to strip strikethrough: ~~text~~ -> text
+strip_strikethrough() {
+    echo "$1" | sed 's/^~~//;s/~~$//'
+}
+
+# Helper to check if value has strikethrough
+has_strikethrough() {
+    [[ "$1" =~ ^~~.*~~$ ]]
+}
+
+# Helper to extract link text: [text](url) -> text
+extract_link_text() {
+    local val
+    val=$(strip_strikethrough "$1")
+    echo "$val" | sed -n 's/^\[\([^]]*\)\].*/\1/p'
+}
+
+# Helper to extract link URL: [text](url) -> url
+extract_link_url() {
+    local val
+    val=$(strip_strikethrough "$1")
+    echo "$val" | sed -n 's/.*(\([^)]*\))$/\1/p'
+}
+
+# Helper to determine entry type (issue or milestone)
+get_entry_type() {
+    local issue_val="$1"
+    local tier_val="$2"
+    local clean_issue
+    clean_issue=$(strip_strikethrough "$issue_val")
+    local clean_tier
+    clean_tier=$(strip_strikethrough "$tier_val")
+
+    # Milestone if tier is "milestone" or URL contains /milestone/
+    if [[ "$clean_tier" == "milestone" ]] || [[ "$clean_issue" =~ milestone/ ]]; then
+        echo "milestone"
+    else
+        echo "issue"
+    fi
+}
+
+# Helper to extract issue/milestone number from link
+extract_number() {
+    local val="$1"
+    local entry_type="$2"
+    local url
+    url=$(extract_link_url "$val")
+
+    if [[ "$entry_type" == "issue" ]]; then
+        # Extract from [#N](url) format
+        local text
+        text=$(extract_link_text "$val")
+        echo "$text" | grep -oE '[0-9]+' || true
+    else
+        # Extract from milestone URL: .../milestone/N
+        echo "$url" | grep -oE 'milestone/[0-9]+' | grep -oE '[0-9]+' || true
+    fi
+}
+
+# Parse dependencies: "None" or "[#X](url), [#Y](url)"
+parse_dependencies() {
+    local dep_val="$1"
+    local dep_clean
+    dep_clean=$(strip_strikethrough "$dep_val")
+
+    if [[ "$dep_clean" == "None" || -z "$dep_clean" ]]; then
+        echo "[]"
+        return
+    fi
+
+    # Split on comma and extract each reference
+    local deps=()
+    IFS=',' read -ra DEP_PARTS <<< "$dep_val"
+    for part in "${DEP_PARTS[@]}"; do
+        part=$(echo "$part" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        local text
+        text=$(extract_link_text "$part")
+        if [[ -n "$text" ]]; then
+            deps+=("$text")
+        fi
+    done
+
+    # Output as JSON array
+    printf '%s\n' "${deps[@]}" | jq -R -s 'split("\n") | map(select(length > 0))'
+}
+
+# Build entries array
+ENTRIES="[]"
+
+while IFS= read -r row; do
+    [[ -z "$row" ]] && continue
+
+    # Extract column values
+    ISSUE_VAL=$(echo "$row" | awk -F'|' -v col="$ISSUE_COL" '{ gsub(/^[ \t]+|[ \t]+$/, "", $col); print $col }')
+    TITLE_VAL=$(echo "$row" | awk -F'|' -v col="$TITLE_COL" '{ gsub(/^[ \t]+|[ \t]+$/, "", $col); print $col }')
+    DEP_VAL=$(echo "$row" | awk -F'|' -v col="$DEP_COL" '{ gsub(/^[ \t]+|[ \t]+$/, "", $col); print $col }')
+    TIER_VAL=$(echo "$row" | awk -F'|' -v col="$TIER_COL" '{ gsub(/^[ \t]+|[ \t]+$/, "", $col); print $col }')
+
+    [[ -z "$ISSUE_VAL" ]] && continue
+
+    # Determine type, number, URL, completion status
+    ENTRY_TYPE=$(get_entry_type "$ISSUE_VAL" "$TIER_VAL")
+    ENTRY_NUMBER=$(extract_number "$ISSUE_VAL" "$ENTRY_TYPE")
+    ENTRY_URL=$(extract_link_url "$ISSUE_VAL")
+    ENTRY_TITLE=$(strip_strikethrough "$TITLE_VAL")
+    ENTRY_TIER=$(strip_strikethrough "$TIER_VAL")
+    ENTRY_DEPS=$(parse_dependencies "$DEP_VAL")
+
+    # Check if completed (strikethrough on issue column)
+    if has_strikethrough "$ISSUE_VAL"; then
+        COMPLETED="true"
+    else
+        COMPLETED="false"
+    fi
+
+    # Handle null number for named milestones without numeric ID
+    if [[ -z "$ENTRY_NUMBER" ]]; then
+        NUMBER_JSON="null"
+    else
+        NUMBER_JSON="$ENTRY_NUMBER"
+    fi
+
+    # Build entry JSON
+    ENTRY=$(jq -n \
+        --arg type "$ENTRY_TYPE" \
+        --argjson number "$NUMBER_JSON" \
+        --arg url "$ENTRY_URL" \
+        --arg title "$ENTRY_TITLE" \
+        --argjson deps "$ENTRY_DEPS" \
+        --arg tier "$ENTRY_TIER" \
+        --argjson completed "$COMPLETED" \
+        '{
+            "type": $type,
+            "number": $number,
+            "url": $url,
+            "title": $title,
+            "dependencies": $deps,
+            "tier": $tier,
+            "completed": $completed
+        }')
+
+    ENTRIES=$(echo "$ENTRIES" | jq --argjson entry "$ENTRY" '. + [$entry]')
+done <<< "$TABLE_ROWS"
+
+# Output final JSON
+jq -n --argjson milestone "$MILESTONE_JSON" --argjson entries "$ENTRIES" \
+    '{ "milestone": $milestone, "entries": $entries }'

--- a/.github/scripts/get-github-status.sh
+++ b/.github/scripts/get-github-status.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# get-github-status.sh - Get GitHub status for issues and milestones
+#
+# Queries the GitHub API to get the current status (open/closed) for a list
+# of issues and milestones. Handles rate limiting and caches responses.
+#
+# Usage:
+#   get-github-status.sh --issues <json-array>
+#   get-github-status.sh --from-doc <doc-path>
+#   echo '<json-array>' | get-github-status.sh --stdin
+#
+# Input format (JSON array):
+#   [
+#     { "type": "issue", "number": 123, "url": "https://github.com/owner/repo/issues/123" },
+#     { "type": "milestone", "number": 38, "url": "https://github.com/owner/repo/milestone/38" }
+#   ]
+#
+# Output (JSON object mapping number to status):
+#   {
+#     "issues": { "123": "open", "456": "closed" },
+#     "milestones": { "38": "closed" }
+#   }
+#
+# Exit codes:
+#   0 - Success
+#   1 - Partial success (some API calls failed)
+#   2 - Operational error (missing argument, no gh CLI)
+#
+# Environment:
+#   GH_TOKEN - GitHub token for API access (optional but recommended)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Check for required tools
+if ! command -v gh &> /dev/null; then
+    echo "Error: gh CLI not found" >&2
+    exit 2
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq required but not found" >&2
+    exit 2
+fi
+
+usage() {
+    echo "Usage: get-github-status.sh --issues <json-array>" >&2
+    echo "       get-github-status.sh --from-doc <doc-path>" >&2
+    echo "       echo '<json>' | get-github-status.sh --stdin" >&2
+    exit 2
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+fi
+
+INPUT_JSON=""
+
+case "$1" in
+    --issues)
+        if [[ $# -lt 2 ]]; then
+            echo "Error: --issues requires a JSON array" >&2
+            usage
+        fi
+        INPUT_JSON="$2"
+        ;;
+    --from-doc)
+        if [[ $# -lt 2 ]]; then
+            echo "Error: --from-doc requires a doc path" >&2
+            usage
+        fi
+        DOC_PATH="$2"
+        if [[ ! -f "$DOC_PATH" ]]; then
+            echo "Error: file not found: $DOC_PATH" >&2
+            exit 2
+        fi
+        # Extract issues from design doc
+        DESIGN_DATA=$("$SCRIPT_DIR/extract-design-issues.sh" "$DOC_PATH" 2>/dev/null) || {
+            echo '{"issues": {}, "milestones": {}}'
+            exit 0
+        }
+        INPUT_JSON=$(echo "$DESIGN_DATA" | jq '[.entries[] | {type, number, url}]')
+        ;;
+    --stdin)
+        INPUT_JSON=$(cat)
+        ;;
+    -h|--help)
+        usage
+        ;;
+    *)
+        echo "Error: unknown option: $1" >&2
+        usage
+        ;;
+esac
+
+# Validate JSON
+if ! echo "$INPUT_JSON" | jq empty 2>/dev/null; then
+    echo "Error: invalid JSON input" >&2
+    exit 2
+fi
+
+# Initialize output
+ISSUE_STATUSES="{}"
+MILESTONE_STATUSES="{}"
+PARTIAL_FAILURE=0
+
+# Process each entry
+while IFS= read -r entry; do
+    [[ -z "$entry" ]] && continue
+
+    TYPE=$(echo "$entry" | jq -r '.type')
+    NUMBER=$(echo "$entry" | jq -r '.number')
+    URL=$(echo "$entry" | jq -r '.url')
+
+    # Skip entries without a number
+    if [[ "$NUMBER" == "null" || -z "$NUMBER" ]]; then
+        continue
+    fi
+
+    # Extract owner/repo from URL
+    owner_repo=""
+    if [[ "$TYPE" == "issue" ]]; then
+        owner_repo=$(echo "$URL" | sed -n 's|https://github.com/\([^/]*/[^/]*\)/issues/.*|\1|p')
+    else
+        owner_repo=$(echo "$URL" | sed -n 's|https://github.com/\([^/]*/[^/]*\)/milestone/.*|\1|p')
+    fi
+
+    if [[ -z "$owner_repo" ]]; then
+        PARTIAL_FAILURE=1
+        continue
+    fi
+
+    # Query GitHub API
+    state=""
+    if [[ "$TYPE" == "issue" ]]; then
+        state=$(gh api "repos/$owner_repo/issues/$NUMBER" --jq '.state' 2>/dev/null) || {
+            PARTIAL_FAILURE=1
+            continue
+        }
+        ISSUE_STATUSES=$(echo "$ISSUE_STATUSES" | jq --arg num "$NUMBER" --arg state "$state" '. + {($num): $state}')
+    else
+        state=$(gh api "repos/$owner_repo/milestones/$NUMBER" --jq '.state' 2>/dev/null) || {
+            PARTIAL_FAILURE=1
+            continue
+        }
+        MILESTONE_STATUSES=$(echo "$MILESTONE_STATUSES" | jq --arg num "$NUMBER" --arg state "$state" '. + {($num): $state}')
+    fi
+done <<< "$(echo "$INPUT_JSON" | jq -c '.[]')"
+
+# Output combined result
+jq -n --argjson issues "$ISSUE_STATUSES" --argjson milestones "$MILESTONE_STATUSES" \
+    '{"issues": $issues, "milestones": $milestones}'
+
+if [[ $PARTIAL_FAILURE -eq 1 ]]; then
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
Add validation check that verifies strikethrough formatting in Implementation
Issues tables matches actual GitHub issue/milestone status. Issues marked with
~~strikethrough~~ must be closed in GitHub, and open issues must not be struck
through.

---

## Summary

**New validation check:**
- `.github/scripts/checks/issue-status.sh` - Validates strikethrough vs GitHub status

**Helper scripts:**
- `extract-design-issues.sh` - Parses Implementation Issues table from design docs
- `extract-closing-issues.sh` - Gets issues that will be closed by a PR
- `get-github-status.sh` - Batch queries GitHub API for issue/milestone status

**Documentation:**
- `docs/IS01.md` - Rule for strikethrough on open issues
- `docs/IS02.md` - Rule for missing strikethrough on closed issues