### PR TITLE
fix(discover): add missing RubyGems and Go quality thresholds

### DIFF
--- a/internal/discover/quality_filter.go
+++ b/internal/discover/quality_filter.go
@@ -24,7 +24,9 @@ func NewQualityFilter() *QualityFilter {
 		thresholds: map[string]qualityThreshold{
 			"crates.io": {MinDownloads: 100, MinVersionCount: 5},
 			"npm":       {MinDownloads: 100, MinVersionCount: 5},
+			"rubygems":  {MinDownloads: 1000, MinVersionCount: 5},
 			"pypi":      {MinDownloads: 0, MinVersionCount: 3},
+			"go":        {MinDownloads: 0, MinVersionCount: 3},
 			"cpan":      {MinDownloads: 1, MinVersionCount: 3}, // MinDownloads = river.total (downstream deps)
 		},
 	}

--- a/internal/discover/quality_filter_test.go
+++ b/internal/discover/quality_filter_test.go
@@ -94,6 +94,36 @@ func TestQualityFilter_Accept(t *testing.T) {
 			wantOK:      false,
 		},
 		{
+			name:        "rubygems passes download threshold",
+			builderName: "rubygems",
+			result:      &builders.ProbeResult{Downloads: 5000, VersionCount: 2},
+			wantOK:      true,
+		},
+		{
+			name:        "rubygems passes version threshold",
+			builderName: "rubygems",
+			result:      &builders.ProbeResult{Downloads: 100, VersionCount: 5},
+			wantOK:      true,
+		},
+		{
+			name:        "rubygems fails both thresholds",
+			builderName: "rubygems",
+			result:      &builders.ProbeResult{Downloads: 500, VersionCount: 3},
+			wantOK:      false,
+		},
+		{
+			name:        "go passes version threshold",
+			builderName: "go",
+			result:      &builders.ProbeResult{Downloads: 0, VersionCount: 3},
+			wantOK:      true,
+		},
+		{
+			name:        "go fails version threshold",
+			builderName: "go",
+			result:      &builders.ProbeResult{Downloads: 0, VersionCount: 2},
+			wantOK:      false,
+		},
+		{
 			name:        "cask fails open (no threshold)",
 			builderName: "cask",
 			result:      &builders.ProbeResult{},


### PR DESCRIPTION
The design doc (DESIGN-probe-quality-filtering.md) specifies thresholds for
all registries, but the implementation was missing RubyGems and Go. This
caused those builders to fail-open, allowing squatters through.

Adds thresholds per design spec:
- RubyGems: downloads >= 1000 OR versions >= 5
- Go: versions >= 3 (no download metrics available)

---

No issue exists for this fix - discovered during milestone completion review.