### PR TITLE
chore(ci): update design doc validation

### DIFF
--- a/.github/scripts/checks/implementation-issues.sh
+++ b/.github/scripts/checks/implementation-issues.sh
@@ -101,10 +101,10 @@ for col in "${REQUIRED_COLUMNS[@]}"; do
     fi
 done
 
-# Extract table data rows (skip header and separator)
-# Pattern: | content | content | content | content |
+# Extract table data rows (skip header, separator, and description rows)
+# Description rows have italic text in first cell with empty remaining cells: | _text_ | | | |
 TABLE_ROWS=$(echo "$ISSUES_SECTION" | awk '
-    /^\|/ && !/^\| *-/ && !/^\| *Issue/ { print }
+    /^\|/ && !/^\| *-/ && !/^\| *Issue/ && !/^\| *_/ { print }
 ')
 
 # Parse column positions from header

--- a/.github/scripts/extract-design-issues.sh
+++ b/.github/scripts/extract-design-issues.sh
@@ -178,10 +178,11 @@ parse_table() {
     dep_col=$(get_column_position "$header" "Dependencies")
     tier_col=$(get_column_position "$header" "Tier")
 
-    # Extract table data rows (skip header and separator)
+    # Extract table data rows (skip header, separator, and description rows)
+    # Description rows have italic text in first cell: | _text_ | | | |
     local rows
     rows=$(echo "$table_content" | awk '
-        /^\|/ && !/^\| *-/ && !/^\| *Issue/ { print }
+        /^\|/ && !/^\| *-/ && !/^\| *Issue/ && !/^\| *_/ { print }
     ')
 
     local entries="[]"


### PR DESCRIPTION
Update design document validation scripts and workflow.

---

## What This Changes

- `.github/scripts/validate-design-doc.sh` - Orchestrator that runs modular validation checks
- `.github/scripts/checks/` - Modular check scripts (common.sh, frontmatter.sh, etc.)
- `.github/workflows/validate-design-docs.yml` - Runs validation on all PRs

## How It Works

The workflow finds all DESIGN-*.md files in the repo and validates each one:
- Location: must be under docs/designs/
- Naming: must start with DESIGN-
- Frontmatter: must have valid YAML frontmatter