### PR TITLE
fix: add GitHub App token to seed-queue workflow for branch protection bypass

### DIFF
--- a/.github/workflows/seed-queue.yml
+++ b/.github/workflows/seed-queue.yml
@@ -33,7 +33,16 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2.2.1
+        with:
+          app-id: ${{ secrets.TSUKU_BATCH_GENERATOR_APP_ID }}
+          private-key: ${{ secrets.TSUKU_BATCH_GENERATOR_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff  # v5
         with:


### PR DESCRIPTION
The seed-queue workflow pushes directly to main with `[skip ci]` but fails because branch protection blocks standard GitHub Actions tokens.

This adds GitHub App authentication to bypass branch protection, matching the pattern used in batch-generate and update-dashboard workflows.

---

## Problem

Seed-queue workflow run 21784546151 failed with:
```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - 3 of 3 required status checks are expected.
remote: - You're not authorized to push to this branch.
```

The workflow has `permissions: contents: write` but that's insufficient when branch protection is enabled.

## Solution

Add GitHub App token generation before checkout:
- Generate token using `TSUKU_BATCH_GENERATOR_APP_ID` and `TSUKU_BATCH_GENERATOR_APP_PRIVATE_KEY` secrets
- Pass token to checkout step
- Git operations now use App token which can bypass protection

## Testing

After this merges, trigger seed-queue manually. Note the limit parameter:
```bash
# Current queue has 10 packages
# To add 100 more, set limit to 110 (not 100)
# The limit is the TOTAL packages to fetch, not the number to ADD
gh workflow run seed-queue.yml -f source=homebrew -f limit=110
```

The seed-queue command fetches the top N packages from Homebrew, merges with existing queue (skipping duplicates), and commits the result.