### PR TITLE
fix(search): omit install suggestion when query is empty

### DIFF
--- a/cmd/tsuku/search.go
+++ b/cmd/tsuku/search.go
@@ -19,7 +19,7 @@ var searchCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		query := ""
 		if len(args) > 0 {
-			query = strings.ToLower(args[0])
+			query = strings.ToLower(strings.TrimSpace(args[0]))
 		}
 		jsonOutput, _ := cmd.Flags().GetBool("json")
 
@@ -90,10 +90,14 @@ var searchCmd = &cobra.Command{
 		}
 
 		if len(results) == 0 {
-			printInfof("No cached recipes found for '%s'.\n\n", query)
-			printInfo("Tip: You can still try installing it!")
-			printInfof("   Run: tsuku install %s\n", query)
-			printInfo("   (Tsuku will attempt to find and install it using AI)")
+			if query == "" {
+				printInfo("No cached recipes found.")
+			} else {
+				printInfof("No cached recipes found for '%s'.\n\n", query)
+				printInfo("Tip: You can still try installing it!")
+				printInfof("   Run: tsuku install %s\n", query)
+				printInfo("   (Tsuku will attempt to find and install it using AI)")
+			}
 			return
 		}
 

--- a/test/functional/features/search.feature
+++ b/test/functional/features/search.feature
@@ -4,11 +4,10 @@ Feature: Search
   Background:
     Given a clean tsuku environment
 
-  Scenario: Search with empty string
-    When I run "tsuku search ''"
+  Scenario: Search with no query does not suggest install
+    When I run "tsuku search"
     Then the exit code is 0
-    # TODO: should assert output does not suggest "tsuku install" with empty name
-    # https://github.com/tsukumogami/tsuku/issues/1293
+    And the output does not contain "tsuku install"
 
   Scenario: Search for a known tool
     When I run "tsuku search go"


### PR DESCRIPTION
When search finds no results for an empty or whitespace-only query, the install suggestion was shown with no tool name (e.g., "Run: tsuku install "). Now the suggestion is only shown when the user provided a non-empty query. Empty queries just show "No cached recipes found." without the misleading install tip.

Also trims whitespace from the query to handle whitespace-only input consistently.

---

Fixes #1293

## Test Plan

- Updated `search.feature` to verify empty query does not suggest install
- `make test-functional` passes (search scenarios green)