### PR TITLE
ci(discover): add weekly discovery registry freshness check

### DIFF
--- a/.github/workflows/discovery-freshness.yml
+++ b/.github/workflows/discovery-freshness.yml
@@ -1,0 +1,95 @@
+# Weekly freshness check for discovery registry entries.
+#
+# Validates that all entries in recipes/discovery/ still resolve to valid
+# sources (repos not archived/deleted, formulas not deprecated, etc.).
+#
+# On failure, creates a GitHub issue listing stale entries.
+name: Discovery Registry Freshness
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly Monday 6 AM UTC
+  workflow_dispatch: {}
+
+jobs:
+  validate:
+    name: Validate Discovery Entries
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: 'go.mod'
+          cache-dependency-path: go.sum
+
+      - name: Build seed-discovery
+        run: go build -o seed-discovery ./cmd/seed-discovery
+
+      - name: Validate discovery entries
+        id: validate
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ./seed-discovery --validate-only recipes/discovery --verbose 2>&1 | tee validation.log
+        continue-on-error: true
+
+      - name: Check validation result
+        id: check
+        run: |
+          if grep -q "0 failed" validation.log; then
+            echo "passed=true" >> $GITHUB_OUTPUT
+          else
+            echo "passed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create failure issue
+        if: steps.check.outputs.passed == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Extract failure lines from log
+          FAILURES=$(grep -A1 "Failures:" validation.log | tail -n +2 || true)
+          if [ -z "$FAILURES" ]; then
+            FAILURES="See workflow run for details."
+          fi
+
+          BODY="$(cat <<EOF
+          ## Discovery Registry Freshness Check Failed
+
+          The weekly freshness check found stale entries in the discovery registry.
+
+          **Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+          ### Stale Entries
+
+          \`\`\`
+          $FAILURES
+          \`\`\`
+
+          ### Next Steps
+
+          1. Check the workflow run for detailed logs
+          2. Remove or update stale entries
+          3. Re-run the workflow to verify fixes
+          EOF
+          )"
+
+          # Check for existing open issue
+          EXISTING=$(gh issue list --label "maintenance,discovery-registry" --state open --json number --limit 1 | jq -r '.[0].number // empty')
+
+          if [ -n "$EXISTING" ]; then
+            echo "Adding comment to existing issue #$EXISTING"
+            gh issue comment "$EXISTING" --body "$BODY"
+          else
+            echo "Creating new issue"
+            gh issue create \
+              --title "[Automated] Discovery Registry Freshness Check Failed - $(date +%Y-%m-%d)" \
+              --body "$BODY" \
+              --label "maintenance,discovery-registry"
+          fi
+
+          exit 1

--- a/docs/designs/current/DESIGN-discovery-registry-bootstrap.md
+++ b/docs/designs/current/DESIGN-discovery-registry-bootstrap.md
@@ -1,5 +1,5 @@
 ---
-status: Planned
+status: Current
 problem: |
   The discovery registry has 1 entry but needs ~500 for the resolver to deliver value.
   The registry is the only resolver stage that exists today — the ecosystem probe and
@@ -28,7 +28,7 @@ rationale: |
 
 ## Status
 
-Planned
+Current
 
 ## Implementation Issues
 
@@ -41,35 +41,8 @@ Planned
 | ~~[#1366: feat(discover): add metadata enrichment to seed-discovery tool](https://github.com/tsukumogami/tsuku/issues/1366)~~ | ~~[#1364](https://github.com/tsukumogami/tsuku/issues/1364)~~ | ~~testable~~ |
 | ~~[#1367: feat(discover): add recipe cross-reference and graduation logic](https://github.com/tsukumogami/tsuku/issues/1367)~~ | ~~[#1364](https://github.com/tsukumogami/tsuku/issues/1364)~~ | ~~testable~~ |
 | ~~[#1368: feat(discover): curate seed lists for ~500 discovery entries](https://github.com/tsukumogami/tsuku/issues/1368)~~ | ~~[#1364](https://github.com/tsukumogami/tsuku/issues/1364)~~ | ~~simple~~ |
-| [#1369: ci(discover): add weekly discovery registry freshness check](https://github.com/tsukumogami/tsuku/issues/1369) | [#1364](https://github.com/tsukumogami/tsuku/issues/1364) | simple |
-| _Adds a GitHub Actions workflow that validates existing `discovery.json` entries weekly, checking that referenced repositories and packages still exist, and creates an issue listing any stale entries._ | | |
+| ~~[#1369: ci(discover): add weekly discovery registry freshness check](https://github.com/tsukumogami/tsuku/issues/1369)~~ | ~~[#1364](https://github.com/tsukumogami/tsuku/issues/1364)~~ | ~~simple~~ |
 
-### Dependency Graph
-
-```mermaid
-graph LR
-    I1364["#1364: seed-discovery tool (skeleton)"]
-    I1365["#1365: registry optional metadata"]
-    I1366["#1366: metadata enrichment"]
-    I1367["#1367: recipe cross-ref + graduation"]
-    I1368["#1368: curate seed lists (~500)"]
-    I1369["#1369: CI freshness check"]
-
-    I1364 --> I1366
-    I1364 --> I1367
-    I1364 --> I1368
-    I1364 --> I1369
-
-    classDef done fill:#c8e6c9
-    classDef ready fill:#bbdefb
-    classDef blocked fill:#fff9c4
-    classDef needsDesign fill:#e1bee7
-
-    class I1364,I1365,I1366,I1367,I1368 done
-    class I1369 ready
-```
-
-**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design
 
 ## Upstream Design Reference
 


### PR DESCRIPTION
Add a GitHub Actions workflow that validates discovery registry entries weekly (Monday 6 AM UTC). The workflow builds the seed-discovery tool and runs its `--validate-only` mode against `recipes/discovery/`, checking that all entries still resolve to valid sources. On failure, it creates a GitHub issue listing stale entries with a link to the workflow run. The workflow deduplicates by commenting on existing open issues rather than creating new ones.

Also marks all milestone 62 issues as complete in the design doc and transitions its status to Complete.

---

Fixes #1369

### What This Accomplishes

- Catches stale discovery entries (archived repos, deleted packages, ownership changes) before users hit them
- Completes the last issue in the Discovery Registry Bootstrap milestone