### PR TITLE
feat(create): register CPAN builder in builder registry

### DIFF
--- a/cmd/tsuku/create.go
+++ b/cmd/tsuku/create.go
@@ -65,6 +65,7 @@ Supported sources:
   pypi                Python packages from pypi.org
   npm                 Node.js packages from npmjs.com
   go:module           Go modules from proxy.golang.org
+  cpan                Perl distributions from metacpan.org
   github:owner/repo      GitHub releases (uses LLM to analyze assets)
   homebrew:formula       Homebrew formulas (uses LLM to generate recipes)
   homebrew:formula:source  Force source build even if bottles available
@@ -79,6 +80,7 @@ Examples:
   tsuku create gh --from github:cli/cli
   tsuku create age --from github:FiloSottile/age
   tsuku create lazygit --from go:github.com/jesseduffield/lazygit
+  tsuku create ack --from cpan
   tsuku create jq --from homebrew:jq
   tsuku create ripgrep --from homebrew:ripgrep
   tsuku create vscode --from cask:visual-studio-code
@@ -170,6 +172,8 @@ func normalizeEcosystem(name string) string {
 		return "npm"
 	case "go", "golang", "goproxy":
 		return "go"
+	case "cpan", "metacpan", "perl":
+		return "cpan"
 	default:
 		return normalized
 	}
@@ -207,6 +211,7 @@ func runCreate(cmd *cobra.Command, args []string) {
 	builderRegistry.Register(builders.NewPyPIBuilder(nil))
 	builderRegistry.Register(builders.NewNpmBuilder(nil))
 	builderRegistry.Register(builders.NewGoBuilder(nil))
+	builderRegistry.Register(builders.NewCPANBuilder(nil))
 	builderRegistry.Register(builders.NewGitHubReleaseBuilder())
 	builderRegistry.Register(builders.NewHomebrewBuilder())
 	builderRegistry.Register(builders.NewCaskBuilder(nil))

--- a/internal/builders/cpan.go
+++ b/internal/builders/cpan.go
@@ -62,10 +62,15 @@ func (b *CPANBuilder) Name() string {
 	return "cpan"
 }
 
+// RequiresLLM returns false as this builder uses ecosystem APIs, not LLM.
+func (b *CPANBuilder) RequiresLLM() bool {
+	return false
+}
+
 // CanBuild checks if the distribution exists on MetaCPAN
-func (b *CPANBuilder) CanBuild(ctx context.Context, packageName string) (bool, error) {
+func (b *CPANBuilder) CanBuild(ctx context.Context, req BuildRequest) (bool, error) {
 	// Normalize module name to distribution name if needed
-	distribution := normalizeToDistribution(packageName)
+	distribution := normalizeToDistribution(req.Package)
 
 	if !isValidCPANDistribution(distribution) {
 		return false, nil
@@ -82,6 +87,11 @@ func (b *CPANBuilder) CanBuild(ctx context.Context, packageName string) (bool, e
 	}
 
 	return true, nil
+}
+
+// NewSession creates a new build session for the given request.
+func (b *CPANBuilder) NewSession(ctx context.Context, req BuildRequest, opts *SessionOptions) (BuildSession, error) {
+	return NewDeterministicSession(b.Build, req), nil
 }
 
 // Build generates a recipe for the CPAN distribution

--- a/internal/builders/cpan_test.go
+++ b/internal/builders/cpan_test.go
@@ -36,7 +36,7 @@ func TestCPANBuilder_CanBuild_ValidDistribution(t *testing.T) {
 	builder := NewCPANBuilderWithBaseURL(nil, server.URL)
 	ctx := context.Background()
 
-	canBuild, err := builder.CanBuild(ctx, "App-Ack")
+	canBuild, err := builder.CanBuild(ctx, BuildRequest{Package: "App-Ack"})
 	if err != nil {
 		t.Fatalf("CanBuild() error = %v", err)
 	}
@@ -68,7 +68,7 @@ func TestCPANBuilder_CanBuild_ModuleName(t *testing.T) {
 	ctx := context.Background()
 
 	// Pass module name with ::
-	canBuild, err := builder.CanBuild(ctx, "App::Ack")
+	canBuild, err := builder.CanBuild(ctx, BuildRequest{Package: "App::Ack"})
 	if err != nil {
 		t.Fatalf("CanBuild() error = %v", err)
 	}
@@ -86,7 +86,7 @@ func TestCPANBuilder_CanBuild_NotFound(t *testing.T) {
 	builder := NewCPANBuilderWithBaseURL(nil, server.URL)
 	ctx := context.Background()
 
-	canBuild, err := builder.CanBuild(ctx, "Nonexistent-Distribution")
+	canBuild, err := builder.CanBuild(ctx, BuildRequest{Package: "Nonexistent-Distribution"})
 	if err != nil {
 		t.Fatalf("CanBuild() error = %v", err)
 	}
@@ -100,7 +100,7 @@ func TestCPANBuilder_CanBuild_InvalidName(t *testing.T) {
 	ctx := context.Background()
 
 	// Invalid distribution name should return false without making any HTTP requests
-	canBuild, err := builder.CanBuild(ctx, "invalid distribution!")
+	canBuild, err := builder.CanBuild(ctx, BuildRequest{Package: "invalid distribution!"})
 	if err != nil {
 		t.Fatalf("CanBuild() error = %v", err)
 	}


### PR DESCRIPTION
Add SessionBuilder interface methods to CPANBuilder and register it in the create command, enabling `tsuku create <tool> --from cpan` to generate recipes for Perl distributions from metacpan.org.

---

## What This Accomplishes

Registers the CPAN builder with the builder registry so users can create recipes for Perl CPAN distributions. The builder queries metacpan.org for distribution metadata and generates `cpan_install` recipes.

Changes:
- Add `RequiresLLM()` returning false (uses ecosystem API, no LLM)
- Add `NewSession()` returning DeterministicSession wrapper
- Update `CanBuild()` signature to accept `BuildRequest`
- Register CPANBuilder in `cmd/tsuku/create.go`
- Add ecosystem aliases: `cpan`, `metacpan`, `perl`
- Update command help text with CPAN example

## Test Plan

- [x] Unit tests pass: `go test ./internal/builders/... -run CPAN`
- [x] Full test suite passes: `go test -test.short ./...`
- [x] Build succeeds: `go build ./cmd/tsuku`

Fixes #1181