### PR TITLE
chore(ci): update design doc validation

### DIFF
--- a/.github/scripts/checks/mermaid.sh
+++ b/.github/scripts/checks/mermaid.sh
@@ -21,6 +21,7 @@
 #   MM16: needs-design label cannot have class 'ready'
 #   MM17: Node with no open blockers cannot have class 'blocked'
 #   MM18: Node with open blocker cannot have class 'ready'
+#   MM19: Node with open blocker cannot have class 'needsDesign'
 #
 # Usage:
 #   mermaid.sh [-q|--quiet] [--skip-status-check] [--github-state <file>] [--pr <number>] <doc-path>
@@ -565,6 +566,13 @@ if [[ "$SKIP_STATUS_CHECK" -eq 0 ]] && { [[ -n "$GITHUB_STATE_FILE" ]] || comman
         if [[ "$ACTUAL" == "ready" ]] && node_has_open_blocker "$node"; then
             BLOCKER_LIST="${BLOCKERS[$node]:-}"
             emit_fail "MM18: Node $node has class 'ready' but is blocked by open dependencies ($(echo "$BLOCKER_LIST" | sed 's/^ //; s/ /, /g')). See: .github/scripts/docs/MM18.md"
+            FAILED=1
+        fi
+
+        # MM19: needsDesign cannot have open blockers (should be 'blocked')
+        if [[ "$ACTUAL" == "needsDesign" ]] && node_has_open_blocker "$node"; then
+            BLOCKER_LIST="${BLOCKERS[$node]:-}"
+            emit_fail "MM19: Node $node has class 'needsDesign' but is blocked by open dependencies ($(echo "$BLOCKER_LIST" | sed 's/^ //; s/ /, /g')), expected 'blocked'. See: .github/scripts/docs/MM19.md"
             FAILED=1
         fi
     done <<< "$DIAGRAM_NODES"

--- a/.github/scripts/docs/MM19.md
+++ b/.github/scripts/docs/MM19.md
@@ -1,0 +1,17 @@
+# MM19: needsDesign node has open blockers
+
+A node with class `needsDesign` has open blocking dependencies. Nodes with open blockers should use class `blocked` instead.
+
+## Why This Matters
+
+The `needsDesign` class indicates future work that hasn't been designed yet. However, if a node has open dependencies, it's also blocked -- and the `blocked` status takes precedence since it reflects the actual workflow state.
+
+## How to Fix
+
+Change the node's class from `needsDesign` to `blocked`:
+
+```
+class I1315 blocked
+```
+
+Or if the dependency is already complete, remove the dependency edge and keep `needsDesign`.


### PR DESCRIPTION
Update design document validation scripts and workflow.

---

## What This Changes

- `.github/scripts/validate-design-doc.sh` - Orchestrator that runs modular validation checks
- `.github/scripts/checks/` - Modular check scripts (common.sh, frontmatter.sh, etc.)
- `.github/workflows/validate-design-docs.yml` - Runs validation on all PRs

## How It Works

The workflow finds all DESIGN-*.md files in the repo and validates each one:
- Location: must be under docs/designs/
- Naming: must start with DESIGN-
- Frontmatter: must have valid YAML frontmatter