### PR TITLE
docs(design): add queue seeding prerequisite to registry scale strategy

### DIFF
--- a/docs/designs/DESIGN-registry-scale-strategy.md
+++ b/docs/designs/DESIGN-registry-scale-strategy.md
@@ -48,7 +48,8 @@ Implements [#1187](https://github.com/tsukumogami/tsuku/issues/1187). See [DESIG
 
 | Issue | Title | Dependencies | Tier |
 |-------|-------|--------------|------|
-| [#1189](https://github.com/tsukumogami/tsuku/issues/1189) | design batch recipe generation CI pipeline | ~~[#1186](https://github.com/tsukumogami/tsuku/issues/1186)~~, ~~[#1187](https://github.com/tsukumogami/tsuku/issues/1187)~~, ~~[#1188](https://github.com/tsukumogami/tsuku/issues/1188)~~ | testable |
+| [#1241](https://github.com/tsukumogami/tsuku/issues/1241) | seed priority queue across ecosystems | ~~[#1202](https://github.com/tsukumogami/tsuku/issues/1202)~~ | testable |
+| [#1189](https://github.com/tsukumogami/tsuku/issues/1189) | design batch recipe generation CI pipeline | ~~[#1186](https://github.com/tsukumogami/tsuku/issues/1186)~~, ~~[#1187](https://github.com/tsukumogami/tsuku/issues/1187)~~, ~~[#1188](https://github.com/tsukumogami/tsuku/issues/1188)~~, [#1241](https://github.com/tsukumogami/tsuku/issues/1241) | testable |
 
 ### Milestone: [M-FailureBackend](https://github.com/tsukumogami/tsuku/milestone/53)
 
@@ -84,6 +85,7 @@ graph TD
     end
 
     subgraph M_BatchPipeline["M-BatchPipeline"]
+        I1241["#1241: Seed priority queue"]
         I1189["#1189: Batch recipe generation CI"]
     end
 
@@ -103,7 +105,9 @@ graph TD
     I1186 --> I1188
     I1186 --> I1189
     I1187 --> I1189
+    I1202 --> I1241
     I1188 --> I1189
+    I1241 --> I1189
     I1189 --> I1190
     I1190 --> I1191
 
@@ -119,6 +123,7 @@ graph TD
     class I1201 done
     class I1202 done
     class I1203 done
+    class I1241 ready
     class I1189 needsDesign
     class I1190,I1191 blocked
 ```


### PR DESCRIPTION
Add #1241 (seed priority queue across ecosystems) as a prerequisite for #1189
(batch recipe generation CI pipeline) in the registry scale strategy.

The batch pipeline reads from `data/priority-queue.json`, but this file doesn't
exist yet. The seed script (#1202) was built but only supports Homebrew and was
never run to commit initial data. #1241 fills this gap by extending the script
to cover all 8 ecosystems and committing the seeded queue.

---

## What This Accomplishes

Adds the missing link between the visibility infrastructure (M50, completed) and
the batch pipeline (M-BatchPipeline). Without seeded queue data, the pipeline
has nothing to process.

Changes to the strategy doc:
- Added #1241 row to M-BatchPipeline issues table
- Added #1241 as dependency of #1189
- Added #1241 node to Mermaid diagram with edge from #1202 (seed script)