### PR TITLE
chore(ci): update design doc validation

### DIFF
--- a/.github/scripts/checks/implementation-issues.sh
+++ b/.github/scripts/checks/implementation-issues.sh
@@ -5,7 +5,7 @@
 # Implements implementation issues validation rules:
 #   II00: Section must NOT exist for Proposed/Accepted status
 #   II01: Section exists for Planned status (optional for Current)
-#   II02: Table has correct columns (Issue, Title, Dependencies, Tier)
+#   II02: Table has correct columns (Issue, Dependencies, Tier) or legacy (Issue, Title, Dependencies, Tier)
 #   II03: Issue/milestone links use valid format [#N](url) or [Name](milestone-url)
 #   II04: Dependencies use link format, not plain text
 #   II05: Tier values are valid (simple, testable, critical, milestone)
@@ -90,7 +90,10 @@ if [[ -z "$TABLE_HEADER" ]]; then
 fi
 
 # II02: Validate required columns exist
-REQUIRED_COLUMNS=("Issue" "Title" "Dependencies" "Tier")
+# Accept both formats:
+#   New (3-col): | Issue | Dependencies | Tier |
+#   Legacy (4-col): | Issue | Title | Dependencies | Tier |
+REQUIRED_COLUMNS=("Issue" "Dependencies" "Tier")
 for col in "${REQUIRED_COLUMNS[@]}"; do
     if ! echo "$TABLE_HEADER" | grep -qiE "\| *$col *\|"; then
         # Check if it's the last column (no trailing |)
@@ -149,11 +152,11 @@ is_milestone_link() {
     [[ "$val" =~ ^\[.+\]\(.*milestone.*\)$ ]]
 }
 
