### PR TITLE
feat(ops): add rollback-batch.sh script

### DIFF
--- a/docs/designs/DESIGN-batch-operations.md
+++ b/docs/designs/DESIGN-batch-operations.md
@@ -20,7 +20,7 @@ Planned
 | ~~[#1197](https://github.com/tsukumogami/tsuku/issues/1197)~~ | ~~feat(ops): add batch-control.json schema and initial file~~ | ~~None~~ | ~~simple~~ |
 | ~~[#1204](https://github.com/tsukumogami/tsuku/issues/1204)~~ | ~~feat(ci): add pre-flight control file check to batch workflow~~ | ~~[#1197](https://github.com/tsukumogami/tsuku/issues/1197)~~ | ~~testable~~ |
 | ~~[#1205](https://github.com/tsukumogami/tsuku/issues/1205)~~ | ~~feat(ops): implement circuit breaker state transitions~~ | ~~[#1197](https://github.com/tsukumogami/tsuku/issues/1197), [#1204](https://github.com/tsukumogami/tsuku/issues/1204)~~ | ~~testable~~ |
-| [#1206](https://github.com/tsukumogami/tsuku/issues/1206) | feat(ops): add rollback-batch.sh script | [#1197](https://github.com/tsukumogami/tsuku/issues/1197) | testable |
+| ~~[#1206](https://github.com/tsukumogami/tsuku/issues/1206)~~ | ~~feat(ops): add rollback-batch.sh script~~ | ~~[#1197](https://github.com/tsukumogami/tsuku/issues/1197)~~ | ~~testable~~ |
 | [#1207](https://github.com/tsukumogami/tsuku/issues/1207) | docs(ops): create batch operations runbook | [#1205](https://github.com/tsukumogami/tsuku/issues/1205), [#1206](https://github.com/tsukumogami/tsuku/issues/1206) | simple |
 
 ### Milestone: [Batch Operations Observability](https://github.com/tsukumogami/tsuku/milestone/56)
@@ -62,10 +62,9 @@ graph TD
     classDef blocked fill:#fff9c4
     classDef needsDesign fill:#e1bee7
 
-    class I1197,I1204,I1205,I1208,I1210 done
+    class I1197,I1204,I1205,I1206,I1208,I1210 done
     class I1209 ready
-    class I1206 ready
-    class I1207 blocked
+    class I1207 ready
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design

--- a/scripts/rollback-batch.sh
+++ b/scripts/rollback-batch.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# scripts/rollback-batch.sh
+# Usage: ./rollback-batch.sh 2026-01-28-001
+
+set -euo pipefail
+
+BATCH_ID="$1"
+
+if [ -z "$BATCH_ID" ]; then
+  echo "Usage: $0 <batch_id>"
+  echo "Example: $0 2026-01-28-001"
+  exit 1
+fi
+
+# Find all recipes from this batch
+echo "Finding recipes from batch $BATCH_ID..."
+files=$(git log --all --name-only --grep="batch_id: $BATCH_ID" --format="" |
+        grep '^recipes/' | sort -u)
+
+if [ -z "$files" ]; then
+  echo "No recipes found for batch $BATCH_ID"
+  exit 1
+fi
+
+echo "Found $(echo "$files" | wc -l) recipes to rollback:"
+echo "$files"
+
+# Create rollback branch
+branch="rollback-batch-$BATCH_ID"
+git checkout -b "$branch"
+
+# Remove the files
+echo "$files" | xargs git rm
+
+# Commit
+git commit -m "chore: rollback batch $BATCH_ID
+
+batch_id: $BATCH_ID
+rollback_reason: manual rollback request
+"
+
+echo ""
+echo "Rollback branch created: $branch"
+echo "Review changes with: git diff main...$branch"
+echo "Create PR with: gh pr create --title 'Rollback batch $BATCH_ID'"


### PR DESCRIPTION
Add a rollback script for batch recipe imports. When a batch introduces problematic recipes, this script finds all commits with a matching batch_id trailer via `git log --grep`, extracts recipe file paths, and removes them on a dedicated rollback branch with a traceable commit.

---

Fixes #1206

### What This Accomplishes

- `scripts/rollback-batch.sh` accepts a batch_id argument and creates a `rollback-batch-<id>` branch with the affected recipe files removed
- Uses git commit trailers for batch identification, keeping rollback operations traceable
- Updates design doc dependency graph (I1206 done, I1207 now ready)