### PR TITLE
fix(check-deps): remove trailing comma from summary line

### DIFF
--- a/cmd/tsuku/check_deps.go
+++ b/cmd/tsuku/check_deps.go
@@ -371,17 +371,17 @@ func printSummary(statuses []DepStatus) {
 		}
 	}
 
-	fmt.Printf("Summary: %d total, ", total)
+	parts := []string{fmt.Sprintf("%d total", total)}
 	if installed > 0 {
-		fmt.Printf("%s%d installed%s, ", colorGreen, installed, colorReset)
+		parts = append(parts, fmt.Sprintf("%s%d installed%s", colorGreen, installed, colorReset))
 	}
 	if missing > 0 {
-		fmt.Printf("%s%d missing%s, ", colorRed, missing, colorReset)
+		parts = append(parts, fmt.Sprintf("%s%d missing%s", colorRed, missing, colorReset))
 	}
 	if versionMismatch > 0 {
-		fmt.Printf("%s%d version mismatch%s, ", colorYellow, versionMismatch, colorReset)
+		parts = append(parts, fmt.Sprintf("%s%d version mismatch%s", colorYellow, versionMismatch, colorReset))
 	}
-	fmt.Println()
+	fmt.Printf("Summary: %s\n", strings.Join(parts, ", "))
 
 	if systemIssues > 0 {
 		fmt.Printf("\n%sNote:%s %d system dependency issue(s) must be resolved before installation.\n",


### PR DESCRIPTION
The summary line was built by conditionally appending "N status, " for each counter, which left a trailing comma after the last item. For example: `Summary: 3 total, 3 missing, `. Switch to collecting parts in a slice and joining with `strings.Join` so the separator only appears between items.

---

Fixes #1294

## Test Plan

- `go build` and `go vet` pass
- Verified manually: `tsuku check-deps serve` now outputs `Summary: 3 total, 3 missing`