### PR TITLE
fix(registry): use validation error type for 4xx HTTP responses

### DIFF
--- a/internal/registry/errors.go
+++ b/internal/registry/errors.go
@@ -79,6 +79,8 @@ func (e *RegistryError) Suggestion() string {
 		return "There may be a certificate issue. Check your system time is correct"
 	case ErrTypeNotFound:
 		return "Verify the recipe name is correct. Run 'tsuku recipes' to list available recipes"
+	case ErrTypeValidation:
+		return "The request was rejected by the registry. Check that the tool name is valid"
 	case ErrTypeNetwork:
 		return "Check your internet connection and try again"
 	case ErrTypeCacheTooStale:

--- a/internal/registry/errors_test.go
+++ b/internal/registry/errors_test.go
@@ -121,9 +121,9 @@ func TestRegistryError_Suggestion(t *testing.T) {
 			wantEmpty: true,
 		},
 		{
-			name:      "validation has no suggestion",
-			errorType: ErrTypeValidation,
-			wantEmpty: true,
+			name:       "validation has suggestion",
+			errorType:  ErrTypeValidation,
+			wantSubstr: "rejected by the registry",
 		},
 	}
 

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -127,8 +127,12 @@ func (r *Registry) FetchRecipe(ctx context.Context, name string) ([]byte, error)
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		errType := ErrTypeNetwork
+		if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+			errType = ErrTypeValidation
+		}
 		return nil, &RegistryError{
-			Type:    ErrTypeNetwork,
+			Type:    errType,
 			Recipe:  name,
 			Message: fmt.Sprintf("registry returned status %d", resp.StatusCode),
 		}


### PR DESCRIPTION
Non-200 responses from the registry were all classified as network errors, producing misleading "check your internet connection" suggestions for client errors like 400 Bad Request. Now 4xx responses use `ErrTypeValidation` with a suggestion indicating the request was rejected by the registry, while 5xx responses remain as `ErrTypeNetwork`.

---

Fixes #1295

## Test Plan

- Updated `TestRegistryError_Suggestion` to verify validation errors have appropriate suggestion
- `go test ./internal/registry/...` passes