### PR TITLE
docs: apply M39 (Library Verification Level 3) completion changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ For libraries, verification includes multiple tiers:
   - System libraries (libc, libm, libSystem.B.dylib, etc.)
   - Tsuku-managed libraries (dependencies installed by tsuku)
   - Externally-managed libraries (from package managers like apt, brew)
+- **Tier 3: dlopen load testing** - Loads the library with dlopen() to verify it can be dynamically loaded at runtime
 
 Tier 2 validation also detects ABI mismatches (glibc vs musl) to catch incompatible binary combinations early.
 

--- a/cmd/tsuku/verify.go
+++ b/cmd/tsuku/verify.go
@@ -824,8 +824,10 @@ For libraries, verification is tiered:
           shared libraries (ELF or Mach-O) for the current platform
   Tier 2: Dependency checking - validates dynamic library dependencies
           are satisfied (system libs, tsuku-managed, or externally-managed)
-  Tier 3: dlopen load testing (not yet implemented)
-  Tier 4: Integrity verification (not yet implemented)
+  Tier 3: dlopen load testing - loads the library with dlopen() to verify
+          it can be dynamically loaded and all dependencies are satisfied
+  Tier 4: Integrity verification - compares current SHA256 checksums
+          against those stored at installation time
 
   Flags:
     --integrity     Enable checksum verification (Tier 4)

--- a/docs/designs/current/DESIGN-library-verify-dlopen.md
+++ b/docs/designs/current/DESIGN-library-verify-dlopen.md
@@ -1,5 +1,5 @@
 ---
-status: Planned
+status: Current
 problem: Levels 1-2 of library verification can't confirm a library will actually load; only dlopen() can test this, but it requires native code which conflicts with tsuku's CGO_ENABLED=0 build.
 decision: Use a dedicated Rust helper binary (tsuku-dltest) with JSON protocol and batched invocation.
 rationale: Rust provides memory-safe dlopen bindings, simpler cross-compilation than Go+cgo, and a small binary (~400KB). Implementation requires a separate release process design for multi-platform native builds.
@@ -9,7 +9,7 @@ rationale: Rust provides memory-safe dlopen bindings, simpler cross-compilation 
 
 ## Status
 
-Planned
+Current
 
 ## Implementation Issues
 


### PR DESCRIPTION
Update documentation to reflect implemented Tier 3/4 verification for the Library Verification Level 3 (dlopen) milestone.

---

## Summary

- Update verify.go help text to describe Tier 3 (dlopen) and Tier 4 (integrity) as implemented, removing stale "not yet implemented" markers
- Add Tier 3 (dlopen load testing) description to README verification section
- Transition DESIGN-library-verify-dlopen.md to Current status and move to docs/designs/current/

## Validation

All M39 milestone issues (7 total) are closed. Milestone completion validation passed:
- Design goals: All implemented
- Dead code: None found
- Metadata: Clean