### PR TITLE
chore(ci): update design doc validation

### DIFF
--- a/.github/scripts/checks/frontmatter.sh
+++ b/.github/scripts/checks/frontmatter.sh
@@ -43,7 +43,7 @@ FAILED=0
 
 # Check: Frontmatter exists (prerequisite for other checks)
 if ! has_frontmatter "$DOC_PATH"; then
-    emit_fail "Frontmatter: missing or malformed (must start with --- and have closing ---)"
+    emit_fail "FM01: Frontmatter missing or malformed. See: .github/scripts/docs/FM01.md"
     exit $EXIT_FAIL
 fi
 
@@ -60,7 +60,7 @@ get_field() {
 for field in "${REQUIRED_FIELDS[@]}"; do
     value=$(get_field "$field")
     if [[ -z "$value" ]]; then
-        emit_fail "Missing frontmatter field: $field. Required: status, problem, decision, rationale"
+        emit_fail "FM01: Missing frontmatter field: $field. See: .github/scripts/docs/FM01.md"
         FAILED=1
     fi
 done
@@ -76,7 +76,7 @@ if [[ -n "$FM_STATUS" ]]; then
         fi
     done
     if [[ "$valid" -eq 0 ]]; then
-        emit_fail "Invalid frontmatter status: $FM_STATUS. Must be: Proposed, Accepted, Planned, Current, Superseded"
+        emit_fail "FM02: Invalid frontmatter status: $FM_STATUS. See: .github/scripts/docs/FM02.md"
         FAILED=1
     fi
 fi
@@ -139,10 +139,10 @@ if [[ "$FM_STATUS" != "Superseded" ]]; then
 
     BODY_STATUS=$(extract_body_status "$DOC_PATH")
     if [[ -z "$BODY_STATUS" ]]; then
-        emit_fail "Could not extract body status from ## Status section (expected **Status** format)"
+        emit_fail "FM03: Could not extract body status from ## Status section. See: .github/scripts/docs/FM03.md"
         FAILED=1
     elif [[ -n "$FM_STATUS" && "$FM_STATUS" != "$BODY_STATUS" ]]; then
-        emit_fail "Frontmatter status '$FM_STATUS' doesn't match body status '$BODY_STATUS'"
+        emit_fail "FM03: Frontmatter status '$FM_STATUS' doesn't match body status '$BODY_STATUS'. See: .github/scripts/docs/FM03.md"
         FAILED=1
     fi
 fi

--- a/.github/scripts/checks/implementation-issues.sh
+++ b/.github/scripts/checks/implementation-issues.sh
@@ -62,7 +62,7 @@ FAILED=0
 # - Current status: MAY have this section (Accepted→Current direct path doesn't create it)
 if ! grep -q "^## Implementation Issues" "$DOC_PATH"; then
     if [[ "$FM_STATUS" == "Planned" ]]; then
-        emit_fail "II01: Planned status requires '## Implementation Issues' section"
+        emit_fail "II01: Planned status requires '## Implementation Issues' section. See: .github/scripts/docs/II01.md"
         FAILED=1
         exit $EXIT_FAIL
     else
@@ -84,7 +84,7 @@ ISSUES_SECTION=$(awk '
 TABLE_HEADER=$(echo "$ISSUES_SECTION" | grep -E "^\| *Issue" | head -1 || true)
 
 if [[ -z "$TABLE_HEADER" ]]; then
-    emit_fail "II02: Implementation Issues section missing issues table"
+    emit_fail "II02: Implementation Issues section missing issues table. See: .github/scripts/docs/II02.md"
     FAILED=1
     exit $EXIT_FAIL
 fi
@@ -95,7 +95,7 @@ for col in "${REQUIRED_COLUMNS[@]}"; do
     if ! echo "$TABLE_HEADER" | grep -qiE "\| *$col *\|"; then
         # Check if it's the last column (no trailing |)
         if ! echo "$TABLE_HEADER" | grep -qiE "\| *$col *$"; then
-            emit_fail "II02: Issues table missing required column: $col"
+            emit_fail "II02: Issues table missing required column: $col. See: .github/scripts/docs/II02.md"
             FAILED=1
         fi
     fi
@@ -179,13 +179,13 @@ while IFS= read -r row; do
         if [[ "$IS_MILESTONE_ROW" == true ]]; then
             # Milestone row: must be a valid markdown link
             if ! is_markdown_link "$ISSUE_VAL"; then
-                emit_fail "II03: Invalid milestone link format: '$ISSUE_VAL'. Expected: [Name](url)"
+                emit_fail "II03: Invalid milestone link format: '$ISSUE_VAL'. See: .github/scripts/docs/II03.md"
                 FAILED=1
             fi
         else
             # Issue row: must be [#N](url) format
             if ! is_issue_link "$ISSUE_VAL"; then
-                emit_fail "II03: Invalid issue link format: '$ISSUE_VAL'. Expected: [#N](url)"
+                emit_fail "II03: Invalid issue link format: '$ISSUE_VAL'. See: .github/scripts/docs/II03.md"
                 FAILED=1
             fi
         fi
@@ -205,15 +205,15 @@ while IFS= read -r row; do
                 dep_clean=$(strip_strikethrough "$dep")
                 # Check for plain text issue reference (e.g., #123)
                 if [[ "$dep_clean" =~ ^#[0-9]+$ ]]; then
-                    emit_fail "II04: Dependencies must use link format, not plain text: '$dep'. Expected: [#N](url)"
+                    emit_fail "II04: Dependencies must use link format, not plain text: '$dep'. See: .github/scripts/docs/II04.md"
                     FAILED=1
                 # Check for plain text milestone reference (e.g., M38)
                 elif [[ "$dep_clean" =~ ^M[0-9]+$ ]]; then
-                    emit_fail "II04: Dependencies must use link format, not plain text: '$dep'. Expected: [MN](url)"
+                    emit_fail "II04: Dependencies must use link format, not plain text: '$dep'. See: .github/scripts/docs/II04.md"
                     FAILED=1
                 # Must be a valid markdown link (issue or milestone)
                 elif ! is_markdown_link "$dep"; then
-                    emit_fail "II04: Invalid dependency format: '$dep'. Expected: None or [text](url)"
+                    emit_fail "II04: Invalid dependency format: '$dep'. See: .github/scripts/docs/II04.md"
                     FAILED=1
                 fi
             done
@@ -227,7 +227,7 @@ while IFS= read -r row; do
                 # Valid
                 ;;
             *)
-                emit_fail "II05: Invalid tier value: '$TIER_VAL'. Must be: simple, testable, critical, milestone"
+                emit_fail "II05: Invalid tier value: '$TIER_VAL'. See: .github/scripts/docs/II05.md"
                 FAILED=1
                 ;;
         esac

--- a/.github/scripts/checks/issue-status.sh
+++ b/.github/scripts/checks/issue-status.sh
@@ -95,8 +95,8 @@ GITHUB_STATUS=$("$CI_DIR/get-github-status.sh" --from-doc "$DOC_PATH") || {
 
 FAILED=0
 
-# Process each entry in the design doc
-ENTRIES=$(echo "$DESIGN_ISSUES" | jq -c '.entries[]')
+# Process each entry in the design doc (flatten all milestones)
+ENTRIES=$(echo "$DESIGN_ISSUES" | jq -c '.milestones[].entries[]')
 
 while IFS= read -r entry; do
     [[ -z "$entry" ]] && continue

--- a/.github/scripts/checks/sections.sh
+++ b/.github/scripts/checks/sections.sh
@@ -118,7 +118,7 @@ for section in "${REQUIRED_SECTIONS[@]}"; do
 done
 
 if [[ "$MISSING_COUNT" -gt 0 ]]; then
-    emit_fail "SC01: Missing $MISSING_COUNT of 9 required sections:"
+    emit_fail "SC01: Missing $MISSING_COUNT of 9 required sections. See: .github/scripts/docs/SC01.md"
     for section in "${MISSING_SECTIONS[@]}"; do
         echo "       - ## $section" >&2
     done
@@ -135,7 +135,7 @@ if [[ "$MISSING_COUNT" -eq 0 ]]; then
     for section in "${REQUIRED_SECTIONS[@]}"; do
         CURRENT_LINE=${SECTION_LINES[$section]}
         if [[ "$PREV_LINE" -gt 0 ]] && [[ "$CURRENT_LINE" -lt "$PREV_LINE" ]]; then
-            emit_fail "SC02: Wrong section order - '## $section' (line $CURRENT_LINE) appears before '## $PREV_SECTION' (line $PREV_LINE)"
+            emit_fail "SC02: Wrong section order - '## $section' (line $CURRENT_LINE) appears before '## $PREV_SECTION' (line $PREV_LINE). See: .github/scripts/docs/SC02.md"
             FAILED=1
             ORDER_FAILED=1
         fi
@@ -169,10 +169,10 @@ if [[ -n "${FOUND_SECTIONS["Security Considerations"]:-}" ]]; then
 
     # Check if empty or only N/A (case insensitive)
     if [[ -z "$STRIPPED_CONTENT" ]]; then
-        emit_fail "SC03: Security Considerations section is empty (must address security dimensions)"
+        emit_fail "SC03: Security Considerations section is empty. See: .github/scripts/docs/SC03.md"
         FAILED=1
     elif [[ "${STRIPPED_CONTENT,,}" =~ ^n/?a\.?$ ]]; then
-        emit_fail "SC03: Security Considerations section contains only 'N/A' (must provide analysis or justification)"
+        emit_fail "SC03: Security Considerations section contains only 'N/A'. See: .github/scripts/docs/SC03.md"
         FAILED=1
     fi
 fi

--- a/.github/scripts/checks/status-directory.sh
+++ b/.github/scripts/checks/status-directory.sh
@@ -96,7 +96,7 @@ if [[ -n "$EXPECTED_DIR" ]]; then
     # Check if actual directory ends with expected pattern
     # This handles both relative (docs/designs/) and absolute (/path/to/docs/designs/) paths
     if [[ "$ACTUAL_DIR" != "$EXPECTED_DIR" && "$ACTUAL_DIR" != */"$EXPECTED_DIR" ]]; then
-        emit_fail "SD01: Status '$FM_STATUS' requires directory '$EXPECTED_DIR', found in '$ACTUAL_DIR'"
+        emit_fail "SD01: Status '$FM_STATUS' requires directory '$EXPECTED_DIR', found in '$ACTUAL_DIR'. See: .github/scripts/docs/SD01.md"
         FAILED=1
     fi
 fi
@@ -106,7 +106,7 @@ if [[ "$FM_STATUS" == "Superseded" ]]; then
     # Search for "Superseded by" followed by markdown link pattern
     # Pattern: Superseded by [anything](anything)
     if ! grep -qE "Superseded by \[.+\]\(.+\)" "$DOC_PATH"; then
-        emit_fail "SD02: Superseded status requires 'Superseded by [DESIGN-...](path)' link in body"
+        emit_fail "SD02: Superseded status requires 'Superseded by [DESIGN-...](path)' link in body. See: .github/scripts/docs/SD02.md"
         FAILED=1
     fi
 fi

--- a/.github/scripts/checks/strikethrough-all-docs.sh
+++ b/.github/scripts/checks/strikethrough-all-docs.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# strikethrough-all-docs.sh - Validate closing issues are marked complete in all design docs
+#
+# When a PR closes an issue, this check ensures that issue is marked as
+# strikethrough (completed) in ALL design documents that reference it.
+#
+# Usage:
+#   strikethrough-all-docs.sh --pr <number>
+#
+# Exit codes:
+#   0 - All checks passed (or no issues to validate)
+#   1 - One or more issues not marked complete in design docs
+#   2 - Operational error
+#
+# Example:
+#   # PR #408 has "Fixes #404" in body
+#   ./strikethrough-all-docs.sh --pr 408
+#   # Checks that #404 is strikethrough in all DESIGN-*.md files that reference it
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
+
+CI_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Validate arguments
+if [[ $# -lt 2 ]] || [[ "$1" != "--pr" ]]; then
+    echo "Usage: strikethrough-all-docs.sh --pr <number>" >&2
+    exit $EXIT_ERROR
+fi
+
+PR_NUMBER="$2"
+
+# Check for required tools
+if ! command -v gh &> /dev/null; then
+    echo "Warning: gh CLI not found, skipping cross-doc strikethrough validation" >&2
+    exit $EXIT_PASS
+fi
+
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq required but not found" >&2
+    exit $EXIT_ERROR
+fi
+
+# Get issues being closed by this PR
+CLOSING_ISSUES=$("$CI_DIR/extract-closing-issues.sh" --pr "$PR_NUMBER" 2>/dev/null) || {
+    echo "Warning: could not extract closing issues from PR #$PR_NUMBER" >&2
+    exit $EXIT_PASS
+}
+
+# If no issues being closed, nothing to validate
+if [[ "$CLOSING_ISSUES" == "[]" ]] || [[ -z "$CLOSING_ISSUES" ]]; then
+    exit $EXIT_PASS
+fi
+
+# Find all design docs (exclude archive - superseded docs don't need updates)
+DESIGN_DOCS=$(find docs/designs -name 'DESIGN-*.md' -type f ! -path '*/archive/*' 2>/dev/null || true)
+
+if [[ -z "$DESIGN_DOCS" ]]; then
+    # No design docs found
+    exit $EXIT_PASS
+fi
+
+FAILED=0
+FAILURES=()
+
+# For each issue being closed
+while IFS= read -r issue_num; do
+    [[ -z "$issue_num" ]] && continue
+
+    # Check each design doc
+    while IFS= read -r doc_path; do
+        [[ -z "$doc_path" ]] && continue
+
+        # Extract issues from this doc
+        DOC_ISSUES=$("$CI_DIR/extract-design-issues.sh" "$doc_path" 2>/dev/null) || continue
+
+        # Check if this issue is referenced in the doc
+        # Look for entry with matching number that is NOT completed
+        INCOMPLETE_MATCH=$(echo "$DOC_ISSUES" | jq -r --argjson num "$issue_num" '
+            .milestones[].entries[]
+            | select(.type == "issue" and .number == $num and .completed == false)
+            | .number
+        ' 2>/dev/null || true)
+
+        if [[ -n "$INCOMPLETE_MATCH" ]]; then
+            FAILURES+=("Issue #$issue_num will be closed but not marked complete in $doc_path")
+            FAILED=1
+        fi
+    done <<< "$DESIGN_DOCS"
+done <<< "$(echo "$CLOSING_ISSUES" | jq -r '.[]')"
+
+# Report results
+if [[ "$FAILED" -eq 1 ]]; then
+    emit_fail "Closing issues not marked complete in all design docs:"
+    for failure in "${FAILURES[@]}"; do
+        echo "       - $failure" >&2
+    done
+    echo "" >&2
+    echo "Fix: Add strikethrough to mark issues complete: ~~[#N](url)~~" >&2
+    exit $EXIT_FAIL
+fi
+
+exit $EXIT_PASS

--- a/.github/scripts/docs/FM01.md
+++ b/.github/scripts/docs/FM01.md
@@ -1,0 +1,39 @@
+# FM01: Missing frontmatter field
+
+A required field is missing from the YAML frontmatter at the top of the design document.
+
+## Required Fields
+
+All design documents must have these 4 fields in their frontmatter:
+
+```yaml
+---
+status: Proposed
+problem: One sentence describing the problem being solved.
+decision: One sentence stating what was decided.
+rationale: 1-2 sentences explaining why this approach was chosen.
+---
+```
+
+## How to Fix
+
+Add the missing field to the frontmatter block at the very top of the file.
+
+**Example - Before (missing `rationale`):**
+```yaml
+---
+status: Proposed
+problem: Users can't track installation progress.
+decision: Add progress bar to CLI output.
+---
+```
+
+**Example - After:**
+```yaml
+---
+status: Proposed
+problem: Users can't track installation progress.
+decision: Add progress bar to CLI output.
+rationale: Visual feedback reduces perceived wait time and helps debug stuck installs.
+---
+```

--- a/.github/scripts/docs/FM02.md
+++ b/.github/scripts/docs/FM02.md
@@ -1,0 +1,35 @@
+# FM02: Invalid frontmatter status
+
+The `status` field in the frontmatter contains an invalid value.
+
+## Valid Status Values
+
+- `Proposed` - Initial draft awaiting review
+- `Accepted` - Approved, ready for implementation planning
+- `Planned` - Has Implementation Issues section with tracked issues
+- `Current` - All implementation complete
+- `Superseded` - Replaced by a newer design
+
+## How to Fix
+
+Update the `status` field to one of the valid values.
+
+**Example - Before (invalid status):**
+```yaml
+---
+status: Draft
+problem: ...
+---
+```
+
+**Example - After:**
+```yaml
+---
+status: Proposed
+problem: ...
+---
+```
+
+## Note
+
+Status values are case-sensitive. Use exactly `Proposed`, not `proposed` or `PROPOSED`.

--- a/.github/scripts/docs/FM03.md
+++ b/.github/scripts/docs/FM03.md
@@ -1,0 +1,54 @@
+# FM03: Status mismatch
+
+The `status` field in the frontmatter doesn't match the status shown in the document body's `## Status` section.
+
+## Expected Behavior
+
+Both locations must show the same status value:
+
+```yaml
+---
+status: Accepted
+...
+---
+```
+
+```markdown
+## Status
+
+**Accepted**
+```
+
+## How to Fix
+
+Update either the frontmatter or body status so they match.
+
+**Common causes:**
+1. Updated one location but forgot the other
+2. Copy-paste from a template with different status
+
+## Body Status Formats
+
+The validation accepts these formats in the `## Status` section:
+
+```markdown
+## Status
+
+**Accepted**
+```
+
+or
+
+```markdown
+## Status
+
+Accepted
+```
+
+or (for Superseded):
+
+```markdown
+## Status
+
+Superseded by [DESIGN-new-feature.md](path)
+```

--- a/.github/scripts/docs/II01.md
+++ b/.github/scripts/docs/II01.md
@@ -1,0 +1,33 @@
+# II01: Missing Implementation Issues section
+
+A design document with status "Planned" must have an `## Implementation Issues` section.
+
+## Why This Matters
+
+The "Planned" status indicates that implementation has been broken into tracked GitHub issues. The Implementation Issues section documents these issues and their dependencies.
+
+## How to Fix
+
+Add an Implementation Issues section with a milestone and issues table:
+
+```markdown
+## Implementation Issues
+
+### Milestone: [Feature Name](https://github.com/org/repo/milestone/N)
+
+| Issue | Title | Dependencies | Tier |
+|-------|-------|--------------|------|
+| [#123](https://github.com/org/repo/issues/123) | First task | None | testable |
+| [#124](https://github.com/org/repo/issues/124) | Second task | [#123](https://github.com/org/repo/issues/123) | testable |
+```
+
+## Alternative
+
+If the design isn't ready for implementation planning yet, change the status to "Accepted" instead:
+
+```yaml
+---
+status: Accepted
+...
+---
+```

--- a/.github/scripts/docs/II02.md
+++ b/.github/scripts/docs/II02.md
@@ -1,0 +1,28 @@
+# II02: Issues table missing column
+
+The Implementation Issues table is missing a required column.
+
+## Required Columns
+
+| Column | Description |
+|--------|-------------|
+| Issue | Link to GitHub issue: `[#N](url)` |
+| Title | Short issue title |
+| Dependencies | `None` or comma-separated issue links |
+| Tier | Validation tier: `simple`, `testable`, or `critical` |
+
+## How to Fix
+
+Add the missing column to the table header and all rows.
+
+**Example - Complete table:**
+```markdown
+| Issue | Title | Dependencies | Tier |
+|-------|-------|--------------|------|
+| [#123](https://github.com/org/repo/issues/123) | Add feature X | None | testable |
+| [#124](https://github.com/org/repo/issues/124) | Update tests | [#123](https://github.com/org/repo/issues/123) | testable |
+```
+
+## Note
+
+Column order matters. Use exactly: Issue, Title, Dependencies, Tier.

--- a/.github/scripts/docs/II03.md
+++ b/.github/scripts/docs/II03.md
@@ -1,0 +1,42 @@
+# II03: Invalid issue link format
+
+An entry in the Issue column has an invalid format.
+
+## Expected Format
+
+Issue links must use markdown link format with the issue number as text:
+
+```markdown
+[#123](https://github.com/org/repo/issues/123)
+```
+
+Milestone links use the milestone name:
+
+```markdown
+[Milestone Name](https://github.com/org/repo/milestone/N)
+```
+
+## Common Mistakes
+
+**Plain text (invalid):**
+```markdown
+| #123 | Title | None | testable |
+```
+
+**URL only (invalid):**
+```markdown
+| https://github.com/org/repo/issues/123 | Title | None | testable |
+```
+
+**Wrong link text (invalid):**
+```markdown
+| [Issue 123](https://github.com/org/repo/issues/123) | Title | None | testable |
+```
+
+## How to Fix
+
+Use the correct link format:
+
+```markdown
+| [#123](https://github.com/org/repo/issues/123) | Title | None | testable |
+```

--- a/.github/scripts/docs/II04.md
+++ b/.github/scripts/docs/II04.md
@@ -1,0 +1,43 @@
+# II04: Dependencies not using link format
+
+The Dependencies column contains plain text instead of proper links.
+
+## Expected Format
+
+Dependencies must use markdown link format:
+
+```markdown
+| Issue | Title | Dependencies | Tier |
+|-------|-------|--------------|------|
+| [#124](url) | Task B | [#123](url) | testable |
+| [#125](url) | Task C | [#123](url), [#124](url) | testable |
+| [#126](url) | Task D | None | testable |
+```
+
+## Common Mistakes
+
+**Plain text (invalid):**
+```markdown
+| [#124](url) | Task B | #123 | testable |
+```
+
+**Mixed format (invalid):**
+```markdown
+| [#124](url) | Task B | #123, [#122](url) | testable |
+```
+
+## How to Fix
+
+Convert all dependencies to link format:
+
+**Before:**
+```markdown
+| [#124](https://github.com/org/repo/issues/124) | Task B | #123 | testable |
+```
+
+**After:**
+```markdown
+| [#124](https://github.com/org/repo/issues/124) | Task B | [#123](https://github.com/org/repo/issues/123) | testable |
+```
+
+Use `None` (not `N/A` or empty) when there are no dependencies.

--- a/.github/scripts/docs/II05.md
+++ b/.github/scripts/docs/II05.md
@@ -1,0 +1,34 @@
+# II05: Invalid tier value
+
+The Tier column contains an invalid value.
+
+## Valid Tier Values
+
+| Tier | When to Use |
+|------|-------------|
+| `simple` | Docs, typos, comments, trivial fixes |
+| `testable` | New features, refactoring, behavior changes (default) |
+| `critical` | Auth, security, payments, crypto, permissions |
+| `milestone` | Milestone rows (not regular issues) |
+
+## How to Fix
+
+Update the tier to a valid value.
+
+**Before (invalid):**
+```markdown
+| [#123](url) | Add feature | None | high |
+```
+
+**After:**
+```markdown
+| [#123](url) | Add feature | None | testable |
+```
+
+## Choosing the Right Tier
+
+- **simple**: Low-risk documentation or trivial fixes. No tests required.
+- **testable**: Default for most implementation work. Requires tests.
+- **critical**: Security-sensitive changes. Requires additional security review.
+
+When in doubt, choose `testable` - it's the safe default.

--- a/.github/scripts/docs/MM01.md
+++ b/.github/scripts/docs/MM01.md
@@ -1,0 +1,32 @@
+# MM01: Using flowchart instead of graph
+
+The Mermaid dependency diagram uses `flowchart` instead of `graph`.
+
+## Expected Format
+
+Use `graph` for better portability:
+
+```mermaid
+graph TD
+    A --> B
+```
+
+## How to Fix
+
+Change `flowchart` to `graph`:
+
+**Before (invalid):**
+```
+flowchart TD
+    A --> B
+```
+
+**After:**
+```
+graph TD
+    A --> B
+```
+
+## Why This Matters
+
+While `flowchart` works in many renderers, `graph` is more portable and renders consistently across different Mermaid implementations.

--- a/.github/scripts/docs/MM02.md
+++ b/.github/scripts/docs/MM02.md
@@ -1,0 +1,40 @@
+# MM02: Missing diagram direction
+
+The Mermaid diagram is missing a direction specifier.
+
+## Expected Format
+
+Include `TD` (top-down) or `LR` (left-right) after `graph`:
+
+```mermaid
+graph TD
+    A --> B
+```
+
+or
+
+```mermaid
+graph LR
+    A --> B
+```
+
+## How to Fix
+
+Add the direction to the graph declaration:
+
+**Before (invalid):**
+```
+graph
+    A --> B
+```
+
+**After:**
+```
+graph TD
+    A --> B
+```
+
+## Choosing Direction
+
+- **TD** (top-down): Use when dependencies span 5+ sequential levels (vertical is more readable)
+- **LR** (left-right): Use for simple diagrams with few sequential levels

--- a/.github/scripts/docs/MM03.md
+++ b/.github/scripts/docs/MM03.md
@@ -1,0 +1,43 @@
+# MM03: Edge inside subgraph
+
+An edge (arrow) is defined inside a subgraph block, which may not render correctly.
+
+## The Problem
+
+Edges defined inside subgraphs can cause rendering issues:
+
+```mermaid
+graph TD
+    subgraph Phase1
+        A --> B    <-- This edge is inside the subgraph
+    end
+```
+
+## How to Fix
+
+Move all edges outside of subgraph blocks:
+
+**Before (may not render):**
+```
+graph TD
+    subgraph Phase1
+        A["Task A"]
+        B["Task B"]
+        A --> B
+    end
+```
+
+**After (correct):**
+```
+graph TD
+    subgraph Phase1
+        A["Task A"]
+        B["Task B"]
+    end
+
+    A --> B
+```
+
+## Why This Matters
+
+Mermaid processes subgraphs and edges separately. Edges inside subgraphs may be ignored or cause rendering failures in some viewers.

--- a/.github/scripts/docs/MM04.md
+++ b/.github/scripts/docs/MM04.md
@@ -1,0 +1,46 @@
+# MM04: Class definition before edges
+
+A `classDef` or `class` statement appears before the diagram edges.
+
+## Expected Structure
+
+Class definitions should come at the end of the diagram:
+
+```mermaid
+graph TD
+    %% 1. Subgraphs with nodes
+    subgraph Phase1
+        A["Task A"]
+    end
+
+    %% 2. Edges
+    A --> B
+
+    %% 3. Class definitions (at the end)
+    classDef done fill:#c8e6c9
+    classDef ready fill:#bbdefb
+
+    class A done
+    class B ready
+```
+
+## How to Fix
+
+Move all `classDef` and `class` statements to the end of the diagram.
+
+**Before (wrong order):**
+```
+graph TD
+    classDef done fill:#c8e6c9
+    A --> B
+    class A done
+```
+
+**After:**
+```
+graph TD
+    A --> B
+
+    classDef done fill:#c8e6c9
+    class A done
+```

--- a/.github/scripts/docs/MM05.md
+++ b/.github/scripts/docs/MM05.md
@@ -1,0 +1,37 @@
+# MM05: Invalid status class
+
+A node is assigned an invalid class name.
+
+## Valid Classes
+
+| Class | Color | Meaning |
+|-------|-------|---------|
+| `done` | Green (#c8e6c9) | Issue is closed |
+| `ready` | Blue (#bbdefb) | Open, no blocking dependencies |
+| `blocked` | Yellow (#fff9c4) | Open, has open blockers |
+| `needsDesign` | Purple (#e1bee7) | Future work, not yet designed |
+
+## How to Fix
+
+Use one of the valid class names:
+
+**Before (invalid):**
+```
+class I123 complete
+```
+
+**After:**
+```
+class I123 done
+```
+
+## Class Definitions
+
+Include the standard class definitions in your diagram:
+
+```
+classDef done fill:#c8e6c9
+classDef ready fill:#bbdefb
+classDef blocked fill:#fff9c4
+classDef needsDesign fill:#e1bee7
+```

--- a/.github/scripts/docs/MM06.md
+++ b/.github/scripts/docs/MM06.md
@@ -1,0 +1,46 @@
+# MM06: Issue in table but not in diagram
+
+An issue appears in the Implementation Issues table but is missing from the Mermaid dependency diagram.
+
+## Expected Behavior
+
+Every issue in the table should have a corresponding node in the diagram:
+
+**Table:**
+```markdown
+| Issue | Title | Dependencies | Tier |
+|-------|-------|--------------|------|
+| [#123](url) | Task A | None | testable |
+| [#124](url) | Task B | [#123](url) | testable |
+```
+
+**Diagram:**
+```mermaid
+graph TD
+    I123["#123: Task A"]
+    I124["#124: Task B"]
+
+    I123 --> I124
+```
+
+## How to Fix
+
+Add the missing issue to the diagram:
+
+1. Create a node: `I<number>["#<number>: <short-title>"]`
+2. Add edges for dependencies
+3. Assign appropriate status class
+
+**Example:**
+```
+I123["#123: Add feature"]
+
+I122 --> I123
+
+class I123 ready
+```
+
+## Node Naming Convention
+
+- Node ID: `I<issue-number>` (e.g., `I123`)
+- Node label: `"#<N>: <title>"` (max 40 characters)

--- a/.github/scripts/docs/SC01.md
+++ b/.github/scripts/docs/SC01.md
@@ -1,0 +1,36 @@
+# SC01: Missing required section
+
+One or more required sections are missing from the design document.
+
+## Required Sections
+
+Design documents must have these 9 sections in order:
+
+1. `## Status`
+2. `## Context and Problem Statement`
+3. `## Decision Drivers`
+4. `## Considered Options`
+5. `## Decision Outcome`
+6. `## Solution Architecture`
+7. `## Implementation Approach`
+8. `## Security Considerations`
+9. `## Consequences`
+
+## How to Fix
+
+Add the missing section(s) with appropriate content.
+
+**Example - Adding a missing section:**
+```markdown
+## Security Considerations
+
+### Download Verification
+All binaries are verified via SHA256 checksums from official sources.
+
+### Execution Isolation
+Tools run with user permissions only; no sudo required.
+```
+
+## Note
+
+Section headers must match exactly, including capitalization. `## security considerations` is not valid.

--- a/.github/scripts/docs/SC02.md
+++ b/.github/scripts/docs/SC02.md
@@ -1,0 +1,49 @@
+# SC02: Wrong section order
+
+A section appears in the wrong position relative to other required sections.
+
+## Required Order
+
+Sections must appear in this order:
+
+1. `## Status`
+2. `## Context and Problem Statement`
+3. `## Decision Drivers`
+4. `## Considered Options`
+5. `## Decision Outcome`
+6. `## Solution Architecture`
+7. `## Implementation Approach`
+8. `## Security Considerations`
+9. `## Consequences`
+
+## How to Fix
+
+Move the section to its correct position in the document.
+
+**Example - Before (wrong order):**
+```markdown
+## Status
+...
+
+## Decision Outcome
+...
+
+## Context and Problem Statement  <-- This should come before Decision Outcome
+...
+```
+
+**Example - After:**
+```markdown
+## Status
+...
+
+## Context and Problem Statement
+...
+
+## Decision Outcome
+...
+```
+
+## Note
+
+Additional sections (like `## Implementation Issues`) can appear anywhere and don't affect ordering validation.

--- a/.github/scripts/docs/SC03.md
+++ b/.github/scripts/docs/SC03.md
@@ -1,0 +1,44 @@
+# SC03: Empty Security Considerations
+
+The Security Considerations section is empty or contains only "N/A".
+
+## Why This Matters
+
+For tsuku (a package manager that downloads and executes binaries), security analysis is mandatory. Every design must address how it handles:
+
+- **Download verification**: How are binaries validated?
+- **Execution isolation**: What permissions are required?
+- **Supply chain risks**: Where do binaries come from?
+- **User data exposure**: What data is accessed or transmitted?
+
+## How to Fix
+
+Add meaningful security analysis to the section.
+
+**Example - Before (invalid):**
+```markdown
+## Security Considerations
+
+N/A
+```
+
+**Example - After:**
+```markdown
+## Security Considerations
+
+### Download Verification
+All binaries are verified via SHA256 checksums published on the tool's official releases page.
+
+### Execution Isolation
+Installed tools run with user permissions only. No sudo or elevated privileges required.
+
+### Supply Chain Risks
+Downloads come directly from official GitHub releases. The recipe specifies exact version and checksum.
+
+### User Data Exposure
+This feature does not access or transmit any user data.
+```
+
+## Note
+
+If a dimension genuinely doesn't apply, explain why instead of writing "N/A".

--- a/.github/scripts/docs/SD01.md
+++ b/.github/scripts/docs/SD01.md
@@ -1,0 +1,36 @@
+# SD01: File in wrong directory
+
+The design document's status doesn't match its directory location.
+
+## Directory Mapping
+
+| Status | Required Directory |
+|--------|-------------------|
+| Proposed | `docs/designs/` |
+| Accepted | `docs/designs/` |
+| Planned | `docs/designs/` |
+| Current | `docs/designs/current/` |
+| Superseded | `docs/designs/archive/` |
+
+## How to Fix
+
+Move the file to the correct directory for its status.
+
+**Example - Status is "Current" but file is in wrong location:**
+```bash
+# Move from docs/designs/ to docs/designs/current/
+git mv docs/designs/DESIGN-feature.md docs/designs/current/DESIGN-feature.md
+```
+
+**Example - Status is "Superseded":**
+```bash
+# Move to archive
+git mv docs/designs/DESIGN-old-feature.md docs/designs/archive/DESIGN-old-feature.md
+```
+
+## Note
+
+The directories must exist. Create them if needed:
+```bash
+mkdir -p docs/designs/current docs/designs/archive
+```

--- a/.github/scripts/docs/SD02.md
+++ b/.github/scripts/docs/SD02.md
@@ -1,0 +1,35 @@
+# SD02: Superseded missing link
+
+A design document with status "Superseded" must include a link to the document that replaces it.
+
+## Expected Format
+
+The `## Status` section should contain a "Superseded by" line with a link:
+
+```markdown
+## Status
+
+Superseded by [DESIGN-new-approach.md](./DESIGN-new-approach.md)
+```
+
+## How to Fix
+
+Add the "Superseded by" line with a link to the new design document.
+
+**Example - Before (invalid):**
+```markdown
+## Status
+
+Superseded
+```
+
+**Example - After:**
+```markdown
+## Status
+
+Superseded by [DESIGN-v2-feature.md](./DESIGN-v2-feature.md)
+```
+
+## Note
+
+The link should be a relative path to the new design document. This helps readers understand the evolution of the design and find current documentation.

--- a/.github/scripts/get-github-status.sh
+++ b/.github/scripts/get-github-status.sh
@@ -81,7 +81,7 @@ case "$1" in
             echo '{"issues": {}, "milestones": {}}'
             exit 0
         }
-        INPUT_JSON=$(echo "$DESIGN_DATA" | jq '[.entries[] | {type, number, url}]')
+        INPUT_JSON=$(echo "$DESIGN_DATA" | jq '[.milestones[].entries[] | {type, number, url}]')
         ;;
     --stdin)
         INPUT_JSON=$(cat)

--- a/.github/workflows/validate-closing-issues.yml
+++ b/.github/workflows/validate-closing-issues.yml
@@ -1,0 +1,32 @@
+name: Validate Closing Issues in Design Docs
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate closing issues are marked complete
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number }}
+
+          echo "Checking that issues closed by PR #$PR_NUMBER are marked complete in all design docs..."
+
+          if ! .github/scripts/checks/strikethrough-all-docs.sh --pr "$PR_NUMBER" 2>&1; then
+            echo ""
+            echo "::error::Issues being closed are not marked complete in all design docs that reference them."
+            exit 1
+          fi
+
+          echo "All closing issues are properly marked in design docs"


### PR DESCRIPTION
Sync design document validation scripts from upstream. Adds error code documentation, strikethrough validation, and a new workflow for validating closing issues.

---

## Changes

**Validation check updates:**
- frontmatter.sh, implementation-issues.sh, issue-status.sh, sections.sh, status-directory.sh - Minor fixes

**New validation:**
- strikethrough-all-docs.sh - Validates strikethrough formatting across all docs
- validate-closing-issues.yml - New workflow to validate issues being closed

**Documentation:**
- Added error code docs (FM01-03, II01-05, MM01-06, SC01-03, SD01-02) explaining each validation check

**Refactoring:**
- extract-design-issues.sh - Significant refactor for improved parsing