### PR TITLE
fix(ci): use event check instead of secret check for deployment

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -39,7 +39,7 @@ jobs:
           cp _site/recipes.json website/
 
       - name: Deploy to Cloudflare Pages
-        if: secrets.CLOUDFLARE_PAGES_DEPLOYER_TOKEN != ''
+        if: github.event_name == 'push'
         uses: cloudflare/pages-action@f0a1cd58cd66095dee69bfa18fa5efd1dde93bca  # v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_PAGES_DEPLOYER_TOKEN }}


### PR DESCRIPTION
Fix deploy-website workflow that was failing with 0 jobs due to invalid secret check in if condition.

---

## Root Cause

PR #1565 attempted to fix the syntax by removing ${{ }} from the conditional, but the resulting condition is still invalid:

```yaml
if: secrets.CLOUDFLARE_PAGES_DEPLOYER_TOKEN != ''
```

**Problem:** Secrets are not available in GitHub Actions expression context outside of step-level ${{ }} blocks. This causes the workflow to fail parsing with 0 jobs executed.

## What This Fixes

Changed from checking the secret to checking the event type:

```yaml
# Before (invalid - secrets not available in if context)
if: secrets.CLOUDFLARE_PAGES_DEPLOYER_TOKEN != ''

# After (correct - check event type)
if: github.event_name == 'push'
```

## Expected Behavior

- Workflow runs successfully on both push and pull_request events
- Cloudflare deployment step only runs on push events (merges to main)
- Cloudflare deployment skipped on pull_request events (PR builds)
- Website at https://tsuku.dev/pipeline/ updates with latest dashboard data

Supersedes PR #1565 which partially fixed the issue but left the invalid conditional.