### PR TITLE
fix(ci): add comment to validate-all-recipes workflow to trigger re-parse

### DIFF
--- a/.github/workflows/validate-all-recipes.yml
+++ b/.github/workflows/validate-all-recipes.yml
@@ -1,4 +1,5 @@
 name: Validate All Recipes
+# Validates all recipes across 11 platforms and optionally adds constraints
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Add a descriptive comment to validate-all-recipes.yml to force GitHub
to re-parse the workflow file. The workflow's trigger configuration
appears corrupted in GitHub's indexer.

---

## What This Fixes

GitHub's workflow indexer has incorrect state for validate-all-recipes.yml:
- Workflow name displays as file path instead of "Validate All Recipes"
- Runs triggered by `push` events that aren't in the workflow config
- API claims no `workflow_dispatch` trigger exists (HTTP 422)
- No "Run workflow" button in the Actions UI
- Runs complete in 0s with zero jobs

This blocks issue #1540, which requires manually triggering the workflow.

## Test Plan

- [ ] After merge, verify "Run workflow" button appears at https://github.com/tsukumogami/tsuku/actions/workflows/validate-all-recipes.yml
- [ ] Verify `gh workflow run validate-all-recipes.yml -f auto_constrain=false` succeeds

Ref #1540