### PR TITLE
chore(ci): update design doc validation

### DIFF
--- a/.github/scripts/checks/mermaid.sh
+++ b/.github/scripts/checks/mermaid.sh
@@ -424,10 +424,23 @@ if [[ "$SKIP_STATUS_CHECK" -eq 0 ]] && command -v gh &>/dev/null && [[ -n "$DIAG
             fi
         fi
 
+        # Build reason string for error context
+        REASON=""
+        if [[ "$ISSUE_STATE" == "CLOSED" ]]; then
+            REASON="(issue is closed)"
+        elif [[ "$HAS_OPEN_BLOCKER" == "true" ]]; then
+            # Format blocker list as "#123, #456"
+            REASON="(blocked by $(echo "$BLOCKER_LIST" | sed 's/I\([0-9]*\)/#\1/g; s/ /, /g'))"
+        elif [[ "$HAS_NEEDS_DESIGN" == "true" ]]; then
+            REASON="(is not blocked and has 'needs-design' label)"
+        else
+            REASON="(issue is open, no blocking dependencies)"
+        fi
+
         # Compare with actual class
         ACTUAL="${ACTUAL_CLASS[$node]:-}"
         if [[ -n "$EXPECTED_CLASS" && -n "$ACTUAL" && "$ACTUAL" != "$EXPECTED_CLASS" ]]; then
-            emit_fail "MM15: Node $node has class '$ACTUAL' but issue #$ISSUE_NUM status requires '$EXPECTED_CLASS'. See: .github/scripts/docs/MM15.md"
+            emit_fail "MM15: Node $node has class '$ACTUAL' but issue #$ISSUE_NUM requires '$EXPECTED_CLASS' $REASON. See: .github/scripts/docs/MM15.md"
             FAILED=1
         fi
     done <<< "$DIAGRAM_NODES"


### PR DESCRIPTION
Update design document validation scripts and workflow.

---

## What This Changes

- `.github/scripts/validate-design-doc.sh` - Orchestrator that runs modular validation checks
- `.github/scripts/checks/` - Modular check scripts (common.sh, frontmatter.sh, etc.)
- `.github/workflows/validate-design-docs.yml` - Runs validation on all PRs

## How It Works

The workflow finds all DESIGN-*.md files in the repo and validates each one:
- Location: must be under docs/designs/
- Naming: must start with DESIGN-
- Frontmatter: must have valid YAML frontmatter