### PR TITLE
fix(batch): use hyphens instead of colons in failure file timestamps

### DIFF
--- a/internal/batch/results.go
+++ b/internal/batch/results.go
@@ -87,7 +87,9 @@ func WriteFailures(dir, ecosystem string, failures []FailureRecord) error {
 		return fmt.Errorf("create failures dir: %w", err)
 	}
 
-	timestamp := time.Now().UTC().Format("2006-01-02T15:04:05Z")
+	// Use hyphens instead of colons in timestamp for artifact upload compatibility
+	// GitHub Actions artifacts reject filenames containing colons
+	timestamp := time.Now().UTC().Format("2006-01-02T15-04-05Z")
 	record := FailureFile{
 		SchemaVersion: 1,
 		Ecosystem:     ecosystem,


### PR DESCRIPTION
Fix the root cause of artifact upload failures in the batch workflow. The `batch-generate` Go binary creates failure files with timestamps containing colons, which GitHub Actions artifacts reject.

This completes the fix started in PR #1531, which only addressed bash-generated files in the workflow. The Go code was still creating incompatible filenames.

---

## What This Fixes

PR #1531 fixed timestamp formats in bash scripts but missed that the `./batch-generate` binary (written in Go) creates its own failure files. The Go code in `internal/batch/results.go` used:

```go
timestamp := time.Now().UTC().Format("2006-01-02T15:04:05Z")
```

This produces filenames like `homebrew-2026-02-07T00:22:36Z.jsonl` with colons, causing GitHub Actions artifact upload to fail:

```
##[error]The path...contains the following character: Colon :
```

## Changes

- `internal/batch/results.go`: Change time format from `"2006-01-02T15:04:05Z"` to `"2006-01-02T15-04-05Z"`
- Adds comment explaining why we use hyphens (artifact compatibility)

Result: Filenames like `homebrew-2026-02-07T00-22-36Z.jsonl` are now artifact-compatible.

## Test Plan

After merge:
```bash
# Trigger batch workflow
gh workflow run batch-generate.yml -f ecosystem=homebrew -f batch_size=5 -f tier=3

# Verify workflow completes successfully
WORKFLOW_RUN=$(gh run list --workflow=batch-generate.yml --limit 1 --json databaseId --jq '.[0].databaseId')
gh run watch $WORKFLOW_RUN
# Expected: SUCCESS, no artifact upload errors

# Verify batch PR is created
gh pr list --label "batch:homebrew" --limit 1
# Expected: PR exists with batch recipes
```

Related to #1508