### PR TITLE
feat(data): add priority queue and failure record schemas

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -27,3 +27,17 @@ Maps ecosystem-specific dependency names to tsuku recipe names. Used by the batc
 - Add new entries when the batch pipeline encounters unmapped dependencies
 - Change `"pending"` to a recipe name when the corresponding recipe is added
 - Multiple ecosystem names can map to the same tsuku recipe (e.g., `sqlite3` and `sqlite` both map to `sqlite`)
+
+### schemas/
+
+JSON Schema (draft-07) definitions for data files:
+
+- **priority-queue.schema.json** - Validates `data/priority-queue.json`. Defines the package queue structure with tiered priority (1-3), status tracking, and source metadata.
+- **failure-record.schema.json** - Validates `data/failures/*.json`. Defines per-ecosystem-environment failure records with categorized failure types and optional `blocked_by` dependencies.
+
+### examples/
+
+Sample data files demonstrating valid structure:
+
+- **priority-queue.json** - Example priority queue with packages at each tier level
+- **failure-record.json** - Example failure records showing different failure categories

--- a/data/examples/failure-record.json
+++ b/data/examples/failure-record.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": 1,
+  "ecosystem": "homebrew",
+  "environment": "linux-glibc",
+  "updated_at": "2026-01-27T10:00:00Z",
+  "failures": [
+    {
+      "package_id": "homebrew:imagemagick",
+      "category": "missing_dep",
+      "blocked_by": ["libpng", "libjpeg-turbo"],
+      "message": "Depends on libpng which is not in tsuku registry",
+      "timestamp": "2026-01-27T10:00:00Z"
+    },
+    {
+      "package_id": "homebrew:ffmpeg",
+      "category": "no_bottles",
+      "message": "No pre-built bottles available for linux-glibc",
+      "timestamp": "2026-01-27T10:05:00Z"
+    },
+    {
+      "package_id": "homebrew:gcc",
+      "category": "build_from_source",
+      "message": "Formula requires compilation from source",
+      "timestamp": "2026-01-27T10:10:00Z"
+    }
+  ]
+}

--- a/data/examples/priority-queue.json
+++ b/data/examples/priority-queue.json
@@ -1,0 +1,43 @@
+{
+  "schema_version": 1,
+  "updated_at": "2026-01-27T10:00:00Z",
+  "tiers": {
+    "1": "Critical - manually curated high-impact tools",
+    "2": "Popular - >10K weekly downloads or >1K GitHub stars",
+    "3": "Standard - all other packages"
+  },
+  "packages": [
+    {
+      "id": "homebrew:ripgrep",
+      "source": "homebrew",
+      "name": "ripgrep",
+      "tier": 1,
+      "status": "pending",
+      "added_at": "2026-01-20T10:00:00Z",
+      "metadata": {
+        "formula": "ripgrep",
+        "tap": "homebrew/core"
+      }
+    },
+    {
+      "id": "homebrew:fd",
+      "source": "homebrew",
+      "name": "fd",
+      "tier": 2,
+      "status": "pending",
+      "added_at": "2026-01-20T10:00:00Z",
+      "metadata": {
+        "formula": "fd",
+        "tap": "homebrew/core"
+      }
+    },
+    {
+      "id": "homebrew:tree",
+      "source": "homebrew",
+      "name": "tree",
+      "tier": 3,
+      "status": "pending",
+      "added_at": "2026-01-25T14:30:00Z"
+    }
+  ]
+}

--- a/data/schemas/failure-record.schema.json
+++ b/data/schemas/failure-record.schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Failure Record",
+  "description": "Per-ecosystem-environment failure records from batch recipe generation",
+  "type": "object",
+  "required": ["schema_version", "ecosystem", "environment", "updated_at", "failures"],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "ecosystem": {
+      "type": "string",
+      "description": "Ecosystem name (e.g., homebrew, cargo)"
+    },
+    "environment": {
+      "type": "string",
+      "description": "Target environment (e.g., linux-glibc, darwin-arm64)"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "failures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["package_id", "category", "message", "timestamp"],
+        "properties": {
+          "package_id": {
+            "type": "string",
+            "pattern": "^[a-z0-9_-]+:[a-z0-9_@.+-]+$",
+            "description": "References a package in the priority queue"
+          },
+          "category": {
+            "type": "string",
+            "enum": [
+              "missing_dep",
+              "no_bottles",
+              "build_from_source",
+              "complex_archive",
+              "api_error",
+              "validation_failed"
+            ],
+            "description": "Failure classification"
+          },
+          "blocked_by": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Tsuku recipe names blocking this package (for missing_dep category)"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable failure description"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this failure was recorded"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/data/schemas/priority-queue.schema.json
+++ b/data/schemas/priority-queue.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Priority Queue",
+  "description": "Packages awaiting recipe generation, ordered by tier",
+  "type": "object",
+  "required": ["schema_version", "updated_at", "packages"],
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "tiers": {
+      "type": "object",
+      "description": "Human-readable tier descriptions",
+      "properties": {
+        "1": { "type": "string" },
+        "2": { "type": "string" },
+        "3": { "type": "string" }
+      }
+    },
+    "packages": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "source", "name", "tier", "status", "added_at"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^[a-z0-9_-]+:[a-z0-9_@.+-]+$",
+            "description": "Globally unique identifier: {source}:{name}"
+          },
+          "source": {
+            "type": "string",
+            "description": "Ecosystem builder name (e.g., homebrew, cargo, npm)"
+          },
+          "name": {
+            "type": "string",
+            "description": "Package name within ecosystem"
+          },
+          "tier": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 3,
+            "description": "Priority tier: 1 (critical), 2 (popular), 3 (standard)"
+          },
+          "status": {
+            "type": "string",
+            "enum": ["pending", "in_progress", "success", "failed", "skipped"],
+            "description": "Current processing status"
+          },
+          "added_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "ISO 8601 timestamp when added to queue"
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Source-specific data (optional)"
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/designs/DESIGN-priority-queue.md
+++ b/docs/designs/DESIGN-priority-queue.md
@@ -17,7 +17,7 @@ Planned
 
 | Issue | Title | Dependencies | Tier |
 |-------|-------|--------------|------|
