### PR TITLE
fix(batch): add --output flag to create and fix orchestrator args

### DIFF
--- a/internal/batch/orchestrator.go
+++ b/internal/batch/orchestrator.go
@@ -132,9 +132,11 @@ type generateResult struct {
 // generate invokes tsuku create for a single package with retry on network errors.
 func (o *Orchestrator) generate(bin string, pkg seed.Package, recipePath string) generateResult {
 	args := []string{
-		"create",
+		"create", pkg.Name,
 		"--from", pkg.ID,
 		"--output", recipePath,
+		"--yes",
+		"--skip-sandbox",
 	}
 
 	var lastErr error

--- a/test/functional/features/create.feature
+++ b/test/functional/features/create.feature
@@ -1,0 +1,23 @@
+Feature: Create
+  Create recipes from package ecosystems.
+
+  Background:
+    Given a clean tsuku environment
+
+  Scenario: Create recipe to default location
+    When I run "tsuku create prettier --from npm --yes --skip-sandbox"
+    Then the exit code is 0
+    And the output contains "Recipe created:"
+    And the file "recipes/prettier.toml" exists
+
+  Scenario: Create recipe with --output flag
+    When I run "tsuku create prettier --from npm --yes --skip-sandbox --output .tsuku-test/custom/prettier.toml"
+    Then the exit code is 0
+    And the output contains "Recipe created:"
+    And the file "custom/prettier.toml" exists
+    And the file "recipes/prettier.toml" does not exist
+
+  Scenario: Create recipe fails without --from
+    When I run "tsuku create prettier"
+    Then the exit code is not 0
+    And the error output contains "required"


### PR DESCRIPTION
The batch orchestrator passed --output to tsuku create, but the flag
didn't exist. The orchestrator was also missing the positional tool name
argument and --yes/--skip-sandbox flags needed for non-interactive batch
runs. All 25 packages in the first batch run failed with "unknown flag:
--output". Additionally, --skip-sandbox required interactive consent
even when --yes was passed, blocking CI use entirely.

Three changes:
- Add --output flag to tsuku create (overrides default registry path)
- Fix orchestrator command: add tool name positional arg, --yes,
  --skip-sandbox
- --yes now implies consent for --skip-sandbox (no interactive prompt)

Functional tests added for all three create scenarios (default output,
custom --output, missing --from error).

---

Tested locally against npm ecosystem (crates.io needs cargo installed).
All unit tests and functional tests pass.