### PR TITLE
chore(ci): update design doc validation

### DIFF
--- a/.github/scripts/checks/common.sh
+++ b/.github/scripts/checks/common.sh
@@ -31,9 +31,14 @@ readonly EXIT_PASS=0
 readonly EXIT_FAIL=1
 readonly EXIT_ERROR=2
 
-# emit_pass - Output a passing check message
+# Quiet mode - when set to 1, suppress [PASS] messages
+# Can be set via: export QUIET_MODE=1
+: "${QUIET_MODE:=0}"
+
+# emit_pass - Output a passing check message (suppressed in quiet mode)
 # Usage: emit_pass "Check passed"
 emit_pass() {
+    [[ "$QUIET_MODE" -eq 1 ]] && return 0
     echo "[PASS] $1"
 }
 

--- a/.github/scripts/checks/mermaid.sh
+++ b/.github/scripts/checks/mermaid.sh
@@ -20,9 +20,10 @@
 #   MM15: Class must match actual issue status (requires gh CLI)
 #
 # Usage:
-#   mermaid.sh [--skip-status-check] <doc-path>
+#   mermaid.sh [-q|--quiet] [--skip-status-check] <doc-path>
 #
 # Options:
+#   -q, --quiet          Suppress [PASS] messages, only show failures
 #   --skip-status-check  Skip MM15 (GitHub API status validation)
 #
 # Exit codes:
@@ -51,6 +52,10 @@ DOC_PATH=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
+        -q|--quiet)
+            export QUIET_MODE=1
+            shift
+            ;;
         --skip-status-check)
             SKIP_STATUS_CHECK=1
             shift

--- a/.github/workflows/validate-closing-issues.yml
+++ b/.github/workflows/validate-closing-issues.yml
@@ -21,12 +21,8 @@ jobs:
         run: |
           PR_NUMBER=${{ github.event.pull_request.number }}
 
-          echo "Checking that issues closed by PR #$PR_NUMBER are marked complete in all design docs..."
-
           if ! .github/scripts/checks/strikethrough-all-docs.sh --pr "$PR_NUMBER" 2>&1; then
-            echo ""
             echo "::error::Issues being closed are not marked complete in all design docs that reference them."
             exit 1
           fi
-
           echo "All closing issues are properly marked in design docs"

--- a/.github/workflows/validate-design-docs.yml
+++ b/.github/workflows/validate-design-docs.yml
@@ -32,14 +32,13 @@ jobs:
           FAILED=0
           while IFS= read -r file; do
             [ -z "$file" ] && continue
-            echo "---"
-            if ! .github/scripts/validate-design-doc.sh "$file"; then
+            if ! .github/scripts/validate-design-doc.sh -q "$file"; then
               FAILED=1
             fi
           done <<< "${{ steps.find.outputs.files }}"
 
           if [ "$FAILED" -eq 1 ]; then
-            echo "---"
             echo "One or more design docs failed validation"
             exit 1
           fi
+          echo "All design docs valid"

--- a/.github/workflows/validate-diagram-classes.yml
+++ b/.github/workflows/validate-diagram-classes.yml
@@ -30,9 +30,6 @@ jobs:
             'docs/designs/DESIGN-*.md' \
             'docs/designs/current/DESIGN-*.md' 2>/dev/null || true)
 
-          echo "Changed design docs:"
-          echo "$CHANGED"
-
           # Save for next step
           echo "docs<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGED" >> $GITHUB_OUTPUT
@@ -52,33 +49,27 @@ jobs:
             [[ -z "$doc" ]] && continue
             [[ ! -f "$doc" ]] && continue
 
-            echo "Checking $doc..."
-
             # Skip if no mermaid diagram
             if ! grep -q '```mermaid' "$doc"; then
-              echo "  No Mermaid diagram, skipping"
               continue
             fi
 
             # Skip archived/superseded docs
             STATUS=$(get_frontmatter_status "$doc")
             if [[ "$STATUS" == "Superseded" ]]; then
-              echo "  Superseded document, skipping"
               continue
             fi
 
-            # Run MM15 validation (without --skip-status-check)
-            if ! .github/scripts/checks/mermaid.sh "$doc"; then
+            # Run MM15 validation (without --skip-status-check, with quiet mode)
+            if ! .github/scripts/checks/mermaid.sh -q "$doc"; then
               echo "::error file=$doc::Diagram class validation failed (MM15)"
               FAILED=1
             fi
           done <<< "${{ steps.changed.outputs.docs }}"
 
           if [[ $FAILED -eq 1 ]]; then
-            echo ""
             echo "One or more design docs have incorrect diagram classes."
             echo "Update the Mermaid diagram class assignments to match issue status."
             exit 1
           fi
-
-          echo "All changed design docs have correct diagram classes"
+          echo "All diagram classes valid"

--- a/.github/workflows/validate-diagram-status.yml
+++ b/.github/workflows/validate-diagram-status.yml
@@ -25,7 +25,6 @@ jobs:
           # Use existing script to extract closing issues, compact to single line
           ISSUES=$(.github/scripts/extract-closing-issues.sh --pr "$PR_NUMBER" | jq -c '.')
           echo "issues=$ISSUES" >> $GITHUB_OUTPUT
-          echo "Closing issues: $ISSUES"
 
       - name: Validate diagram status for closed issues
         if: steps.closed-issues.outputs.issues != '[]'
@@ -37,25 +36,15 @@ jobs:
 
           # Parse JSON array to iterate over issue numbers
           for issue_num in $(echo "$ISSUES" | jq -r '.[]'); do
-            echo "Checking issue #$issue_num..."
-
             # Find all design docs referencing this issue in Implementation Issues section
             # Search both active and current design doc directories
             DOCS=$(grep -l "\[#${issue_num}\]" docs/designs/DESIGN-*.md docs/designs/current/DESIGN-*.md 2>/dev/null || true)
 
-            if [[ -z "$DOCS" ]]; then
-              echo "  No design docs reference issue #$issue_num, skipping"
-              continue
-            fi
+            [[ -z "$DOCS" ]] && continue
 
             for doc in $DOCS; do
-              echo "  Checking $doc..."
-
               # Skip docs without mermaid diagrams
-              if ! grep -q '```mermaid' "$doc"; then
-                echo "    No Mermaid diagram in $doc, skipping"
-                continue
-              fi
+              grep -q '```mermaid' "$doc" || continue
 
               # Verify issue is marked as 'done' in the Mermaid diagram
               if ! .github/scripts/check-issue-status.sh "$doc" "$issue_num" "done"; then
@@ -66,10 +55,8 @@ jobs:
           done
 
           if [[ $FAILED -eq 1 ]]; then
-            echo ""
             echo "Some issues being closed are not marked 'done' in their design doc diagrams."
             echo "Update the Mermaid diagram class assignments before merging."
             exit 1
           fi
-
           echo "All closing issues have correct status in design docs"


### PR DESCRIPTION
Update design document validation scripts and workflow.

---

## What This Changes

- `.github/scripts/validate-design-doc.sh` - Orchestrator that runs modular validation checks
- `.github/scripts/checks/` - Modular check scripts (common.sh, frontmatter.sh, etc.)
- `.github/workflows/validate-design-docs.yml` - Runs validation on all PRs

## How It Works

The workflow finds all DESIGN-*.md files in the repo and validates each one:
- Location: must be under docs/designs/
- Naming: must start with DESIGN-
- Frontmatter: must have valid YAML frontmatter