### PR TITLE
test: validate platform filtering in recipe CI

### DIFF
--- a/recipes/b/btop.toml
+++ b/recipes/b/btop.toml
@@ -1,3 +1,4 @@
+# Platform filtering validation test
 [metadata]
 name = "btop"
 description = "Resource monitor that shows usage and stats"

--- a/recipes/f/fzf.toml
+++ b/recipes/f/fzf.toml
@@ -1,3 +1,4 @@
+# Platform filtering validation test
 [metadata]
 name = "fzf"
 description = "Command-line fuzzy finder"


### PR DESCRIPTION
Test PR to validate the platform filtering logic from #1258. Do not merge.

Adds no-op comments to two recipes:
- **btop** (Linux-only) - should appear only in the Linux matrix, NOT in macOS
- **fzf** (cross-platform) - should appear in both Linux and macOS

Expected behavior in the Detect Changes job output:
- `recipes` output: both btop and fzf
- `macos_recipes` output: only fzf
- Linux jobs: btop and fzf
- macOS job: fzf only