### PR TITLE
chore(telemetry): inject D1 database ID from GitHub variable

### DIFF
--- a/.github/workflows/telemetry-deploy.yml
+++ b/.github/workflows/telemetry-deploy.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Inject D1 database ID
+        run: |
+          sed -i 's/BATCH_METRICS_DATABASE_ID/${{ vars.BATCH_METRICS_DATABASE_ID }}/' wrangler.toml
+
       - name: Deploy to Cloudflare Workers
         uses: cloudflare/wrangler-action@v3
         env:

--- a/telemetry/wrangler.toml
+++ b/telemetry/wrangler.toml
@@ -16,7 +16,7 @@ CF_ACCOUNT_ID = "3c4fa2269fc145e89553adc332dc9546"
 [[d1_databases]]
 binding = "BATCH_METRICS"
 database_name = "tsuku-batch-metrics"
-database_id = "placeholder-configure-after-d1-create"
+database_id = "BATCH_METRICS_DATABASE_ID" # Injected by CI from vars.BATCH_METRICS_DATABASE_ID
 migrations_dir = "migrations"
 
 # Custom domain: telemetry.tsuku.dev


### PR DESCRIPTION
Replace the hardcoded D1 database_id in wrangler.toml with a placeholder token that the deploy workflow substitutes from `vars.BATCH_METRICS_DATABASE_ID` at deploy time. This keeps infrastructure IDs out of the codebase, consistent with how other deploy-time values (COMMIT_SHA, DEPLOY_TIME) are already injected.