### PR TITLE
chore(ci): update design doc validation

### DIFF
--- a/.github/scripts/docs/MM10.md
+++ b/.github/scripts/docs/MM10.md
@@ -4,20 +4,19 @@ A node in the Mermaid diagram doesn't follow the required naming convention.
 
 ## Required Format
 
-All issue nodes must be named `I<issue-number>`:
-- `I123` for issue #123
-- `I404` for issue #404
-- `I1` for issue #1
+All nodes must use one of these naming conventions:
+- `I<issue-number>` for issues (e.g., `I123`, `I404`, `I1`)
+- `M<milestone-number>` for milestones (e.g., `M38`, `M1`)
 
 ## Why This Matters
 
 - Consistent naming enables tooling to update diagrams automatically
-- The `I` prefix clearly identifies issue nodes vs other diagram elements
-- Issue number in the ID allows cross-referencing with the table
+- The `I` prefix identifies issue nodes, `M` prefix identifies milestone nodes
+- The number in the ID allows cross-referencing with tables and GitHub
 
 ## How to Fix
 
-Rename nodes to follow the `I<number>` convention:
+Rename nodes to follow the `I<number>` or `M<number>` convention:
 
 **Before (invalid):**
 ```mermaid
@@ -31,6 +30,7 @@ graph TD
 graph TD
     I123["#123: Add feature"]
     I124["#124: Another task"]
+    M38["M38: Downstream milestone"]
 ```
 
 ## Node Labels
@@ -41,5 +41,5 @@ The node ID is the part before the brackets. The label inside brackets can be an
 I123["#123: Short description"]
  ^       ^
  |       +-- Label (displayed)
- +---------- Node ID (must be I<number>)
+ +---------- Node ID (must be I<number> or M<number>)
 ```


### PR DESCRIPTION
Update design document validation scripts and workflow.

---

## What This Changes

- `.github/scripts/validate-design-doc.sh` - Orchestrator that runs modular validation checks
- `.github/scripts/checks/` - Modular check scripts (common.sh, frontmatter.sh, etc.)
- `.github/workflows/validate-design-docs.yml` - Runs validation on all PRs

## How It Works

The workflow finds all DESIGN-*.md files in the repo and validates each one:
- Location: must be under docs/designs/
- Naming: must start with DESIGN-
- Frontmatter: must have valid YAML frontmatter