### PR TITLE
feat(batch): add half-open circuit breaker transition and probe limiting

### DIFF
--- a/.github/workflows/batch-generate.yml
+++ b/.github/workflows/batch-generate.yml
@@ -44,18 +44,38 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Preflight circuit breaker check
+        id: preflight
         run: |
           STATE=$(jq -r --arg eco "${{ inputs.ecosystem }}" \
             '.circuit_breaker[$eco].state // "closed"' batch-control.json)
+
           if [ "$STATE" = "open" ]; then
-            OPENED_AT=$(jq -r --arg eco "${{ inputs.ecosystem }}" \
-              '.circuit_breaker[$eco].last_failure // "unknown"' batch-control.json)
-            FAILURES=$(jq -r --arg eco "${{ inputs.ecosystem }}" \
-              '.circuit_breaker[$eco].failures // 0' batch-control.json)
-            echo "::error::Circuit breaker is OPEN for ${{ inputs.ecosystem }} (${FAILURES} consecutive failures, last failure: ${OPENED_AT}). Skipping batch generation."
-            exit 1
+            OPENS_AT=$(jq -r --arg eco "${{ inputs.ecosystem }}" \
+              '.circuit_breaker[$eco].opens_at // ""' batch-control.json)
+            NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+            if [ -n "$OPENS_AT" ] && [[ "$NOW" > "$OPENS_AT" ]]; then
+              # Timeout expired: transition to half-open for probe
+              jq --arg eco "${{ inputs.ecosystem }}" --arg now "$NOW" \
+                '.circuit_breaker[$eco].state = "half-open"' \
+                batch-control.json > batch-control.tmp && mv batch-control.tmp batch-control.json
+              STATE="half-open"
+              echo "::notice::Circuit breaker transitioned to half-open for ${{ inputs.ecosystem }} (recovery timeout expired). Running probe batch (size=1)."
+              echo "batch_size_override=1" >> "$GITHUB_OUTPUT"
+            else
+              FAILURES=$(jq -r --arg eco "${{ inputs.ecosystem }}" \
+                '.circuit_breaker[$eco].failures // 0' batch-control.json)
+              echo "::error::Circuit breaker is OPEN for ${{ inputs.ecosystem }} (${FAILURES} consecutive failures, recovery at: ${OPENS_AT}). Skipping batch generation."
+              exit 1
+            fi
           fi
-          echo "Circuit breaker check passed for ${{ inputs.ecosystem }} (state: ${STATE})"
+
+          if [ "$STATE" = "half-open" ]; then
+            echo "Circuit breaker is half-open for ${{ inputs.ecosystem }}. Running probe batch (size=1)."
+            echo "batch_size_override=1" >> "$GITHUB_OUTPUT"
+          else
+            echo "Circuit breaker check passed for ${{ inputs.ecosystem }} (state: ${STATE})"
+          fi
 
       - uses: actions/setup-go@v5
         with:
@@ -73,9 +93,11 @@ jobs:
 
       - name: Run batch generation
         run: |
+          OVERRIDE="${{ steps.preflight.outputs.batch_size_override }}"
+          BATCH_SIZE="${OVERRIDE:-${{ inputs.batch_size }}}"
           ./batch-generate \
             -ecosystem "${{ inputs.ecosystem }}" \
-            -batch-size "${{ inputs.batch_size }}" \
+            -batch-size "$BATCH_SIZE" \
             -tier "${{ inputs.tier }}"
 
       - name: Requeue unblocked packages

--- a/docs/designs/DESIGN-batch-recipe-generation.md
+++ b/docs/designs/DESIGN-batch-recipe-generation.md
@@ -20,7 +20,7 @@ Planned
 | ~~[#1252](https://github.com/tsukumogami/tsuku/issues/1252)~~ | ~~Preflight job and rate limiting~~ | ~~None~~ | ~~testable~~ |
 | [#1253](https://github.com/tsukumogami/tsuku/issues/1253) | Pinned release with source fallback | [#1258](https://github.com/tsukumogami/tsuku/issues/1258) | simple |
 | ~~[#1254](https://github.com/tsukumogami/tsuku/issues/1254)~~ | ~~Multi-platform validation jobs~~ | ~~[#1252](https://github.com/tsukumogami/tsuku/issues/1252)~~ | ~~testable~~ |
-| [#1255](https://github.com/tsukumogami/tsuku/issues/1255) | Circuit breaker integration (preflight side) | [#1252](https://github.com/tsukumogami/tsuku/issues/1252), [M63](https://github.com/tsukumogami/tsuku/milestone/63) | testable |
+| ~~[#1255](https://github.com/tsukumogami/tsuku/issues/1255)~~ | ~~Circuit breaker integration (preflight side)~~ | ~~[#1252](https://github.com/tsukumogami/tsuku/issues/1252), [M63](https://github.com/tsukumogami/tsuku/milestone/63)~~ | ~~testable~~ |
 | ~~[#1256](https://github.com/tsukumogami/tsuku/issues/1256)~~ | ~~Platform constraints in merge job~~ | ~~[M60](https://github.com/tsukumogami/tsuku/milestone/60)~~ | ~~testable~~ |
 | ~~[#1257](https://github.com/tsukumogami/tsuku/issues/1257)~~ | ~~SLI metrics collection~~ | ~~[M60](https://github.com/tsukumogami/tsuku/milestone/60)~~ | ~~testable~~ |
 | [#1258](https://github.com/tsukumogami/tsuku/issues/1258) | PR CI platform filtering | [#1256](https://github.com/tsukumogami/tsuku/issues/1256) | testable |
@@ -80,7 +80,8 @@ graph LR
     class M60,I1256 done
     class M63 done
     class I1252 done
-    class I1287,M61,I1255 ready
+    class I1255 done
+    class I1287,M61 ready
     class I1253 blocked
     class M64 ready
     class I1258 ready


### PR DESCRIPTION
Expand the preflight circuit breaker check to handle the full state machine. When an ecosystem's breaker is open and its recovery timeout has expired, the preflight step transitions it to half-open and limits batch size to 1 for a probe run. This lets the pipeline automatically test recovery without manual intervention.

The three paths through preflight are now:
- **Closed**: normal operation, no changes
- **Open (timeout not expired)**: fail early, skip generation
- **Open (timeout expired)**: transition to half-open, set batch_size=1
- **Half-open**: set batch_size=1 for probe

The merge job side already handles half-open outcomes via `update_breaker.sh`: a successful probe closes the breaker, a failed probe reopens it with a fresh 60-minute timeout.

---

Fixes #1255

## What This Accomplishes

Completes the circuit breaker feedback loop. The pipeline can now automatically recover from ecosystem failures: after 5 consecutive failures the breaker opens, after 60 minutes it transitions to half-open for a single-package probe, and on success it closes again. No manual batch-control.json editing required for recovery.

## Test Plan

- Manual: set an ecosystem's breaker to open with an `opens_at` in the past, trigger workflow, verify it transitions to half-open and runs with batch_size=1
- Manual: set breaker to open with future `opens_at`, verify workflow fails at preflight
- The `update_breaker.sh` half-open handling is covered by existing merge job behavior (#1352)