### PR TITLE
docs: mark M39 (Tier 3 dlopen) as complete in umbrella design

### DIFF
--- a/docs/designs/DESIGN-library-verification.md
+++ b/docs/designs/DESIGN-library-verification.md
@@ -22,8 +22,8 @@ Planned
 | ~~[#948](https://github.com/tsukumogami/tsuku/issues/948)~~ | ~~docs: design dependency resolution for library verification (Tier 2)~~ | ~~[#947](https://github.com/tsukumogami/tsuku/issues/947)~~ | ~~critical~~ |
 | ~~[M38](https://github.com/tsukumogami/tsuku/milestone/38)~~ | ~~Tier 2 Dependency Validation (12 issues)~~ | ~~[#948](https://github.com/tsukumogami/tsuku/issues/948)~~ | ~~milestone~~ |
 | ~~[#949](https://github.com/tsukumogami/tsuku/issues/949)~~ | ~~docs: design dlopen load testing for library verification (Tier 3)~~ | ~~[M38](https://github.com/tsukumogami/tsuku/milestone/38)~~ | ~~critical~~ |
-| [M39](https://github.com/tsukumogami/tsuku/milestone/39) | Tier 3 dlopen Verification (7 issues) | [#949](https://github.com/tsukumogami/tsuku/issues/949) | milestone |
-| [#950](https://github.com/tsukumogami/tsuku/issues/950) | docs: design integrity verification for library verification (Tier 4) | [#946](https://github.com/tsukumogami/tsuku/issues/946), [M39](https://github.com/tsukumogami/tsuku/milestone/39) | testable |
+| ~~[M39](https://github.com/tsukumogami/tsuku/milestone/39)~~ | ~~Tier 3 dlopen Verification (7 issues)~~ | ~~[#949](https://github.com/tsukumogami/tsuku/issues/949)~~ | ~~milestone~~ |
+| [#950](https://github.com/tsukumogami/tsuku/issues/950) | docs: design integrity verification for library verification (Tier 4) | ~~[#946](https://github.com/tsukumogami/tsuku/issues/946)~~, ~~[M39](https://github.com/tsukumogami/tsuku/milestone/39)~~ | testable |
 
 ```mermaid
 graph TD
@@ -38,7 +38,7 @@ graph TD
         I948["#948 Tier 2 Design<br/>(done)"]:::done
         M38["M38: Tier 2 Implementation<br/>(done)"]:::done
         I949["#949 Tier 3 Design<br/>(done)"]:::done
-        M39["M39: Tier 3 Implementation<br/>(in progress)"]:::ready
+        M39["M39: Tier 3 Implementation<br/>(done)"]:::done
         I950["#950 Tier 4 Design<br/>(needs-design)"]:::needsdesign
     end
 


### PR DESCRIPTION
Update DESIGN-library-verification.md to reflect M39 milestone completion.

---

## Summary

Marks M39 (Library Verification Level 3 - dlopen) as complete in the umbrella design document:
- Strike through M39 row in Implementation Issues table
- Update Mermaid diagram node to show "done" status with green color

Follows up on PR #1154 which completed the M39 milestone.