### PR TITLE
fix(ci): rename workflow to force GitHub re-indexing

### DIFF
--- a/.github/workflows/full-recipe-validation.yml
+++ b/.github/workflows/full-recipe-validation.yml
@@ -1,4 +1,4 @@
-name: Validate All Recipes
+name: Full Recipe Validation
 # Validates all recipes across 11 platforms and optionally adds constraints
 
 on:


### PR DESCRIPTION
Rename validate-all-recipes.yml to full-recipe-validation.yml to force
GitHub to create a fresh workflow entry. The previous workflow had
corrupted indexer state that prevented workflow_dispatch from working.

---

## What This Fixes

GitHub's workflow indexer was corrupted for validate-all-recipes.yml:
- Workflow name showed as file path instead of "Validate All Recipes"
- Runs triggered by `push` events not in the config
- API rejected workflow_dispatch calls (HTTP 422)
- No "Run workflow" button in Actions UI

Previous attempt (PR #1594) added a comment to force re-parse but GitHub
kept using the cached corrupted state. Renaming the file forces creation
of a new workflow entry with ID, bypassing the corrupted cache.

## Test Plan

- [ ] After merge, new workflow appears at Actions with "Run workflow" button
- [ ] `gh workflow run full-recipe-validation.yml -f auto_constrain=false` works
- [ ] Old workflow (validate-all-recipes.yml) no longer appears in Actions

Ref #1540