### PR TITLE
fix(batch): treat recipe_not_found as blocked instead of failed

### DIFF
--- a/internal/batch/orchestrator.go
+++ b/internal/batch/orchestrator.go
@@ -110,7 +110,7 @@ func (o *Orchestrator) Run() (*BatchResult, error) {
 		if valResult.Err != nil {
 			result.Failures = append(result.Failures, valResult.Failure)
 			os.Remove(recipePath)
-			if valResult.Failure.Category == "missing_dep" {
+			if valResult.Failure.Category == "missing_dep" || valResult.Failure.Category == "recipe_not_found" {
 				result.Blocked++
 				o.setStatus(pkg.ID, "blocked")
 			} else {


### PR DESCRIPTION
Update the orchestrator's validation failure handler to treat `recipe_not_found`
as a blocking condition alongside `missing_dep`. Both categories represent
missing dependencies that may become available in future batches, so neither
should increment the circuit breaker failure counter.

Refactor duplicate test functions into a single table-driven test to satisfy
linter requirements.

---

## What This Fixes

When batch-generate validates a recipe with missing runtime dependencies, the
CLI returns `category: "recipe_not_found"`. The orchestrator only checked for
`missing_dep` to mark packages as blocked, causing `recipe_not_found` failures
to be counted as hard failures and unnecessarily incrementing the circuit breaker.

## Changes

- `internal/batch/orchestrator.go`: Add `recipe_not_found` to blocking condition
- `internal/batch/orchestrator_test.go`: Refactor into table-driven test covering both categories

Fixes #1557