### PR TITLE
fix(ci): use --recipe flag for local recipe files in PR tests

### DIFF
--- a/.github/workflows/test-changed-recipes.yml
+++ b/.github/workflows/test-changed-recipes.yml
@@ -176,7 +176,7 @@ jobs:
       - name: "Install ${{ matrix.recipe.tool }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./tsuku install --force ${{ matrix.recipe.tool }}
+        run: ./tsuku install --force --recipe ${{ matrix.recipe.path }}
 
   # Test all macOS-compatible recipes in a single job (reduces runner queue pressure)
   test-macos:
@@ -210,13 +210,17 @@ jobs:
           for recipe in $(echo "$RECIPES" | jq -r '.[]'); do
             echo "::group::Testing $recipe"
 
+            # Derive recipe file path from tool name
+            first_letter=$(echo "$recipe" | cut -c1)
+            recipe_path="recipes/$first_letter/$recipe.toml"
+
             # Fresh TSUKU_HOME per recipe with shared download cache
             export TSUKU_HOME="${{ runner.temp }}/tsuku-$recipe"
             mkdir -p "$TSUKU_HOME/cache"
             ln -s "$CACHE_DIR" "$TSUKU_HOME/cache/downloads"
             echo "$TSUKU_HOME/bin" >> "$GITHUB_PATH"
 
-            if ! ./tsuku install --force "$recipe"; then
+            if ! ./tsuku install --force --recipe "$recipe_path"; then
               FAILED+=("$recipe")
             fi
             echo "::endgroup::"

--- a/data/priority-queue.json
+++ b/data/priority-queue.json
@@ -43,22 +43,6 @@
       "added_at": "2026-01-30T23:59:06Z"
     },
     {
-      "id": "homebrew:cmake",
-      "source": "homebrew",
-      "name": "cmake",
-      "tier": 1,
-      "status": "pending",
-      "added_at": "2026-01-30T23:59:06Z"
-    },
-    {
-      "id": "homebrew:go",
-      "source": "homebrew",
-      "name": "go",
-      "tier": 1,
-      "status": "pending",
-      "added_at": "2026-01-30T23:59:06Z"
-    },
-    {
       "id": "homebrew:gemini-cli",
       "source": "homebrew",
       "name": "gemini-cli",


### PR DESCRIPTION
The test-changed-recipes workflow runs `tsuku install <tool>` which resolves
recipes from the registry. New recipes introduced in PRs don't exist in the
registry yet, so every batch-generated recipe PR fails with "recipe not found."

Switch to `tsuku install --recipe <path>` to install directly from the local
recipe file in the checkout. The `--recipe` flag bypasses registry lookup and
parses the TOML file directly.

Also remove cmake and go from the priority queue since they're embedded recipes
and can't exist in both embedded and registry locations (CI enforces this via
the duplicate recipe check). See #1267 for the longer-term fix to the seed
tool.

---

### What This Fixes

Batch recipe generation PRs (like #1270) fail CI because the test workflow
can't find new recipes in the registry. This unblocks the batch pipeline from
producing mergeable PRs.

### Changes

- Linux per-recipe jobs: use `--recipe ${{ matrix.recipe.path }}`
- macOS batch job: derive path from tool name, use `--recipe "$recipe_path"`
- Remove 2 embedded recipes (cmake, go) from priority queue