### PR TITLE
fix(ci): add --autostash to batch-generate rebase

### DIFF
--- a/.github/workflows/batch-generate.yml
+++ b/.github/workflows/batch-generate.yml
@@ -923,7 +923,7 @@ jobs:
 
           # Sync with latest main to avoid race conditions with other workflows
           git fetch origin main
-          git rebase origin/main
+          git rebase --autostash origin/main
 
           BRANCH="batch/${{ env.ECOSYSTEM }}-$(date +%Y%m%d-%H%M%S)"
           git checkout -b "$BRANCH"


### PR DESCRIPTION
The batch-generate workflow's merge job was failing with:

```
error: cannot rebase: You have unstaged changes.
error: Please commit or stash them.
```

Root cause: The workflow updates the queue file with success/failure statuses before rebasing with origin/main, creating unstaged changes. Without `--autostash`, git rebase refuses to proceed.

This is the same issue we fixed in PR #1552 for the seed-queue workflow.

---

## What Changed

Changed line 926 in `.github/workflows/batch-generate.yml`:

```diff
- git rebase origin/main
+ git rebase --autostash origin/main
```

## Validation

This fix allows the queue updates to be automatically stashed before rebasing and reapplied after, preventing the "unstaged changes" error that was blocking PR creation in batch run 21787706954.