### PR TITLE
chore(ci): update design doc validation

### DIFF
--- a/.github/scripts/checks/design-doc-template.md
+++ b/.github/scripts/checks/design-doc-template.md
@@ -5,9 +5,16 @@ Required sections in order:
 ```markdown
 ---
 status: Proposed
-problem: One sentence describing the problem.
-decision: One sentence stating the decision.
-rationale: 1-2 sentences explaining why.
+problem: |
+  2-3 paragraphs describing the problem being solved.
+  Cover what's broken or missing, who it affects,
+  and why it matters now.
+decision: |
+  2-3 paragraphs stating the decision.
+  Cover the chosen approach and key design choices.
+rationale: |
+  2-3 paragraphs explaining why this approach was chosen.
+  Cover trade-offs and why alternatives were rejected.
 ---
 
 # DESIGN: Title

--- a/.github/scripts/docs/FM01.md
+++ b/.github/scripts/docs/FM01.md
@@ -9,9 +9,12 @@ All design documents must have these 4 fields in their frontmatter:
 ```yaml
 ---
 status: Proposed
-problem: One sentence describing the problem being solved.
-decision: One sentence stating what was decided.
-rationale: 1-2 sentences explaining why this approach was chosen.
+problem: |
+  2-3 paragraphs describing the problem being solved.
+decision: |
+  2-3 paragraphs stating what was decided.
+rationale: |
+  2-3 paragraphs explaining why this approach was chosen.
 ---
 ```
 


### PR DESCRIPTION
Update design document validation scripts and workflow.

---

## What This Changes

- `.github/scripts/validate-design-doc.sh` - Orchestrator that runs modular validation checks
- `.github/scripts/checks/` - Modular check scripts (common.sh, frontmatter.sh, etc.)
- `.github/workflows/validate-design-docs.yml` - Runs validation on all PRs

## How It Works

The workflow finds all DESIGN-*.md files in the repo and validates each one:
- Location: must be under docs/designs/
- Naming: must start with DESIGN-
- Frontmatter: must have valid YAML frontmatter