### PR TITLE
feat(recipes): add batch homebrew recipes (2 recipes)

### DIFF
--- a/data/failures/homebrew.jsonl
+++ b/data/failures/homebrew.jsonl
@@ -28,3 +28,6 @@
 {"schema_version":1,"recipe":"htop","platform":"linux-suse-glibc-arm64","exit_code":6,"category":"deterministic","timestamp":"2026-02-03T13:24:28Z"}
 {"schema_version":1,"recipe":"htop","platform":"linux-alpine-musl-arm64","exit_code":6,"category":"deterministic","timestamp":"2026-02-03T13:24:28Z"}
 {"schema_version":1,"recipe":"htop","platform":"darwin-x86_64","exit_code":124,"category":"timeout","timestamp":"2026-02-03T13:24:28Z"}
+{"schema_version":1,"ecosystem":"homebrew","environment":"linux-glibc-x86_64","updated_at":"2026-02-03T15:56:55Z","failures":[{"package_id":"homebrew:hyperfine","category":"validation_failed","message":"Warning: Skipping recipe review (--yes). The recipe will be installed without confirmation.\nCreating recipe for hyperfine from homebrew:hyperfine...\nFetching formula metadata... done (v1.20.0)\nInspecting bottle contents... done (deterministic)\nError: recipe already exists at recipes/h/hyperfine.toml\nUse --force to overwrite","timestamp":"2026-02-03T15:56:55.582777453Z"}]}
+{"schema_version":1,"recipe":"tokei","platform":"linux-alpine-musl-x86_64","exit_code":6,"category":"deterministic","timestamp":"2026-02-03T15:59:17Z"}
+{"schema_version":1,"recipe":"tokei","platform":"linux-alpine-musl-arm64","exit_code":6,"category":"deterministic","timestamp":"2026-02-03T15:59:17Z"}

--- a/data/metrics/batch-runs.jsonl
+++ b/data/metrics/batch-runs.jsonl
@@ -130,3 +130,36 @@
   "timestamp": "2026-02-03T13:24:28Z",
   "duration_seconds": 4
 }
+{
+  "batch_id": "2026-02-03-homebrew",
+  "ecosystem": "homebrew",
+  "total": 2,
+  "generated": 2,
+  "platforms": {
+    "linux-x86_64": {
+      "tested": 10,
+      "passed": 9,
+      "failed": 1
+    },
+    "linux-arm64": {
+      "tested": 8,
+      "passed": 7,
+      "failed": 1
+    },
+    "darwin-arm64": {
+      "tested": 2,
+      "passed": 2,
+      "failed": 0
+    },
+    "darwin-x86_64": {
+      "tested": 2,
+      "passed": 2,
+      "failed": 0
+    }
+  },
+  "merged": 2,
+  "excluded": 0,
+  "constrained": 1,
+  "timestamp": "2026-02-03T15:59:17Z",
+  "duration_seconds": 6
+}

--- a/data/priority-queue.json
+++ b/data/priority-queue.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-02-03T13:15:46Z",
+  "updated_at": "2026-02-03T15:56:55Z",
   "packages": [
     {
       "id": "homebrew:awscli",
@@ -3191,7 +3191,7 @@
       "source": "homebrew",
       "name": "shfmt",
       "tier": 1,
-      "status": "pending",
+      "status": "success",
       "added_at": "2026-02-01T21:31:19Z"
     },
     {
@@ -4359,7 +4359,7 @@
       "source": "homebrew",
       "name": "tokei",
       "tier": 1,
-      "status": "pending",
+      "status": "success",
       "added_at": "2026-02-01T21:31:19Z"
     },
     {
@@ -6199,7 +6199,7 @@
       "source": "homebrew",
       "name": "hyperfine",
       "tier": 1,
-      "status": "pending",
+      "status": "failed",
       "added_at": "2026-02-01T21:31:19Z"
     },
     {

--- a/recipes/s/shfmt.toml
+++ b/recipes/s/shfmt.toml
@@ -1,0 +1,34 @@
+[metadata]
+  name = "shfmt"
+  description = "Autoformat shell script source code"
+  homepage = "https://github.com/mvdan/sh"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "shfmt"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "shfmt"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/shfmt"]
+
+[verify]
+  command = "shfmt --version"
+  pattern = ""

--- a/recipes/t/tokei.toml
+++ b/recipes/t/tokei.toml
@@ -1,0 +1,35 @@
+[metadata]
+  name = "tokei"
+  description = "Program that allows you to count code, quickly"
+  homepage = "https://github.com/XAMPPRocky/tokei"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+supported_libc = ["glibc"]
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "tokei"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "tokei"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/tokei"]
+
+[verify]
+  command = "tokei --version"
+  pattern = ""


### PR DESCRIPTION
Batch homebrew recipe generation: 2 recipes included, 0 excluded.

Validated across 11 platform environments (5 Linux x86_64 families, 4 Linux arm64 families, 2 macOS).

## Platform Constraints

1 recipe(s) have partial platform coverage. Constraints were derived automatically:

- **tokei**: supported_libc = ["glibc"]
---

## Validation Summary

| Platform | Status |
|----------|--------|
| linux-x86_64 | 9 passed, 1 failed |
| linux-arm64 | 7 passed, 1 failed |
| darwin-arm64 | 2 passed, 0 failed |
| darwin-x86_64 | 2 passed, 0 failed |
