### PR TITLE
feat(batch): validate generated recipes before including in PR

### DIFF
--- a/cmd/tsuku/install.go
+++ b/cmd/tsuku/install.go
@@ -164,6 +164,10 @@ Test installation in a sandbox container:
 				if err := runInstallWithTelemetry(toolName, resolveVersion, versionConstraint, true, "", telemetryClient); err != nil {
 					// Continue installing other tools even if one fails?
 					// For now, exit on first failure to be safe
+					// TODO(#1273): Distinguish dependency failures (ExitDependencyFailed)
+					// from other install failures. Currently all errors exit with
+					// ExitInstallFailed, which prevents programmatic consumers from
+					// identifying missing dependencies via exit code alone.
 					printError(err)
 					exitWithCode(ExitInstallFailed)
 				}

--- a/docs/designs/DESIGN-batch-recipe-generation.md
+++ b/docs/designs/DESIGN-batch-recipe-generation.md
@@ -24,6 +24,7 @@ Planned
 | [#1256](https://github.com/tsukumogami/tsuku/issues/1256) | Platform constraints in merge job | [#1254](https://github.com/tsukumogami/tsuku/issues/1254) | testable |
 | [#1257](https://github.com/tsukumogami/tsuku/issues/1257) | SLI metrics collection | [#1254](https://github.com/tsukumogami/tsuku/issues/1254) | testable |
 | [#1258](https://github.com/tsukumogami/tsuku/issues/1258) | PR CI platform filtering | [#1256](https://github.com/tsukumogami/tsuku/issues/1256) | testable |
+| [#1273](https://github.com/tsukumogami/tsuku/issues/1273) | Structured JSON CLI output + batch integration | None | testable |
 
 ### Dependency Graph
 
@@ -49,6 +50,7 @@ graph LR
 
     subgraph Future["Future Work"]
         I1253["#1253: Pinned release + source fallback"]
+        I1273["#1273: Structured JSON CLI output"]
     end
 
     I1252 --> I1254
@@ -65,6 +67,7 @@ graph LR
 
     class I1252 ready
     class I1253 blocked
+    class I1273 needsDesign
     class I1254,I1255,I1256,I1257,I1258 blocked
 ```
 

--- a/docs/designs/DESIGN-registry-scale-strategy.md
+++ b/docs/designs/DESIGN-registry-scale-strategy.md
@@ -53,6 +53,7 @@ Implements [#1187](https://github.com/tsukumogami/tsuku/issues/1187). See [DESIG
 | ~~[#1189](https://github.com/tsukumogami/tsuku/issues/1189)~~ | ~~design batch recipe generation CI pipeline~~ | ~~[#1186](https://github.com/tsukumogami/tsuku/issues/1186)~~, ~~[#1187](https://github.com/tsukumogami/tsuku/issues/1187)~~, ~~[#1188](https://github.com/tsukumogami/tsuku/issues/1188)~~, ~~[#1241](https://github.com/tsukumogami/tsuku/issues/1241)~~ | ~~testable~~ |
 | [#1267](https://github.com/tsukumogami/tsuku/issues/1267) | skip existing recipes in seed tool | [#1241](https://github.com/tsukumogami/tsuku/issues/1241) | simple |
 | [#1268](https://github.com/tsukumogami/tsuku/issues/1268) | CI validation of queue against registry | [#1267](https://github.com/tsukumogami/tsuku/issues/1267) | testable |
+| [#1273](https://github.com/tsukumogami/tsuku/issues/1273) | Structured JSON output for CLI + batch integration | None | testable |
 
 Implements [#1189](https://github.com/tsukumogami/tsuku/issues/1189). See [DESIGN-batch-recipe-generation.md](DESIGN-batch-recipe-generation.md) for issue details.
 
@@ -95,6 +96,7 @@ graph TD
         I1189["#1189: Batch recipe generation CI"]
         I1267["#1267: Skip existing in seed tool"]
         I1268["#1268: CI queue vs registry check"]
+        I1273["#1273: Structured JSON CLI output"]
     end
 
     subgraph M_FailureBackend["M-FailureBackend"]
@@ -139,6 +141,7 @@ graph TD
     class I1189 done
     class I1267 needsDesign
     class I1268 needsDesign
+    class I1273 needsDesign
     class I1266 needsDesign
     class I1190 needsDesign
     class I1191 blocked

--- a/internal/batch/orchestrator_test.go
+++ b/internal/batch/orchestrator_test.go
@@ -244,3 +244,194 @@ exit 0
 		t.Errorf("expected queue status success, got %s", queue.Packages[0].Status)
 	}
 }
+
+func TestRun_validationFailureMissingDep(t *testing.T) {
+	tmpDir := t.TempDir()
+	fakeBin := filepath.Join(tmpDir, "tsuku")
+	// Fake binary: "create" succeeds, "install" fails with missing dep error
+	script := `#!/bin/sh
+case "$1" in
+  create)
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --output) shift; mkdir -p "$(dirname "$1")"; echo "[metadata]" > "$1"; shift ;;
+        *) shift ;;
+      esac
+    done
+    exit 0
+    ;;
+  install)
+    echo "Checking dependencies for coreutils..." >&2
+    echo "  Resolving dependency 'dav1d'..." >&2
+    echo "Error: registry: recipe dav1d not found in registry" >&2
+    echo "" >&2
+    echo "Suggestion: Verify the recipe name is correct." >&2
+    echo "Error: failed to install dependency 'dav1d': registry: recipe dav1d not found in registry" >&2
+    exit 6
+    ;;
+esac
+`
+	if err := os.WriteFile(fakeBin, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	queue := &seed.PriorityQueue{
+		SchemaVersion: 1,
+		Packages: []seed.Package{
+			{ID: "homebrew:coreutils", Name: "coreutils", Status: "pending", Tier: 1},
+		},
+	}
+
+	orch := NewOrchestrator(Config{
+		Ecosystem:   "homebrew",
+		BatchSize:   10,
+		MaxTier:     3,
+		QueuePath:   filepath.Join(tmpDir, "queue.json"),
+		OutputDir:   filepath.Join(tmpDir, "recipes"),
+		FailuresDir: filepath.Join(tmpDir, "failures"),
+		TsukuBin:    fakeBin,
+	}, queue)
+
+	result, err := orch.Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Generated != 1 {
+		t.Errorf("expected generated 1, got %d", result.Generated)
+	}
+	if result.Failed != 1 {
+		t.Errorf("expected failed 1, got %d", result.Failed)
+	}
+	if len(result.Recipes) != 0 {
+		t.Errorf("expected 0 validated recipes, got %d", len(result.Recipes))
+	}
+	if len(result.Failures) != 1 {
+		t.Fatalf("expected 1 failure, got %d", len(result.Failures))
+	}
+
+	f := result.Failures[0]
+	if f.Category != "missing_dep" {
+		t.Errorf("expected category missing_dep, got %s", f.Category)
+	}
+	if len(f.BlockedBy) != 1 || f.BlockedBy[0] != "dav1d" {
+		t.Errorf("expected BlockedBy [dav1d], got %v", f.BlockedBy)
+	}
+
+	// Recipe file should be cleaned up
+	recipePath := recipeOutputPath(filepath.Join(tmpDir, "recipes"), "coreutils")
+	if _, err := os.Stat(recipePath); !os.IsNotExist(err) {
+		t.Errorf("expected recipe file to be removed after validation failure")
+	}
+
+	if queue.Packages[0].Status != "failed" {
+		t.Errorf("expected queue status failed, got %s", queue.Packages[0].Status)
+	}
+}
+
+func TestRun_validationFailureGeneric(t *testing.T) {
+	tmpDir := t.TempDir()
+	fakeBin := filepath.Join(tmpDir, "tsuku")
+	// Fake binary: "create" succeeds, "install" fails without dep pattern
+	script := `#!/bin/sh
+case "$1" in
+  create)
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --output) shift; mkdir -p "$(dirname "$1")"; echo "[metadata]" > "$1"; shift ;;
+        *) shift ;;
+      esac
+    done
+    exit 0
+    ;;
+  install)
+    echo "Error: download failed: 404 Not Found" >&2
+    exit 6
+    ;;
+esac
+`
+	if err := os.WriteFile(fakeBin, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	queue := &seed.PriorityQueue{
+		SchemaVersion: 1,
+		Packages: []seed.Package{
+			{ID: "homebrew:testpkg", Name: "testpkg", Status: "pending", Tier: 1},
+		},
+	}
+
+	orch := NewOrchestrator(Config{
+		Ecosystem:   "homebrew",
+		BatchSize:   10,
+		MaxTier:     3,
+		QueuePath:   filepath.Join(tmpDir, "queue.json"),
+		OutputDir:   filepath.Join(tmpDir, "recipes"),
+		FailuresDir: filepath.Join(tmpDir, "failures"),
+		TsukuBin:    fakeBin,
+	}, queue)
+
+	result, err := orch.Run()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	f := result.Failures[0]
+	if f.Category != "validation_failed" {
+		t.Errorf("expected category validation_failed, got %s", f.Category)
+	}
+	if len(f.BlockedBy) != 0 {
+		t.Errorf("expected empty BlockedBy, got %v", f.BlockedBy)
+	}
+}
+
+func TestClassifyValidationFailure(t *testing.T) {
+	tests := []struct {
+		name         string
+		output       string
+		wantCategory string
+		wantBlocked  []string
+	}{
+		{
+			name:         "single missing dep",
+			output:       "Error: registry: recipe dav1d not found in registry\nError: failed to install dependency 'dav1d'",
+			wantCategory: "missing_dep",
+			wantBlocked:  []string{"dav1d"},
+		},
+		{
+			name:         "multiple missing deps",
+			output:       "recipe libfoo not found in registry\nrecipe libbar not found in registry",
+			wantCategory: "missing_dep",
+			wantBlocked:  []string{"libfoo", "libbar"},
+		},
+		{
+			name:         "duplicate dep mentioned twice",
+			output:       "recipe dav1d not found in registry\nfailed to install dependency 'dav1d': registry: recipe dav1d not found in registry",
+			wantCategory: "missing_dep",
+			wantBlocked:  []string{"dav1d"},
+		},
+		{
+			name:         "no dep pattern",
+			output:       "Error: download failed: 404 Not Found",
+			wantCategory: "validation_failed",
+			wantBlocked:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			category, blockedBy := classifyValidationFailure([]byte(tt.output))
+			if category != tt.wantCategory {
+				t.Errorf("category = %q, want %q", category, tt.wantCategory)
+			}
+			if len(blockedBy) != len(tt.wantBlocked) {
+				t.Fatalf("blockedBy = %v, want %v", blockedBy, tt.wantBlocked)
+			}
+			for i, got := range blockedBy {
+				if got != tt.wantBlocked[i] {
+					t.Errorf("blockedBy[%d] = %q, want %q", i, got, tt.wantBlocked[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The batch orchestrator now runs `tsuku install --force --recipe <path>` after
each successful `tsuku create`. Recipes that fail validation are excluded from
the PR and recorded as structured failures. Missing dependency names are
extracted from CLI output so failure records are actionable -- the `BlockedBy`
field is populated with the specific recipe names that are missing from the
registry.

This fixes the issue where PR #1272 included 7 recipes that all failed CI
because their dependencies weren't in the registry. With this change, those
recipes would be filtered out during generation and only installable recipes
make it into the batch PR.

---

Fixes the validation gap identified during walking skeleton testing where
generated recipes were included in PRs without verifying they install.

### What this accomplishes

- `validate()` method on the orchestrator runs install after generation
- `classifyValidationFailure()` parses CLI output to distinguish missing deps
  from other failures, populating `BlockedBy` with missing recipe names
- Failed recipes are deleted from the output directory so they don't appear in the PR
- TODO(#1273) markers added at regex parsing points for future structured JSON replacement

### Test plan

- `TestRun_validationFailureMissingDep`: fake binary simulates missing dep error,
  verifies `missing_dep` category and `BlockedBy: ["dav1d"]`
- `TestRun_validationFailureGeneric`: non-dep failure gets `validation_failed` category
- `TestClassifyValidationFailure`: unit tests for the output parser with single dep,
  multiple deps, duplicate mentions, and non-dep errors