### PR TITLE
fix(ci): pass GITHUB_TOKEN to install.sh in batch-generate workflow

### DIFF
--- a/.github/workflows/batch-generate.yml
+++ b/.github/workflows/batch-generate.yml
@@ -49,6 +49,8 @@ jobs:
         run: go build -o batch-generate ./cmd/batch-generate
 
       - name: Install tsuku
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           curl -fsSL https://tsuku.dev/install.sh | bash
           echo "$HOME/.tsuku/bin" >> "$GITHUB_PATH"


### PR DESCRIPTION
The batch-generate workflow's install step hits a 403 from the GitHub
API when fetching the latest tsuku release. GitHub Actions runners share
IP pools, so unauthenticated API requests from runners frequently
exhaust the per-IP rate limit. The install script already supports
GITHUB_TOKEN for authenticated requests but the workflow wasn't passing
it through.

---

Fixes the batch-generate workflow failing at the "Install tsuku" step.