### PR TITLE
chore(ci): update design doc validation

### DIFF
--- a/.github/scripts/checks/sections.sh
+++ b/.github/scripts/checks/sections.sh
@@ -21,7 +21,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Constants - required sections in order
-readonly REQUIRED_SECTIONS=(
+REQUIRED_SECTIONS=(
     "Status"
     "Context and Problem Statement"
     "Decision Drivers"
@@ -32,6 +32,7 @@ readonly REQUIRED_SECTIONS=(
     "Security Considerations"
     "Consequences"
 )
+readonly REQUIRED_SECTIONS
 
 # Validate arguments
 if [[ $# -lt 1 ]]; then
@@ -107,7 +108,7 @@ for section in "${REQUIRED_SECTIONS[@]}"; do
 done
 
 if [[ "$MISSING_COUNT" -gt 0 ]]; then
-    emit_fail "SC01: Missing $MISSING_COUNT of 9 required sections. See: .github/scripts/docs/SC01.md"
+    emit_fail "SC01: Missing $MISSING_COUNT of ${#REQUIRED_SECTIONS[@]} required sections. See: .github/scripts/docs/SC01.md"
     for section in "${MISSING_SECTIONS[@]}"; do
         echo "       - ## $section" >&2
     done

--- a/.github/scripts/validate-design-doc.sh
+++ b/.github/scripts/validate-design-doc.sh
@@ -40,6 +40,7 @@ source "$CHECKS_DIR/common.sh"
 # Cutoff dates for each check category (ISO 8601 format)
 readonly II_CHECK_CUTOFF="2026-01-01"  # Implementation Issues validation introduced
 
+
 # Check if file was created before a cutoff date
 # Usage: file_predates_check "$DOC_PATH" "$CUTOFF_DATE"
 # Returns: 0 if file predates cutoff (should skip), 1 if file is newer (should check)


### PR DESCRIPTION
Update design document validation scripts and workflow.

---

## What This Changes

- `.github/scripts/validate-design-doc.sh` - Orchestrator that runs modular validation checks
- `.github/scripts/checks/` - Modular check scripts (common.sh, frontmatter.sh, etc.)
- `.github/workflows/validate-design-docs.yml` - Runs validation on all PRs

## How It Works

The workflow finds all DESIGN-*.md files in the repo and validates each one:
- Location: must be under docs/designs/
- Naming: must start with DESIGN-
- Frontmatter: must have valid YAML frontmatter