### PR TITLE
fix(cli): recognize TSUKU_TELEMETRY=0 as telemetry opt-out

### DIFF
--- a/docs/ENVIRONMENT.md
+++ b/docs/ENVIRONMENT.md
@@ -61,6 +61,15 @@ Disable telemetry collection.
 
 When set to any non-empty value, tsuku will not send any telemetry data. This takes precedence over the `telemetry` setting in `config.toml`.
 
+### TSUKU_TELEMETRY
+
+Alternative way to control telemetry.
+
+- **Default:** (unset - telemetry enabled)
+- **Example:** `export TSUKU_TELEMETRY=0`
+
+Setting this to `0` or `false` disables telemetry. This is an alias for `TSUKU_NO_TELEMETRY` for users who prefer the `VARIABLE=0` convention.
+
 ### TSUKU_TELEMETRY_DEBUG
 
 Enable telemetry debug mode.
@@ -162,6 +171,7 @@ To create a token:
 | `TSUKU_RECIPE_CACHE_MAX_STALE` | `168h` | Maximum stale cache age for fallback |
 | `TSUKU_RECIPE_CACHE_STALE_FALLBACK` | `true` | Enable stale-if-error fallback |
 | `TSUKU_NO_TELEMETRY` | (unset) | Disable telemetry when set |
+| `TSUKU_TELEMETRY` | (unset) | Disable telemetry when `0` or `false` |
 | `TSUKU_TELEMETRY_DEBUG` | (unset) | Print telemetry to stderr |
 | `TSUKU_DEBUG` | (unset) | Enable verbose debug output |
 | `GITHUB_TOKEN` | (unset) | GitHub API token |

--- a/internal/telemetry/client.go
+++ b/internal/telemetry/client.go
@@ -16,6 +16,11 @@ const (
 	// EnvNoTelemetry disables telemetry when set to any non-empty value.
 	EnvNoTelemetry = "TSUKU_NO_TELEMETRY"
 
+	// EnvTelemetry disables telemetry when set to "0" or "false".
+	// This is an alias for TSUKU_NO_TELEMETRY for users who expect
+	// TSUKU_TELEMETRY=0 to work.
+	EnvTelemetry = "TSUKU_TELEMETRY"
+
 	// EnvDebug enables debug mode: prints events to stderr without sending.
 	EnvDebug = "TSUKU_TELEMETRY_DEBUG"
 
@@ -34,14 +39,26 @@ type Client struct {
 	debug    bool
 }
 
+// DisabledByEnv reports whether telemetry is disabled via environment variables.
+// It checks TSUKU_NO_TELEMETRY (any non-empty value) and TSUKU_TELEMETRY ("0" or "false").
+func DisabledByEnv() bool {
+	if os.Getenv(EnvNoTelemetry) != "" {
+		return true
+	}
+	if v := os.Getenv(EnvTelemetry); v == "0" || v == "false" {
+		return true
+	}
+	return false
+}
+
 // NewClient creates a telemetry client.
-// It checks TSUKU_NO_TELEMETRY env var first (takes precedence), then config file.
+// It checks environment variables first (takes precedence), then config file.
 // TSUKU_TELEMETRY_DEBUG enables debug mode.
 func NewClient() *Client {
 	disabled := false
 
 	// Environment variable takes precedence
-	if os.Getenv(EnvNoTelemetry) != "" {
+	if DisabledByEnv() {
 		disabled = true
 	} else {
 		// Check config file

--- a/internal/telemetry/client_test.go
+++ b/internal/telemetry/client_test.go
@@ -16,6 +16,7 @@ func TestNewClient_Default(t *testing.T) {
 	// Clear env vars using t.Setenv with empty string won't work,
 	// so we unset them and ignore errors (they may not be set)
 	_ = os.Unsetenv(EnvNoTelemetry)
+	_ = os.Unsetenv(EnvTelemetry)
 	_ = os.Unsetenv(EnvDebug)
 
 	c := NewClient()
@@ -55,6 +56,40 @@ func TestNewClient_DisabledAnyValue(t *testing.T) {
 
 	if !c.disabled {
 		t.Error("disabled = false, want true")
+	}
+}
+
+func TestDisabledByEnv_TsukuTelemetryZero(t *testing.T) {
+	_ = os.Unsetenv(EnvNoTelemetry)
+	t.Setenv(EnvTelemetry, "0")
+	if !DisabledByEnv() {
+		t.Error("DisabledByEnv() = false, want true for TSUKU_TELEMETRY=0")
+	}
+}
+
+func TestDisabledByEnv_TsukuTelemetryFalse(t *testing.T) {
+	_ = os.Unsetenv(EnvNoTelemetry)
+	t.Setenv(EnvTelemetry, "false")
+	if !DisabledByEnv() {
+		t.Error("DisabledByEnv() = false, want true for TSUKU_TELEMETRY=false")
+	}
+}
+
+func TestDisabledByEnv_TsukuTelemetryOne(t *testing.T) {
+	// TSUKU_TELEMETRY=1 means telemetry is enabled, not disabled
+	_ = os.Unsetenv(EnvNoTelemetry)
+	t.Setenv(EnvTelemetry, "1")
+	if DisabledByEnv() {
+		t.Error("DisabledByEnv() = true, want false for TSUKU_TELEMETRY=1")
+	}
+}
+
+func TestNewClient_DisabledByTsukuTelemetryZero(t *testing.T) {
+	_ = os.Unsetenv(EnvNoTelemetry)
+	t.Setenv(EnvTelemetry, "0")
+	c := NewClient()
+	if !c.disabled {
+		t.Error("disabled = false, want true for TSUKU_TELEMETRY=0")
 	}
 }
 

--- a/internal/telemetry/notice.go
+++ b/internal/telemetry/notice.go
@@ -28,7 +28,7 @@ To opt out: tsuku config set telemetry false
 // Returns silently on any error (file permissions, etc.).
 func ShowNoticeIfNeeded() {
 	// Don't show notice if telemetry is disabled via env var
-	if os.Getenv(EnvNoTelemetry) != "" {
+	if DisabledByEnv() {
 		return
 	}
 


### PR DESCRIPTION
The telemetry system only checked `TSUKU_NO_TELEMETRY` but users
reasonably expect `TSUKU_TELEMETRY=0` to work. A new `DisabledByEnv()`
helper checks both env vars and is used from both `NewClient()` and
`ShowNoticeIfNeeded()`.

`TSUKU_TELEMETRY=0` and `TSUKU_TELEMETRY=false` now suppress telemetry
and the first-run notice. Other values like `TSUKU_TELEMETRY=1` have no
effect.

---

## What This Fixes

Setting `TSUKU_TELEMETRY=0` had no effect — the telemetry prompt still
appeared and events were still sent. Only `TSUKU_NO_TELEMETRY=1` worked.

## Test Plan

New unit tests cover `DisabledByEnv()` for `TSUKU_TELEMETRY=0`,
`TSUKU_TELEMETRY=false`, and `TSUKU_TELEMETRY=1` (should not disable).

Fixes #1348