### PR TITLE
fix(ci): build tsuku from source in batch-generate workflow

### DIFF
--- a/.github/workflows/batch-generate.yml
+++ b/.github/workflows/batch-generate.yml
@@ -45,15 +45,11 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Build batch-generate
-        run: go build -o batch-generate ./cmd/batch-generate
-
-      - name: Install tsuku
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build binaries
         run: |
-          curl -fsSL https://tsuku.dev/install.sh | bash
-          echo "$HOME/.tsuku/bin" >> "$GITHUB_PATH"
+          go build -o batch-generate ./cmd/batch-generate
+          go build -o tsuku ./cmd/tsuku
+          echo "$PWD" >> "$GITHUB_PATH"
 
       - name: Run batch generation
         run: |


### PR DESCRIPTION
The workflow installed tsuku from the latest release, but the released
binary doesn't have the --output flag the orchestrator needs. Build
from source so the workflow always uses the same version as the
orchestrator. This also removes the dependency on install.sh and the
GITHUB_TOKEN for release fetching.

---

Replaces the install.sh step with a local go build. Both batch-generate
and tsuku are now built from the checked-out source and placed on PATH.