### PR TITLE
chore(ci): update design doc validation

### DIFF
--- a/.github/scripts/docs/MM15.md
+++ b/.github/scripts/docs/MM15.md
@@ -1,66 +1,35 @@
-# MM15: Class doesn't match issue status
+# MM15: Class doesn't match issue open/closed status
 
-A node's class assignment doesn't match the actual status of the GitHub issue.
+A node's class assignment doesn't match its GitHub open/closed state.
 
-## Status to Class Mapping
+## Rules
 
-| Issue State | Blocking Status | Label | Expected Class |
-|-------------|-----------------|-------|----------------|
-| Closed | - | - | `done` |
-| Open | Has open blockers | - | `blocked` |
-| Open | No open blockers | `needs-design` | `needsDesign` |
-| Open | No open blockers | (none) | `ready` |
-
-## How Blocking Status is Determined
-
-A node is "blocked" if any of its dependencies (upstream nodes in the graph) have a class other than `done`.
-
-```mermaid
-graph TD
-    I123 --> I124
-    I124 --> I125
-```
-
-In this example:
-- I123 blocks I124
-- I124 blocks I125
-- If I123 is not `done`, then I124 is blocked
-- If I124 is not `done`, then I125 is blocked
+| GitHub State | Expected Class |
+|-------------|----------------|
+| Closed (or PR closing it) | `done` |
+| Open | NOT `done` |
 
 ## Why This Matters
 
-- Diagram should reflect actual project state
-- Incorrect classes mislead readers about what's ready to work on
-- Helps identify stale diagrams that need updating
+- Closed issues showing as `ready` or `blocked` mislead readers
+- Open issues showing as `done` suggest work is complete when it isn't
+- The diagram should reflect actual project state
 
 ## How to Fix
 
-Update the class assignment to match the issue's actual status:
-
-**Before (incorrect - issue is actually closed):**
-```mermaid
-graph TD
-    I123["#123: Task A"]
-    class I123 ready
+**Issue is closed but not marked done:**
+```
+class I123 done
 ```
 
-**After (correct):**
-```mermaid
-graph TD
-    I123["#123: Task A"]
-    class I123 done
-```
+**Issue is open but marked done:**
+Change to the appropriate class (`ready`, `blocked`, or `needsDesign`) based on its actual state.
 
-## Common Scenarios
+## Related Rules
 
-### Issue was closed but diagram not updated
-Change the class from `ready` or `blocked` to `done`.
-
-### Blocker was completed but dependent still shows blocked
-Update the dependent issue's class from `blocked` to `ready` (or `needsDesign` if it has that label).
-
-### Issue has needs-design label but shows as ready
-Change the class from `ready` to `needsDesign`.
+- MM16: needs-design label cannot be ready
+- MM17: No open blockers cannot be blocked
+- MM18: Open blocker cannot be ready
 
 ## Note
 

--- a/.github/scripts/docs/MM16.md
+++ b/.github/scripts/docs/MM16.md
@@ -1,0 +1,23 @@
+# MM16: needs-design issue cannot be ready
+
+An issue with the `needs-design` label has class `ready` in the diagram. Issues that still need design work should use the `needsDesign` class instead.
+
+## Why This Matters
+
+The `ready` class signals that an issue can be picked up for implementation. An issue with `needs-design` isn't ready for implementation yet -- it needs a design doc or design review first.
+
+## How to Fix
+
+Change the class from `ready` to `needsDesign`:
+
+**Before (incorrect):**
+```
+class I123 ready
+```
+
+**After (correct):**
+```
+class I123 needsDesign
+```
+
+Alternatively, if the design work is done, remove the `needs-design` label from the GitHub issue.

--- a/.github/scripts/docs/MM17.md
+++ b/.github/scripts/docs/MM17.md
@@ -1,0 +1,24 @@
+# MM17: No open blockers but class is blocked
+
+A node has class `blocked` but none of its upstream dependencies are actually open on GitHub. If all blockers are closed (or being closed by the current PR), the node isn't blocked.
+
+## How Blocking is Determined
+
+The validation parses the mermaid diagram's edge relationships (`A --> B` means A blocks B) and checks the actual GitHub state of each blocker. A node is only considered blocked if at least one upstream dependency is open.
+
+## How to Fix
+
+Update the class to reflect the node's actual state:
+
+- If the issue has a `needs-design` label, use `needsDesign`
+- Otherwise, use `ready`
+
+**Before (incorrect -- all blockers are closed):**
+```
+class I123 blocked
+```
+
+**After (correct):**
+```
+class I123 ready
+```

--- a/.github/scripts/docs/MM18.md
+++ b/.github/scripts/docs/MM18.md
@@ -1,0 +1,25 @@
+# MM18: Open blocker but class is ready
+
+A node has class `ready` but at least one of its upstream dependencies is still open on GitHub. An issue can't be ready for implementation if it's waiting on unfinished work.
+
+## How Blocking is Determined
+
+The validation parses the mermaid diagram's edge relationships (`A --> B` means A blocks B) and checks the actual GitHub state of each blocker. A node with any open upstream dependency should use class `blocked`.
+
+## How to Fix
+
+Change the class from `ready` to `blocked`:
+
+**Before (incorrect -- I100 is still open):**
+```
+I100 --> I123
+class I123 ready
+```
+
+**After (correct):**
+```
+I100 --> I123
+class I123 blocked
+```
+
+Alternatively, close the blocking issue first if the work is done.


### PR DESCRIPTION
Update design document validation scripts and workflow.

---

## What This Changes

- `.github/scripts/validate-design-doc.sh` - Orchestrator that runs modular validation checks
- `.github/scripts/checks/` - Modular check scripts (common.sh, frontmatter.sh, etc.)
- `.github/workflows/validate-design-docs.yml` - Runs validation on all PRs

## How It Works

The workflow finds all DESIGN-*.md files in the repo and validates each one:
- Location: must be under docs/designs/
- Naming: must start with DESIGN-
- Frontmatter: must have valid YAML frontmatter