### PR TITLE
docs: add design for registry recipe cache policy

### DIFF
--- a/docs/designs/DESIGN-recipe-registry-separation.md
+++ b/docs/designs/DESIGN-recipe-registry-separation.md
@@ -32,8 +32,8 @@ rationale: Location-based categorization is simplest. R2 storage scales to 10K+ 
 
 | Issue | Title | Dependencies | Tier | Status |
 |-------|-------|--------------|------|--------|
-| [M33 - Registry Cache Policy](https://github.com/tsukumogami/tsuku/milestone/48) | Implement registry recipe cache policy (7 issues) | [#1033](https://github.com/tsukumogami/tsuku/issues/1033) | milestone | |
-| [#1038](https://github.com/tsukumogami/tsuku/issues/1038) | Document recipe separation for contributors | [#1036](https://github.com/tsukumogami/tsuku/issues/1036), [M33](https://github.com/tsukumogami/tsuku/milestone/48) | simple | |
+| [Registry Cache Policy](https://github.com/tsukumogami/tsuku/milestone/48) | Implement registry recipe cache policy (7 issues) | [#1033](https://github.com/tsukumogami/tsuku/issues/1033) | milestone | |
+| [#1038](https://github.com/tsukumogami/tsuku/issues/1038) | Document recipe separation for contributors | [#1036](https://github.com/tsukumogami/tsuku/issues/1036), [Registry Cache Policy](https://github.com/tsukumogami/tsuku/milestone/48) | simple | |
 
 ### Future Work
 
@@ -57,7 +57,7 @@ graph TD
     end
 
     subgraph M32["M32: Cache Management and Documentation"]
-        M33["M33: Registry Cache Policy (7 issues)"]
+        M33["Registry Cache Policy (7 issues)"]
         I1038["#1038: Document recipe separation"]
     end
 

--- a/docs/designs/DESIGN-registry-cache-policy.md
+++ b/docs/designs/DESIGN-registry-cache-policy.md
@@ -13,7 +13,7 @@ rationale: Follows existing version cache patterns for consistency, provides bes
 
 ## Implementation Issues
 
-### Milestone: [M33 - Registry Cache Policy](https://github.com/tsukumogami/tsuku/milestone/48)
+### Milestone: [Registry Cache Policy](https://github.com/tsukumogami/tsuku/milestone/48)
 
 | Issue | Title | Dependencies | Tier |
 |-------|-------|--------------|------|


### PR DESCRIPTION
Add tactical design document for registry recipe cache policy and create implementation issues.

This design implements Stage 5 from the recipe registry separation design, addressing the cache policy requirements specified in Gap 5 (unbounded cache) and Gap 6 (undefined error messages).

Key design decisions:
- JSON sidecar metadata files matching existing version cache patterns
- Bounded stale-if-error fallback (7 days max) for network resilience
- Threshold-based LRU eviction (80%/60%) for disk space management
- Structured error types for programmatic handling

---

Closes #1037

## Created Artifacts

### Milestone: [Registry Cache Policy](https://github.com/tsukumogami/tsuku/milestone/48)

| Issue | Title | Dependencies |
|-------|-------|--------------|
| #1156 | Add registry cache metadata infrastructure | None |
| #1157 | Implement TTL-based cache expiration | #1156 |
| #1158 | Implement LRU cache size management | #1156 |
| #1159 | Add stale-if-error fallback | #1157 |
| #1160 | Enhance update-registry with status and selective refresh | #1157 |
| #1162 | Add cache cleanup command | #1158 |
| #1163 | Enhance cache info with registry statistics | #1158 |

## Next Steps

Start with issue #1156 (cache metadata infrastructure) which has no dependencies.