### PR TITLE
fix(workflow): ensure exit code is always set for circuit breaker

### DIFF
--- a/.github/workflows/batch-generate.yml
+++ b/.github/workflows/batch-generate.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       has_recipes: ${{ steps.check.outputs.changes }}
-      exit_code: ${{ steps.batch.outputs.exit_code }}
+      exit_code: ${{ steps.exit-code-default.outputs.exit_code }}
     steps:
       # Generate short-lived GitHub App token for PR creation and git operations.
       # Provides automatic rotation (60min expiry), scoped permissions, and audit trail.
@@ -144,6 +144,18 @@ jobs:
           set -e
           echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
           exit $EXIT_CODE
+
+      - name: Set default exit code if batch was skipped
+        if: always()
+        id: exit-code-default
+        run: |
+          # If batch step was skipped (open PRs exist), set exit code to 0
+          # This ensures circuit breaker gets a valid exit code
+          if [ -z "${{ steps.batch.outputs.exit_code }}" ]; then
+            echo "exit_code=0" >> "$GITHUB_OUTPUT"
+          else
+            echo "exit_code=${{ steps.batch.outputs.exit_code }}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Requeue unblocked packages
         if: steps.check-open-prs.outputs.should_skip != 'true'


### PR DESCRIPTION
Fix circuit breaker receiving empty exit code when batch generation step is skipped, causing it to incorrectly treat skipped batches as failures.

---

## Root Cause

The Run batch generation step has a conditional that skips the step when open PRs exist. When skipped, steps.batch.outputs.exit_code is never set, so the job output evaluates to empty string.

In the circuit breaker update step, the empty string causes the comparison to fail, falling through to the failure branch.

## What This Fixes

Adds a step that always runs after batch generation to set a default exit code of 0 when the batch step is skipped. Updates job output to use this new step instead of the batch step directly.

## Expected Behavior After Fix

- Batch generation runs: exit code captured from batch step
- Batch generation skipped (open PRs): exit code defaults to 0
- Circuit breaker always receives valid exit code
- Skipped batches treated as success (exit 0)