### PR TITLE
ci(batch): process all queue tiers hourly

### DIFF
--- a/.github/workflows/batch-generate.yml
+++ b/.github/workflows/batch-generate.yml
@@ -1,7 +1,7 @@
 name: Batch Recipe Generation
 on:
   schedule:
-    - cron: '0 */3 * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
     inputs:
       ecosystem:
@@ -25,14 +25,14 @@ on:
       tier:
         description: 'Queue tier (1=critical, 2=popular, 3=all)'
         required: true
-        default: '2'
+        default: '3'
         type: choice
         options: ['1', '2', '3']
 
 env:
   ECOSYSTEM: ${{ inputs.ecosystem || 'homebrew' }}
   BATCH_SIZE: ${{ inputs.batch_size || '10' }}
-  TIER: ${{ inputs.tier || '2' }}
+  TIER: ${{ inputs.tier || '3' }}
 
 concurrency:
   group: batch-generate


### PR DESCRIPTION
- Change default tier from 2 to 3 so scheduled runs process all pending packages by priority order instead of stopping at tier 2
- Increase schedule frequency from every 3 hours to every hour

With tier 1 and 2 exhausted, scheduled runs were selecting 0 packages because all 746 remaining pending packages are tier 3.

---

## Summary

Three-line change: update the cron schedule to hourly, and update the `tier` input default and `TIER` env fallback from `'2'` to `'3'`.

## Test Plan

After merge, the next scheduled batch-generate run (at the top of the hour) should pick up tier 3 packages and create a PR with new recipes.