### PR TITLE
feat(scripts): add schema validation scripts (#1201)

### DIFF
--- a/docs/designs/DESIGN-priority-queue.md
+++ b/docs/designs/DESIGN-priority-queue.md
@@ -19,7 +19,7 @@ Planned
 |-------|-------|--------------|------|
 | ~~[#1199](https://github.com/tsukumogami/tsuku/issues/1199)~~ | ~~feat(data): add priority queue and failure record schemas~~ | ~~None~~ | ~~testable~~ |
 | ~~[#1200](https://github.com/tsukumogami/tsuku/issues/1200)~~ | ~~feat(data): add dependency name mapping structure~~ | ~~None~~ | ~~simple~~ |
-| [#1201](https://github.com/tsukumogami/tsuku/issues/1201) | feat(scripts): add schema validation scripts | [#1199](https://github.com/tsukumogami/tsuku/issues/1199) | testable |
+| ~~[#1201](https://github.com/tsukumogami/tsuku/issues/1201)~~ | ~~feat(scripts): add schema validation scripts~~ | ~~[#1199](https://github.com/tsukumogami/tsuku/issues/1199)~~ | ~~testable~~ |
 | [#1202](https://github.com/tsukumogami/tsuku/issues/1202) | feat(scripts): add queue seed script for Homebrew | [#1199](https://github.com/tsukumogami/tsuku/issues/1199) | testable |
 | [#1203](https://github.com/tsukumogami/tsuku/issues/1203) | feat(scripts): add gap analysis script | [#1199](https://github.com/tsukumogami/tsuku/issues/1199) | testable |
 
@@ -48,7 +48,8 @@ graph LR
     classDef needsDesign fill:#e1bee7
 
     class I1199,I1200 done
-    class I1201,I1202,I1203 ready
+    class I1201 done
+    class I1202,I1203 ready
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design

--- a/docs/designs/DESIGN-registry-scale-strategy.md
+++ b/docs/designs/DESIGN-registry-scale-strategy.md
@@ -26,7 +26,7 @@ Planned
 |-------|-------|--------------|------|
 | ~~[#1199](https://github.com/tsukumogami/tsuku/issues/1199)~~ | ~~feat(data): add priority queue and failure record schemas~~ | ~~[#1186](https://github.com/tsukumogami/tsuku/issues/1186)~~ | ~~testable~~ |
 | ~~[#1200](https://github.com/tsukumogami/tsuku/issues/1200)~~ | ~~feat(data): add dependency name mapping structure~~ | ~~[#1186](https://github.com/tsukumogami/tsuku/issues/1186)~~ | ~~simple~~ |
-| [#1201](https://github.com/tsukumogami/tsuku/issues/1201) | feat(scripts): add schema validation scripts | [#1199](https://github.com/tsukumogami/tsuku/issues/1199) | testable |
+| ~~[#1201](https://github.com/tsukumogami/tsuku/issues/1201)~~ | ~~feat(scripts): add schema validation scripts~~ | ~~[#1199](https://github.com/tsukumogami/tsuku/issues/1199)~~ | ~~testable~~ |
 | [#1202](https://github.com/tsukumogami/tsuku/issues/1202) | feat(scripts): add queue seed script for Homebrew | [#1199](https://github.com/tsukumogami/tsuku/issues/1199) | testable |
 | [#1203](https://github.com/tsukumogami/tsuku/issues/1203) | feat(scripts): add gap analysis script | [#1199](https://github.com/tsukumogami/tsuku/issues/1199) | testable |
 
@@ -116,7 +116,8 @@ graph TD
     class I1200 done
     class I1199 done
     class I1188 needsDesign
-    class I1201,I1202,I1203 ready
+    class I1201 done
+    class I1202,I1203 ready
     class I1189,I1190,I1191 blocked
 ```
 

--- a/scripts/validate-failures.sh
+++ b/scripts/validate-failures.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# validate-failures.sh - Validate failure record files against their JSON schema.
+#
+# Usage: ./scripts/validate-failures.sh
+#
+# Validates all data/failures/*.json files against data/schemas/failure-record.schema.json.
+# Exits 0 on success, 1 on validation failure, 2 on missing schema.
+# If no failure files exist yet, prints a warning and exits 0.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+SCHEMA="$REPO_ROOT/data/schemas/failure-record.schema.json"
+FAILURES_DIR="$REPO_ROOT/data/failures"
+
+if [[ ! -f "$SCHEMA" ]]; then
+  echo "ERROR: Schema file not found: $SCHEMA" >&2
+  exit 2
+fi
+
+if [[ ! -d "$FAILURES_DIR" ]]; then
+  echo "WARN: Failures directory not found: $FAILURES_DIR (skipping validation)" >&2
+  exit 0
+fi
+
+shopt -s nullglob
+FILES=("$FAILURES_DIR"/*.json)
+shopt -u nullglob
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+  echo "WARN: No failure files found in $FAILURES_DIR (skipping validation)" >&2
+  exit 0
+fi
+
+FAILED=0
+
+for file in "${FILES[@]}"; do
+  echo "Validating $file against schema..."
+  if pipx run check-jsonschema --schemafile "$SCHEMA" "$file"; then
+    echo "PASS: $file is valid"
+  else
+    echo "FAIL: $file does not conform to schema" >&2
+    FAILED=1
+  fi
+done
+
+if [[ $FAILED -eq 1 ]]; then
+  echo "FAIL: One or more failure files are invalid" >&2
+  exit 1
+fi
+
+echo "PASS: All ${#FILES[@]} failure file(s) are valid"

--- a/scripts/validate-queue.sh
+++ b/scripts/validate-queue.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# validate-queue.sh - Validate priority queue data against its JSON schema.
+#
+# Usage: ./scripts/validate-queue.sh
+#
+# Validates data/priority-queue.json against data/schemas/priority-queue.schema.json.
+# Exits 0 on success, 1 on validation failure, 2 on missing schema.
+# If the queue file doesn't exist yet, prints a warning and exits 0.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+SCHEMA="$REPO_ROOT/data/schemas/priority-queue.schema.json"
+QUEUE="$REPO_ROOT/data/priority-queue.json"
+
+if [[ ! -f "$SCHEMA" ]]; then
+  echo "ERROR: Schema file not found: $SCHEMA" >&2
+  exit 2
+fi
+
+if [[ ! -f "$QUEUE" ]]; then
+  echo "WARN: Queue file not found: $QUEUE (skipping validation)" >&2
+  exit 0
+fi
+
+echo "Validating $QUEUE against schema..."
+if pipx run check-jsonschema --schemafile "$SCHEMA" "$QUEUE"; then
+  echo "PASS: $QUEUE is valid"
+else
+  echo "FAIL: $QUEUE does not conform to schema" >&2
+  exit 1
+fi


### PR DESCRIPTION
Add two shell scripts for validating data files against their JSON Schema
definitions. `validate-queue.sh` checks `data/priority-queue.json` against
its schema, and `validate-failures.sh` checks all files in `data/failures/`
against the failure record schema. Both use `pipx run check-jsonschema`
so no permanent Python package installation is needed.

Scripts handle missing files gracefully: missing schema exits with code 2,
missing data files produce a warning and exit 0.

---

Fixes #1201

## What This Accomplishes

- Enables CI or local validation of priority queue and failure record files
- Catches schema violations before they reach downstream consumers
- Graceful handling of missing files for repos that don't yet have data files