### PR TITLE
docs(design): add Tier 4 integrity verification design

### DIFF
--- a/docs/designs/DESIGN-library-verification.md
+++ b/docs/designs/DESIGN-library-verification.md
@@ -24,6 +24,7 @@ Planned
 | ~~[#949](https://github.com/tsukumogami/tsuku/issues/949)~~ | ~~docs: design dlopen load testing for library verification (Tier 3)~~ | ~~[M38](https://github.com/tsukumogami/tsuku/milestone/38)~~ | ~~critical~~ |
 | ~~[M39](https://github.com/tsukumogami/tsuku/milestone/39)~~ | ~~Tier 3 dlopen Verification (7 issues)~~ | ~~[#949](https://github.com/tsukumogami/tsuku/issues/949)~~ | ~~milestone~~ |
 | ~~[#950](https://github.com/tsukumogami/tsuku/issues/950)~~ | ~~docs: design integrity verification for library verification (Tier 4)~~ | ~~[#946](https://github.com/tsukumogami/tsuku/issues/946)~~, ~~[M39](https://github.com/tsukumogami/tsuku/milestone/39)~~ | ~~testable~~ |
+| [M49](https://github.com/tsukumogami/tsuku/milestone/49) | Tier 4 Implementation (3 issues) | [#950](https://github.com/tsukumogami/tsuku/issues/950) | milestone |
 
 ```mermaid
 graph TD
@@ -40,6 +41,7 @@ graph TD
         I949["#949 Tier 3 Design<br/>(done)"]:::done
         M39["M39: Tier 3 Implementation<br/>(done)"]:::done
         I950["#950 Tier 4 Design<br/>(done)"]:::done
+        M49["M49: Tier 4 Implementation<br/>(ready)"]:::ready
     end
 
     I942 --> I946
@@ -50,6 +52,7 @@ graph TD
     I949 --> M39
     I946 --> I950
     M39 --> I950
+    I950 --> M49
 
     classDef done fill:#2da44e,color:white
     classDef ready fill:#0969da,color:white

--- a/docs/designs/DESIGN-library-verify-integrity.md
+++ b/docs/designs/DESIGN-library-verify-integrity.md
@@ -1,5 +1,5 @@
 ---
-status: Accepted
+status: Planned
 problem: Libraries can be modified after installation (malware injection, disk corruption, unauthorized changes) but tsuku verify's Tiers 1-3 only check validity and loadability, not whether files match their original state.
 decision: Add optional Tier 4 integrity verification that compares SHA256 checksums of library files against values stored at installation time, enabled via the --integrity flag.
 rationale: This follows the proven pattern from binary checksum verification (DESIGN-checksum-pinning.md), reuses existing checksum infrastructure, and complements rather than duplicates Tiers 1-3. Making it opt-in keeps default verification fast while giving security-conscious users tamper detection.
@@ -9,7 +9,39 @@ rationale: This follows the proven pattern from binary checksum verification (DE
 
 ## Status
 
-Accepted
+Planned
+
+## Implementation Issues
+
+### Milestone: [Tier 4 Integrity Verification](https://github.com/tsukumogami/tsuku/milestone/49)
+
+| Issue | Title | Dependencies | Tier |
+|-------|-------|--------------|------|
+| [#1168](https://github.com/tsukumogami/tsuku/issues/1168) | feat(verify): add integrity verification module for Tier 4 | None | testable |
+| [#1169](https://github.com/tsukumogami/tsuku/issues/1169) | test(verify): add comprehensive tests for integrity verification | [#1168](https://github.com/tsukumogami/tsuku/issues/1168) | testable |
+| [#1170](https://github.com/tsukumogami/tsuku/issues/1170) | docs(verify): update documentation for Tier 4 integrity verification | [#1168](https://github.com/tsukumogami/tsuku/issues/1168) | simple |
+
+### Dependency Graph
+
+```mermaid
+graph LR
+    I1168["#1168: Add integrity verification module"]
+    I1169["#1169: Add comprehensive tests"]
+    I1170["#1170: Update documentation"]
+
+    I1168 --> I1169
+    I1168 --> I1170
+
+    classDef done fill:#c8e6c9
+    classDef ready fill:#bbdefb
+    classDef blocked fill:#fff9c4
+    classDef needsDesign fill:#e1bee7
+
+    class I1168 ready
+    class I1169,I1170 blocked
+```
+
+**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design
 
 ## Upstream Design Reference
 


### PR DESCRIPTION
Add DESIGN-library-verify-integrity.md proposing Tier 4 integrity verification
for the library verification system. This is the final tier, enabling optional
SHA256 checksum comparison against values stored at installation time.

Tier 4 answers "has this library been modified since installation?" while
Tiers 1-3 answer "is this library valid and loadable?" Verification is opt-in
via the `--integrity` flag to keep default verification fast.

---

## Design Highlights

**Chosen Approach: Checksum Only Stored Files**

Verify only files that have checksums in `LibraryVersionState.Checksums`:
- Exact match between stored and verified
- Handles pre-existing libraries gracefully (skip with informative message)
- Follows symlink chains to checksum real files
- Aligns with binary verification patterns from DESIGN-checksum-pinning.md

**Key Components:**
- New `internal/verify/integrity.go` module
- Integration in verify command after Tier 3
- Output format consistent with other tiers

**Scope Boundary:**
- Only tsuku-managed libraries in `$TSUKU_HOME/libs/` are verified
- External dependencies (apt, dnf, brew) are the package manager's responsibility

Fixes #950