-# Helper: Check if a value is an issue link [#N](url)
+# Helper: Check if a value is an issue link [#N](url) or [#N: title](url)
 is_issue_link() {
     local val
     val=$(strip_strikethrough "$1")
-    [[ "$val" =~ ^\[#[0-9]+\]\(.+\)$ ]]
+    [[ "$val" =~ ^\[#[0-9]+(\]|:\ .*\])\(.+\)$ ]]
 }
 
 # Process each row

--- a/.github/scripts/docs/II00.md
+++ b/.github/scripts/docs/II00.md
@@ -43,9 +43,9 @@ status: Accepted
 ```markdown
 ## Implementation Issues
 
-| Issue | Title | Dependencies | Tier |
-|-------|-------|--------------|------|
-| [#123](url) | Task | None | simple |
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#123: Task](url) | None | simple |
 ```
 
 **Valid - Accepted status without Implementation Issues:**

--- a/.github/scripts/docs/II01.md
+++ b/.github/scripts/docs/II01.md
@@ -15,10 +15,10 @@ Add an Implementation Issues section with a milestone and issues table:
 
 ### Milestone: [Feature Name](https://github.com/org/repo/milestone/N)
 
-| Issue | Title | Dependencies | Tier |
-|-------|-------|--------------|------|
-| [#123](https://github.com/org/repo/issues/123) | First task | None | testable |
-| [#124](https://github.com/org/repo/issues/124) | Second task | [#123](https://github.com/org/repo/issues/123) | testable |
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#123: First task](https://github.com/org/repo/issues/123) | None | testable |
+| [#124: Second task](https://github.com/org/repo/issues/124) | [#123](https://github.com/org/repo/issues/123) | testable |
 ```
 
 ## Alternative

--- a/.github/scripts/docs/II02.md
+++ b/.github/scripts/docs/II02.md
@@ -6,8 +6,7 @@ The Implementation Issues table is missing a required column.
 
 | Column | Description |
 |--------|-------------|
-| Issue | Link to GitHub issue: `[#N](url)` |
-| Title | Short issue title |
+| Issue | Link with title: `[#N: <title>](url)` |
 | Dependencies | `None` or comma-separated issue links |
 | Tier | Validation tier: `simple`, `testable`, or `critical` |
 
@@ -15,14 +14,21 @@ The Implementation Issues table is missing a required column.
 
 Add the missing column to the table header and all rows.
 
-**Example - Complete table:**
+**Example - Current format (3-col):**
+```markdown
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#123: Add feature X](https://github.com/org/repo/issues/123) | None | testable |
+| [#124: Update tests](https://github.com/org/repo/issues/124) | [#123](https://github.com/org/repo/issues/123) | testable |
+```
+
+**Legacy format (4-col, still accepted):**
 ```markdown
 | Issue | Title | Dependencies | Tier |
 |-------|-------|--------------|------|
 | [#123](https://github.com/org/repo/issues/123) | Add feature X | None | testable |
-| [#124](https://github.com/org/repo/issues/124) | Update tests | [#123](https://github.com/org/repo/issues/123) | testable |
 ```
 
 ## Note
 
-Column order matters. Use exactly: Issue, Title, Dependencies, Tier.
+Required columns: Issue, Dependencies, Tier. The legacy Title column is optional.

--- a/.github/scripts/docs/II04.md
+++ b/.github/scripts/docs/II04.md
@@ -7,23 +7,23 @@ The Dependencies column contains plain text instead of proper links.
 Dependencies must use markdown link format:
 
 ```markdown
-| Issue | Title | Dependencies | Tier |
-|-------|-------|--------------|------|
-| [#124](url) | Task B | [#123](url) | testable |
-| [#125](url) | Task C | [#123](url), [#124](url) | testable |
-| [#126](url) | Task D | None | testable |
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#124: Task B](url) | [#123](url) | testable |
+| [#125: Task C](url) | [#123](url), [#124](url) | testable |
+| [#126: Task D](url) | None | testable |
 ```
 
 ## Common Mistakes
 
 **Plain text (invalid):**
 ```markdown
-| [#124](url) | Task B | #123 | testable |
+| [#124: Task B](url) | #123 | testable |
 ```
 
 **Mixed format (invalid):**
 ```markdown
-| [#124](url) | Task B | #123, [#122](url) | testable |
+| [#124: Task B](url) | #123, [#122](url) | testable |
 ```
 
 ## How to Fix
@@ -32,12 +32,12 @@ Convert all dependencies to link format:
 
 **Before:**
 ```markdown
-| [#124](https://github.com/org/repo/issues/124) | Task B | #123 | testable |
+| [#124: Task B](https://github.com/org/repo/issues/124) | #123 | testable |
 ```
 
 **After:**
 ```markdown
-| [#124](https://github.com/org/repo/issues/124) | Task B | [#123](https://github.com/org/repo/issues/123) | testable |
+| [#124: Task B](https://github.com/org/repo/issues/124) | [#123](https://github.com/org/repo/issues/123) | testable |
 ```
 
 Use `None` (not `N/A` or empty) when there are no dependencies.

--- a/.github/scripts/docs/MM06.md
+++ b/.github/scripts/docs/MM06.md
@@ -8,10 +8,10 @@ Every issue in the table should have a corresponding node in the diagram:
 
 **Table:**
 ```markdown
-| Issue | Title | Dependencies | Tier |
-|-------|-------|--------------|------|
-| [#123](url) | Task A | None | testable |
-| [#124](url) | Task B | [#123](url) | testable |
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#123: Task A](url) | None | testable |
+| [#124: Task B](url) | [#123](url) | testable |
 ```
 
 **Diagram:**

--- a/.github/scripts/docs/MM09.md
+++ b/.github/scripts/docs/MM09.md
@@ -8,10 +8,10 @@ Every node in the diagram must correspond to an issue in the table:
 
 **Table:**
 ```markdown
-| Issue | Title | Dependencies | Tier |
-|-------|-------|--------------|------|
-| [#123](url) | Task A | None | testable |
-| [#124](url) | Task B | [#123](url) | testable |
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#123: Task A](url) | None | testable |
+| [#124: Task B](url) | [#123](url) | testable |
 ```
 
 **Diagram:**

--- a/.github/scripts/extract-design-issues.sh
+++ b/.github/scripts/extract-design-issues.sh
@@ -204,7 +204,15 @@ parse_table() {
         entry_type=$(get_entry_type "$issue_val" "$tier_val")
         entry_number=$(extract_number "$issue_val" "$entry_type")
         entry_url=$(extract_link_url "$issue_val")
-        entry_title=$(strip_strikethrough "$title_val")
+        # Title: from Title column (legacy) or from issue link text [#N: title](url)
+        if [[ -n "$title_col" && -n "$title_val" ]]; then
+            entry_title=$(strip_strikethrough "$title_val")
+        else
+            # Extract title from issue link: [#N: title](url) -> title
+            local link_text
+            link_text=$(extract_link_text "$issue_val")
+            entry_title=$(echo "$link_text" | sed 's/^#[0-9]*: *//')
+        fi
         entry_tier=$(strip_strikethrough "$tier_val")
         entry_deps=$(parse_dependencies "$dep_val")
 


### PR DESCRIPTION
Update design document validation scripts and workflow.

---

## What This Changes

- `.github/scripts/validate-design-doc.sh` - Orchestrator that runs modular validation checks
- `.github/scripts/checks/` - Modular check scripts (common.sh, frontmatter.sh, etc.)
- `.github/workflows/validate-design-docs.yml` - Runs validation on all PRs

## How It Works

The workflow finds all DESIGN-*.md files in the repo and validates each one:
- Location: must be under docs/designs/
- Naming: must start with DESIGN-
- Frontmatter: must have valid YAML frontmatter