### PR TITLE
fix(ci): use PAT for batch-generate PR creation

### DIFF
--- a/.github/workflows/batch-generate.yml
+++ b/.github/workflows/batch-generate.yml
@@ -86,4 +86,4 @@ jobs:
             --body "Automated batch generation for ${{ inputs.ecosystem }} ecosystem." \
             --base main
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT_BATCH_GENERATE }}


### PR DESCRIPTION
The default GITHUB_TOKEN isn't permitted to create pull requests from
Actions. Switch the PR creation step to use a fine-grained PAT
(PAT_BATCH_GENERATE) scoped to contents and pull request write access
on this repo only.

---

Fixes the "GitHub Actions is not permitted to create or approve pull
requests" error in the batch-generate workflow.