### PR TITLE
fix(ci): correct if condition syntax in deploy-website workflow

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -39,7 +39,7 @@ jobs:
           cp _site/recipes.json website/
 
       - name: Deploy to Cloudflare Pages
-        if: ${{ secrets.CLOUDFLARE_PAGES_DEPLOYER_TOKEN != '' }}
+        if: secrets.CLOUDFLARE_PAGES_DEPLOYER_TOKEN != ''
         uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca  # v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_DEPLOYER_TOKEN }}


### PR DESCRIPTION
Fix invalid if condition syntax that was preventing website deployments from running.

---

## Root Cause

PR #1561 added a conditional to skip Cloudflare deployment when secrets are unavailable:

```yaml
if: ${{ secrets.CLOUDFLARE_PAGES_DEPLOYER_TOKEN != '' }}
```

This syntax is invalid. In GitHub Actions, if conditions should NOT wrap expressions in ${{ }}. The if field already evaluates as an expression context.

The invalid syntax caused the workflow to fail during parsing, resulting in 0 jobs running and all deployments failing since 03:26 UTC today.

## What This Fixes

Removes the ${{ }} wrapper:

```yaml
# Before (invalid)
if: ${{ secrets.CLOUDFLARE_PAGES_DEPLOYER_TOKEN != '' }}

# After (correct)
if: secrets.CLOUDFLARE_PAGES_DEPLOYER_TOKEN != ''
```

## Expected Behavior After Fix

- Workflow parses successfully
- Jobs execute normally
- Cloudflare deployment step runs when secret is present
- Website deployments resume updating https://tsuku.dev/pipeline/ with latest dashboard data