-| [#1199](https://github.com/tsukumogami/tsuku/issues/1199) | feat(data): add priority queue and failure record schemas | None | testable |
+| ~~[#1199](https://github.com/tsukumogami/tsuku/issues/1199)~~ | ~~feat(data): add priority queue and failure record schemas~~ | ~~None~~ | ~~testable~~ |
 | ~~[#1200](https://github.com/tsukumogami/tsuku/issues/1200)~~ | ~~feat(data): add dependency name mapping structure~~ | ~~None~~ | ~~simple~~ |
 | [#1201](https://github.com/tsukumogami/tsuku/issues/1201) | feat(scripts): add schema validation scripts | [#1199](https://github.com/tsukumogami/tsuku/issues/1199) | testable |
 | [#1202](https://github.com/tsukumogami/tsuku/issues/1202) | feat(scripts): add queue seed script for Homebrew | [#1199](https://github.com/tsukumogami/tsuku/issues/1199) | testable |
@@ -47,9 +47,8 @@ graph LR
     classDef blocked fill:#fff9c4
     classDef needsDesign fill:#e1bee7
 
-    class I1200 done
-    class I1199 ready
-    class I1201,I1202,I1203 blocked
+    class I1199,I1200 done
+    class I1201,I1202,I1203 ready
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design

--- a/docs/designs/DESIGN-registry-scale-strategy.md
+++ b/docs/designs/DESIGN-registry-scale-strategy.md
@@ -24,7 +24,7 @@ Planned
 
 | Issue | Title | Dependencies | Tier |
 |-------|-------|--------------|------|
-| [#1199](https://github.com/tsukumogami/tsuku/issues/1199) | feat(data): add priority queue and failure record schemas | [#1186](https://github.com/tsukumogami/tsuku/issues/1186) | testable |
+| ~~[#1199](https://github.com/tsukumogami/tsuku/issues/1199)~~ | ~~feat(data): add priority queue and failure record schemas~~ | ~~[#1186](https://github.com/tsukumogami/tsuku/issues/1186)~~ | ~~testable~~ |
 | ~~[#1200](https://github.com/tsukumogami/tsuku/issues/1200)~~ | ~~feat(data): add dependency name mapping structure~~ | ~~[#1186](https://github.com/tsukumogami/tsuku/issues/1186)~~ | ~~simple~~ |
 | [#1201](https://github.com/tsukumogami/tsuku/issues/1201) | feat(scripts): add schema validation scripts | [#1199](https://github.com/tsukumogami/tsuku/issues/1199) | testable |
 | [#1202](https://github.com/tsukumogami/tsuku/issues/1202) | feat(scripts): add queue seed script for Homebrew | [#1199](https://github.com/tsukumogami/tsuku/issues/1199) | testable |
@@ -114,9 +114,9 @@ graph TD
 
     class I1186,I1187 done
     class I1200 done
-    class I1199 ready
+    class I1199 done
     class I1188 needsDesign
-    class I1201,I1202,I1203 blocked
+    class I1201,I1202,I1203 ready
     class I1189,I1190,I1191 blocked
 ```
 


### PR DESCRIPTION
Add JSON Schema (draft-07) definitions for the priority queue and failure record data files. These schemas define the contract for batch recipe generation visibility infrastructure: the priority queue tracks which packages to generate (with tiered priority), and failure records capture why generation failed (enabling gap analysis).

The schemas, example files, and updated data README provide everything downstream tooling needs to produce and validate these data files.

---

Fixes #1199

### What This Accomplishes

Establishes the foundational data contracts from the [priority queue design](docs/designs/DESIGN-priority-queue.md):

- `data/schemas/priority-queue.schema.json` - validates queue structure with tiered priority (1-3), status tracking, and `{source}:{name}` ID format
- `data/schemas/failure-record.schema.json` - validates per-ecosystem-environment failure records with categorized failures and optional `blocked_by` dependencies
- `data/examples/` - sample files demonstrating valid structure for each schema

This unblocks #1201 (validation scripts), #1202 (seed script), and #1203 (gap analysis script).