### PR TITLE
fix(ci): skip Cloudflare deploy when secrets unavailable

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -39,6 +39,7 @@ jobs:
           cp _site/recipes.json website/
 
       - name: Deploy to Cloudflare Pages
+        if: ${{ secrets.CLOUDFLARE_PAGES_DEPLOYER_TOKEN != '' }}
         uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca  # v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_DEPLOYER_TOKEN }}


### PR DESCRIPTION
Add condition to skip the Cloudflare Pages deploy step when the API token secret is not available. This prevents CI failures on PRs from forks and Dependabot.

---

## What This Fixes

PR #1560 (Dependabot grouped update) failed because the deploy step requires `CLOUDFLARE_PAGES_DEPLOYER_TOKEN`, which isn't exposed to Dependabot PRs or fork PRs for security reasons.

## Changes

- `.github/workflows/deploy-website.yml`: Add `if: ${{ secrets.CLOUDFLARE_PAGES_DEPLOYER_TOKEN != '' }}` to deploy step

The other steps (checkout, python setup, generate recipes.json) still run and validate the PR. Only the actual Cloudflare deployment is skipped when secrets aren't available.