### PR TITLE
docs: complete milestone M48 Registry Cache Policy

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -70,6 +70,53 @@ Enable telemetry debug mode.
 
 When set, telemetry events are printed to stderr instead of being sent to the telemetry server. Useful for seeing what data would be collected without actually sending it.
 
+## Recipe Cache
+
+These variables control the behavior of the recipe cache, which stores downloaded recipes locally to reduce network requests and provide offline capabilities.
+
+### TSUKU_RECIPE_CACHE_TTL
+
+Time duration until a cached recipe is considered stale and needs refresh.
+
+- **Default:** `24h`
+- **Valid range:** `1m` to `720h` (30 days)
+- **Format:** Go duration string (e.g., `1h`, `24h`, `7d`)
+- **Example:** `export TSUKU_RECIPE_CACHE_TTL=12h`
+
+After this duration, tsuku will attempt to refresh the recipe from the registry on next access. If the refresh fails, stale-if-error fallback may serve the cached version.
+
+### TSUKU_RECIPE_CACHE_SIZE_LIMIT
+
+Maximum total size of the recipe cache before LRU eviction is triggered.
+
+- **Default:** `50MB` (52428800 bytes)
+- **Valid range:** `1MB` to `1GB`
+- **Format:** Integer (bytes) or size string (e.g., `50MB`, `100MB`)
+- **Example:** `export TSUKU_RECIPE_CACHE_SIZE_LIMIT=100MB`
+
+When the cache exceeds 80% of this limit, least-recently-used entries are evicted until the cache is below 60%.
+
+### TSUKU_RECIPE_CACHE_MAX_STALE
+
+Maximum age for a cached recipe to be used as a stale-if-error fallback when the registry is unavailable.
+
+- **Default:** `168h` (7 days)
+- **Valid range:** `1h` to `720h` (30 days)
+- **Format:** Go duration string (e.g., `24h`, `168h`)
+- **Example:** `export TSUKU_RECIPE_CACHE_MAX_STALE=72h`
+
+If a registry request fails and the cached recipe is within this age limit, tsuku will use the cached version with a warning. This provides resilience against temporary network issues.
+
+### TSUKU_RECIPE_CACHE_STALE_FALLBACK
+
+Enable or disable stale-if-error fallback behavior.
+
+- **Default:** `true`
+- **Valid values:** `true`, `false`, `1`, `0`
+- **Example:** `export TSUKU_RECIPE_CACHE_STALE_FALLBACK=false`
+
+When enabled, tsuku will fall back to cached recipes when the registry is unavailable (subject to `TSUKU_RECIPE_CACHE_MAX_STALE`). Disable this for strict freshness requirements.
+
 ## Development and Debugging
 
 ### TSUKU_DEBUG
@@ -110,6 +157,10 @@ To create a token:
 | `TSUKU_HOME` | `~/.tsuku` | Base directory for tsuku data |
 | `TSUKU_API_TIMEOUT` | `30s` | HTTP API request timeout |
 | `TSUKU_REGISTRY_URL` | GitHub | Remote registry URL |
+| `TSUKU_RECIPE_CACHE_TTL` | `24h` | Recipe cache freshness duration |
+| `TSUKU_RECIPE_CACHE_SIZE_LIMIT` | `50MB` | Recipe cache size limit |
+| `TSUKU_RECIPE_CACHE_MAX_STALE` | `168h` | Maximum stale cache age for fallback |
+| `TSUKU_RECIPE_CACHE_STALE_FALLBACK` | `true` | Enable stale-if-error fallback |
 | `TSUKU_NO_TELEMETRY` | (unset) | Disable telemetry when set |
 | `TSUKU_TELEMETRY_DEBUG` | (unset) | Print telemetry to stderr |
 | `TSUKU_DEBUG` | (unset) | Enable verbose debug output |

--- a/docs/designs/current/DESIGN-registry-cache-policy.md
+++ b/docs/designs/current/DESIGN-registry-cache-policy.md
@@ -1,5 +1,5 @@
 ---
-status: Planned
+status: Current
 problem: The registry recipe cache stores recipes indefinitely with no TTL, no size limits, and no metadata tracking, causing network failures to result in hard failures instead of graceful degradation.
 decision: Implement TTL-based caching with JSON metadata sidecars, stale-if-error fallback, and LRU eviction.
 rationale: Follows existing version cache patterns for consistency, provides best user experience during network issues, and enables configurable cache management.
@@ -9,7 +9,7 @@ rationale: Follows existing version cache patterns for consistency, provides bes
 
 ## Status
 
-**Planned**
+**Current**
 
 ## Implementation Issues
 


### PR DESCRIPTION
Milestone M48 (Registry Cache Policy) is now complete with all 7 issues implemented and merged.

This commit finalizes the milestone by transitioning the design doc from Planned to Current status, moving it to the current/ directory, and adding the 4 new cache environment variables to ENVIRONMENT.md.

---

## Summary

- Design doc status: Planned → Current
- Design doc location: `docs/designs/` → `docs/designs/current/`
- Added 4 environment variables to ENVIRONMENT.md:
  - `TSUKU_RECIPE_CACHE_TTL`
  - `TSUKU_RECIPE_CACHE_SIZE_LIMIT`
  - `TSUKU_RECIPE_CACHE_MAX_STALE`
  - `TSUKU_RECIPE_CACHE_STALE_FALLBACK`

## Milestone Issues

All 7 issues are closed:
- #1156: Add registry cache metadata infrastructure
- #1157: Implement TTL-based cache expiration
- #1158: Implement LRU cache size management
- #1159: Add stale-if-error fallback
- #1160: Enhance update-registry with status and selective refresh
- #1162: Add cache cleanup command
- #1163: Enhance cache info with registry statistics