### PR TITLE
docs(design): mark DESIGN-merge-job-completion as current, M64 done

### DIFF
--- a/docs/designs/DESIGN-batch-recipe-generation.md
+++ b/docs/designs/DESIGN-batch-recipe-generation.md
@@ -27,7 +27,7 @@ Planned
 | ~~[#1273](https://github.com/tsukumogami/tsuku/issues/1273)~~ | ~~Structured JSON CLI output + batch integration~~ | ~~None~~ | ~~testable~~ |
 | ~~[#1287](https://github.com/tsukumogami/tsuku/issues/1287)~~ | ~~Auto-install required toolchains for ecosystem builders~~ | ~~None~~ | ~~testable~~ |
 | ~~[M63](https://github.com/tsukumogami/tsuku/milestone/63)~~ | ~~Merge Job Completion (batch_id, recipe tracking, circuit breaker update, queue sync)~~ | ~~None~~ | |
-| [M64](https://github.com/tsukumogami/tsuku/milestone/64) | Merge Job Observability (SLI metrics, auto-merge gating) | [M63](https://github.com/tsukumogami/tsuku/milestone/63) | |
+| ~~[M64](https://github.com/tsukumogami/tsuku/milestone/64)~~ | ~~Merge Job Observability (SLI metrics, auto-merge gating)~~ | ~~[M63](https://github.com/tsukumogami/tsuku/milestone/63)~~ | |
 
 ### Dependency Graph
 
@@ -84,7 +84,7 @@ graph LR
     class I1258 done
     class M61 ready
     class I1253 ready
-    class M64 ready
+    class M64 done
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design
@@ -551,7 +551,7 @@ The preflight job reads `batch-control.json` and skips ecosystems with open circ
 }
 ```
 
-The preflight job should also check for open batch PRs (`gh pr list --label batch --state open`) and skip the run if one exists. This prevents conflicting PRs and is a prerequisite for safe auto-merge (see [DESIGN-merge-job-completion.md](DESIGN-merge-job-completion.md)).
+The preflight job should also check for open batch PRs (`gh pr list --label batch --state open`) and skip the run if one exists. This prevents conflicting PRs and is a prerequisite for safe auto-merge (see [DESIGN-merge-job-completion.md](current/DESIGN-merge-job-completion.md)).
 
 After generation, the merge job updates circuit breaker state:
 - Track consecutive failures per ecosystem

--- a/docs/designs/current/DESIGN-merge-job-completion.md
+++ b/docs/designs/current/DESIGN-merge-job-completion.md
@@ -1,5 +1,5 @@
 ---
-status: Planned
+status: Current
 problem: |
   The batch-generate merge job has working constraint derivation and PR creation but lacks structured commit messages with batch metadata, SLI metrics collection, circuit breaker state updates, and auto-merge gating required by DESIGN-batch-recipe-generation.md for pipeline observability and scale.
 decision: |
@@ -12,7 +12,7 @@ rationale: |
 
 ## Status
 
-Planned
+Current
 
 ## Implementation Issues
 
@@ -39,38 +39,6 @@ Observability and scale improvements: SLI metrics for trend analysis and auto-me
 | _Appends a structured JSON line to `data/metrics/batch-runs.jsonl` with per-platform tested/passed/failed counts, recipe totals, and duration. Uses the batch_id from #1349 as the primary key._ | | |
 | ~~[#1353: ci(batch): add auto-merge gating for clean batches](https://github.com/tsukumogami/tsuku/issues/1353)~~ | [#1350](https://github.com/tsukumogami/tsuku/issues/1350) | testable |
 | _Enables `gh pr merge --auto --squash` when `EXCLUDED_COUNT=0` and leaves a PR comment explaining why auto-merge was skipped otherwise. Fail-open policy: the PR is always created regardless._ | | |
-
-### Dependency Graph
-
-```mermaid
-graph LR
-    subgraph M63["M63: Merge Job Completion"]
-        I1349["#1349: batch_id + structured commit"]
-        I1350["#1350: recipe list tracking"]
-        I1352["#1352: circuit breaker + queue"]
-    end
-
-    subgraph M64["M64: Merge Job Observability"]
-        I1351["#1351: SLI metrics collection"]
-        I1353["#1353: auto-merge gating"]
-    end
-
-    I1350 --> I1352
-    I1349 --> I1351
-    I1350 --> I1353
-
-    classDef done fill:#c8e6c9
-    classDef ready fill:#bbdefb
-    classDef blocked fill:#fff9c4
-    classDef needsDesign fill:#e1bee7
-
-    class I1349,I1350 done
-    class I1352 done
-    class I1351 done
-    class I1353 done
-```
-
-**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design
 
 ## Upstream Design Reference
 


### PR DESCRIPTION
Status updates for completed milestones:

- DESIGN-merge-job-completion.md: Planned → Current (all issues done)
- DESIGN-batch-recipe-generation.md: M64 marked complete

No issue for this change — straightforward doc status update.