### PR TITLE
fix(ci): replace corrupted workflow with fresh recipe-platform-validation

### DIFF
--- a/.github/workflows/recipe-platform-validation.yml
+++ b/.github/workflows/recipe-platform-validation.yml
@@ -1,0 +1,559 @@
+name: Recipe Platform Validation
+# Validates all recipes across 11 platforms and optionally adds constraints
+
+on:
+  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      auto_constrain:
+        description: 'Automatically add platform constraints to failing recipes'
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    # Run weekly on Sunday at 2 AM UTC
+    - cron: '0 2 * * 0'
+
+jobs:
+  # Build binaries and collect all recipes
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    outputs:
+      recipes: ${{ steps.collect.outputs.recipes }}
+      has_recipes: ${{ steps.collect.outputs.has_recipes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache-dependency-path: go.sum
+
+      - name: Build binaries for all platforms
+        run: |
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o tsuku-linux-amd64 ./cmd/tsuku
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o tsuku-linux-arm64 ./cmd/tsuku
+          CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -o tsuku-darwin-arm64 ./cmd/tsuku
+          CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build -o tsuku-darwin-amd64 ./cmd/tsuku
+
+      - name: Collect all recipes
+        id: collect
+        run: |
+          EXECUTION_EXCLUSIONS_FILE="testdata/golden/execution-exclusions.json"
+
+          # Function to check if a recipe is excluded
+          is_execution_excluded() {
+            local recipe="$1"
+            if [ ! -f "$EXECUTION_EXCLUSIONS_FILE" ]; then
+              return 1
+            fi
+            local match
+            match=$(jq -r --arg r "$recipe" '.exclusions[] | select(.recipe == $r) | .issue' "$EXECUTION_EXCLUSIONS_FILE" 2>/dev/null | head -1)
+            [ -n "$match" ] && echo "$match" && return 0
+            return 1
+          }
+
+          # Collect all recipe paths (excluding libraries, system deps, and excluded recipes)
+          # Include both embedded recipes and registry recipes
+          RECIPE_LIST=""
+          for path in internal/recipe/recipes/*.toml recipes/*/*.toml; do
+            if [ ! -f "$path" ]; then
+              continue
+            fi
+
+            # Skip library recipes
+            if grep -q 'type = "library"' "$path" 2>/dev/null; then
+              continue
+            fi
+
+            # Skip system dependency recipes
+            if grep -q 'action = "require_system"' "$path" 2>/dev/null; then
+              continue
+            fi
+
+            # Skip excluded recipes
+            tool=$(basename "$path" .toml)
+            if is_execution_excluded "$tool" >/dev/null 2>&1; then
+              continue
+            fi
+
+            RECIPE_LIST="$RECIPE_LIST $path"
+          done
+
+          # Trim leading space
+          RECIPE_LIST="${RECIPE_LIST# }"
+
+          if [ -z "$RECIPE_LIST" ]; then
+            echo "has_recipes=false" >> $GITHUB_OUTPUT
+            echo "recipes=" >> $GITHUB_OUTPUT
+          else
+            echo "has_recipes=true" >> $GITHUB_OUTPUT
+            echo "recipes=$RECIPE_LIST" >> $GITHUB_OUTPUT
+            echo "Found $(echo $RECIPE_LIST | wc -w) recipes to validate"
+          fi
+
+      - name: Upload binaries
+        if: steps.collect.outputs.has_recipes == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: tsuku-binaries
+          path: tsuku-*
+          retention-days: 1
+
+  # Validate on all Linux x86_64 families
+  validate-linux-x86_64:
+    name: "Linux x86_64"
+    needs: prepare
+    if: needs.prepare.outputs.has_recipes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: tsuku-binaries
+
+      - name: Make binary executable
+        run: chmod +x tsuku-linux-amd64
+
+      - name: Validate on all Linux x86_64 families
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RESULTS="[]"
+          IMAGES=("debian:bookworm-slim" "fedora:41-minimal" "archlinux:base" "opensuse/tumbleweed" "alpine:3.21")
+          NAMES=("debian" "rhel" "arch" "suse" "alpine")
+          LIBCS=("glibc" "glibc" "glibc" "glibc" "musl")
+          RECIPES="${{ needs.prepare.outputs.recipes }}"
+
+          for i in "${!IMAGES[@]}"; do
+            image="${IMAGES[$i]}"
+            family="${NAMES[$i]}"
+            libc="${LIBCS[$i]}"
+            platform="linux-${family}-${libc}-x86_64"
+
+            echo "=== Validating on $platform ($image) ==="
+
+            for recipe_path in $RECIPES; do
+              recipe_name=$(basename "$recipe_path" .toml)
+
+              echo "--- $recipe_name on $platform ---"
+              STATUS="pass"
+              EXIT_CODE=0
+              ATTEMPTS=1
+
+              for attempt in 0 1 2; do
+                ATTEMPTS=$((attempt + 1))
+                docker run --rm \
+                  -v "$PWD:/workspace" \
+                  -w /workspace \
+                  -e GITHUB_TOKEN="$GITHUB_TOKEN" \
+                  "$image" \
+                  sh -c "
+                    case '$family' in
+                      alpine) apk add --no-cache curl bash ca-certificates ;;
+                      debian) apt-get update && apt-get install -y --no-install-recommends curl ca-certificates ;;
+                      rhel) dnf install -y --setopt=install_weak_deps=False curl ca-certificates ;;
+                      arch) pacman -Sy --noconfirm curl ca-certificates ;;
+                      suse) zypper -n install curl ca-certificates ;;
+                    esac
+                    timeout 300 ./tsuku-linux-amd64 install --force --recipe '$recipe_path'
+                    echo \$? > /workspace/.tsuku-exit-code
+                  " 2>&1 || true
+
+                if [ -f .tsuku-exit-code ]; then
+                  EXIT_CODE=$(cat .tsuku-exit-code)
+                  rm -f .tsuku-exit-code
+                else
+                  EXIT_CODE=1
+                fi
+
+                if [ "$EXIT_CODE" = "0" ]; then
+                  STATUS="pass"
+                  break
+                elif [ "$EXIT_CODE" = "5" ] && [ "$attempt" -lt 2 ]; then
+                  echo "Network error, retrying (attempt $((attempt+2)))..."
+                  sleep $((2 ** (attempt + 1)))
+                  continue
+                else
+                  STATUS="fail"
+                  break
+                fi
+              done
+
+              RESULTS=$(echo "$RESULTS" | jq --arg r "$recipe_name" --arg p "$platform" \
+                --arg s "$STATUS" --argjson e "$EXIT_CODE" --argjson a "$ATTEMPTS" \
+                '. + [{"recipe": $r, "platform": $p, "status": $s, "exit_code": $e, "attempts": $a}]')
+            done
+          done
+
+          echo "$RESULTS" > validation-results-linux-x86_64.json
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-results-linux-x86_64
+          path: validation-results-linux-x86_64.json
+          retention-days: 7
+
+  # Validate on all Linux arm64 families
+  validate-linux-arm64:
+    name: "Linux arm64"
+    needs: prepare
+    if: needs.prepare.outputs.has_recipes == 'true'
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: tsuku-binaries
+
+      - name: Make binary executable
+        run: chmod +x tsuku-linux-arm64
+
+      - name: Validate on all Linux arm64 families
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RESULTS="[]"
+          IMAGES=("debian:bookworm-slim" "fedora:41-minimal" "opensuse/tumbleweed" "alpine:3.21")
+          NAMES=("debian" "rhel" "suse" "alpine")
+          LIBCS=("glibc" "glibc" "glibc" "musl")
+          RECIPES="${{ needs.prepare.outputs.recipes }}"
+
+          for i in "${!IMAGES[@]}"; do
+            image="${IMAGES[$i]}"
+            family="${NAMES[$i]}"
+            libc="${LIBCS[$i]}"
+            platform="linux-${family}-${libc}-arm64"
+
+            echo "=== Validating on $platform ($image) ==="
+
+            for recipe_path in $RECIPES; do
+              recipe_name=$(basename "$recipe_path" .toml)
+
+              echo "--- $recipe_name on $platform ---"
+              STATUS="pass"
+              EXIT_CODE=0
+              ATTEMPTS=1
+
+              for attempt in 0 1 2; do
+                ATTEMPTS=$((attempt + 1))
+                docker run --rm \
+                  -v "$PWD:/workspace" \
+                  -w /workspace \
+                  -e GITHUB_TOKEN="$GITHUB_TOKEN" \
+                  "$image" \
+                  sh -c "
+                    case '$family' in
+                      alpine) apk add --no-cache curl bash ca-certificates ;;
+                      debian) apt-get update && apt-get install -y --no-install-recommends curl ca-certificates ;;
+                      rhel) dnf install -y --setopt=install_weak_deps=False curl ca-certificates ;;
+                      suse) zypper -n install curl ca-certificates ;;
+                    esac
+                    timeout 300 ./tsuku-linux-arm64 install --force --recipe '$recipe_path'
+                    echo \$? > /workspace/.tsuku-exit-code
+                  " 2>&1 || true
+
+                if [ -f .tsuku-exit-code ]; then
+                  EXIT_CODE=$(cat .tsuku-exit-code)
+                  rm -f .tsuku-exit-code
+                else
+                  EXIT_CODE=1
+                fi
+
+                if [ "$EXIT_CODE" = "0" ]; then
+                  STATUS="pass"
+                  break
+                elif [ "$EXIT_CODE" = "5" ] && [ "$attempt" -lt 2 ]; then
+                  echo "Network error, retrying (attempt $((attempt+2)))..."
+                  sleep $((2 ** (attempt + 1)))
+                  continue
+                else
+                  STATUS="fail"
+                  break
+                fi
+              done
+
+              RESULTS=$(echo "$RESULTS" | jq --arg r "$recipe_name" --arg p "$platform" \
+                --arg s "$STATUS" --argjson e "$EXIT_CODE" --argjson a "$ATTEMPTS" \
+                '. + [{"recipe": $r, "platform": $p, "status": $s, "exit_code": $e, "attempts": $a}]')
+            done
+          done
+
+          echo "$RESULTS" > validation-results-linux-arm64.json
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-results-linux-arm64
+          path: validation-results-linux-arm64.json
+          retention-days: 7
+
+  # Validate on macOS arm64
+  validate-darwin-arm64:
+    name: "macOS arm64"
+    needs: prepare
+    if: needs.prepare.outputs.has_recipes == 'true'
+    runs-on: macos-14
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: tsuku-binaries
+
+      - name: Make binary executable
+        run: chmod +x tsuku-darwin-arm64
+
+      - name: Install GNU coreutils for gtimeout
+        run: brew install coreutils
+
+      - name: Validate on macOS arm64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RESULTS="[]"
+          RECIPES="${{ needs.prepare.outputs.recipes }}"
+
+          for recipe_path in $RECIPES; do
+            recipe_name=$(basename "$recipe_path" .toml)
+
+            echo "--- $recipe_name on darwin-arm64 ---"
+            STATUS="pass"
+            EXIT_CODE=0
+            ATTEMPTS=1
+
+            for attempt in 0 1 2; do
+              ATTEMPTS=$((attempt + 1))
+              if gtimeout 300 ./tsuku-darwin-arm64 install --force --recipe "$recipe_path" 2>&1; then
+                EXIT_CODE=0
+                STATUS="pass"
+                break
+              else
+                EXIT_CODE=$?
+                if [ "$EXIT_CODE" = "5" ] && [ "$attempt" -lt 2 ]; then
+                  echo "Network error, retrying (attempt $((attempt+2)))..."
+                  sleep $((2 ** (attempt + 1)))
+                  continue
+                fi
+                STATUS="fail"
+                break
+              fi
+            done
+
+            RESULTS=$(echo "$RESULTS" | jq --arg r "$recipe_name" --arg p "darwin-arm64" \
+              --arg s "$STATUS" --argjson e "$EXIT_CODE" --argjson a "$ATTEMPTS" \
+              '. + [{"recipe": $r, "platform": $p, "status": $s, "exit_code": $e, "attempts": $a}]')
+          done
+
+          echo "$RESULTS" > validation-results-darwin-arm64.json
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-results-darwin-arm64
+          path: validation-results-darwin-arm64.json
+          retention-days: 7
+
+  # Validate on macOS x86_64
+  validate-darwin-x86_64:
+    name: "macOS x86_64"
+    needs: prepare
+    if: needs.prepare.outputs.has_recipes == 'true'
+    runs-on: macos-15-intel
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: tsuku-binaries
+
+      - name: Make binary executable
+        run: chmod +x tsuku-darwin-amd64
+
+      - name: Install GNU coreutils for gtimeout
+        run: brew install coreutils
+
+      - name: Validate on macOS x86_64
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RESULTS="[]"
+          RECIPES="${{ needs.prepare.outputs.recipes }}"
+
+          for recipe_path in $RECIPES; do
+            recipe_name=$(basename "$recipe_path" .toml)
+
+            echo "--- $recipe_name on darwin-x86_64 ---"
+            STATUS="pass"
+            EXIT_CODE=0
+            ATTEMPTS=1
+
+            for attempt in 0 1 2; do
+              ATTEMPTS=$((attempt + 1))
+              if gtimeout 300 ./tsuku-darwin-amd64 install --force --recipe "$recipe_path" 2>&1; then
+                EXIT_CODE=0
+                STATUS="pass"
+                break
+              else
+                EXIT_CODE=$?
+                if [ "$EXIT_CODE" = "5" ] && [ "$attempt" -lt 2 ]; then
+                  echo "Network error, retrying (attempt $((attempt+2)))..."
+                  sleep $((2 ** (attempt + 1)))
+                  continue
+                fi
+                STATUS="fail"
+                break
+              fi
+            done
+
+            RESULTS=$(echo "$RESULTS" | jq --arg r "$recipe_name" --arg p "darwin-x86_64" \
+              --arg s "$STATUS" --argjson e "$EXIT_CODE" --argjson a "$ATTEMPTS" \
+              '. + [{"recipe": $r, "platform": $p, "status": $s, "exit_code": $e, "attempts": $a}]')
+          done
+
+          echo "$RESULTS" > validation-results-darwin-x86_64.json
+
+      - name: Upload results
+        uses: actions/upload-artifact@v4
+        with:
+          name: validation-results-darwin-x86_64
+          path: validation-results-darwin-x86_64.json
+          retention-days: 7
+
+  # Aggregate results and optionally add constraints
+  report:
+    name: Report and Constrain
+    needs: [prepare, validate-linux-x86_64, validate-linux-arm64, validate-darwin-arm64, validate-darwin-x86_64]
+    if: always() && needs.prepare.outputs.has_recipes == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: validation-results-*
+          merge-multiple: true
+
+      - name: Aggregate results
+        run: |
+          # Merge all validation results
+          jq -s 'add' validation-results-*.json > all-results.json
+
+          echo "## All Recipes Platform Validation" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Validated $(jq '[.[] | .recipe] | unique | length' all-results.json) recipes across 11 platforms." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          # Get unique recipe names
+          RECIPES=$(jq -r '.[].recipe' all-results.json | sort -u)
+
+          # Build detailed summary
+          echo "### Recipes Needing Constraints" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Recipe | Passed | Failed | Failed Platforms |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|--------|--------|--------|------------------|" >> "$GITHUB_STEP_SUMMARY"
+
+          NEEDS_CONSTRAINTS=0
+          for recipe in $RECIPES; do
+            TOTAL=$(jq --arg r "$recipe" '[.[] | select(.recipe == $r)] | length' all-results.json)
+            PASSED=$(jq --arg r "$recipe" '[.[] | select(.recipe == $r and .status == "pass")] | length' all-results.json)
+            FAILED=$(jq --arg r "$recipe" '[.[] | select(.recipe == $r and .status == "fail")] | length' all-results.json)
+
+            if [ "$FAILED" -gt 0 ]; then
+              FAILED_PLATFORMS=$(jq -r --arg r "$recipe" '[.[] | select(.recipe == $r and .status == "fail") | .platform] | join(", ")' all-results.json)
+              echo "| $recipe | $PASSED/$TOTAL | $FAILED | $FAILED_PLATFORMS |" >> "$GITHUB_STEP_SUMMARY"
+              NEEDS_CONSTRAINTS=$((NEEDS_CONSTRAINTS + 1))
+            fi
+          done
+
+          if [ "$NEEDS_CONSTRAINTS" -eq 0 ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "All recipes passed on all platforms!" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "$NEEDS_CONSTRAINTS recipe(s) need platform constraints." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+          # Save results for optional constraint step
+          echo "NEEDS_CONSTRAINTS=$NEEDS_CONSTRAINTS" >> "$GITHUB_ENV"
+
+      - name: Add platform constraints (if enabled)
+        if: env.NEEDS_CONSTRAINTS != '0' && inputs.auto_constrain
+        run: |
+          # Get recipes that need constraints
+          RECIPES=$(jq -r '[.[] | select(.status == "fail") | .recipe] | unique | .[]' all-results.json)
+
+          for recipe in $RECIPES; do
+            RECIPE_FILE=$(find recipes -name "${recipe}.toml" | head -1)
+            if [ -z "$RECIPE_FILE" ]; then
+              echo "Warning: Could not find recipe file for $recipe"
+              continue
+            fi
+
+            echo "Adding constraints to $RECIPE_FILE based on failures..."
+            ./scripts/write-platform-constraints.sh "$RECIPE_FILE" "$recipe" all-results.json
+          done
+
+          # Check if any files were modified
+          if git diff --quiet recipes/; then
+            echo "No constraints were added"
+          else
+            echo "CONSTRAINTS_ADDED=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Create pull request (if constraints added)
+        if: env.CONSTRAINTS_ADDED == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="recipe-platform-validation-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "$BRANCH"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add recipes/
+          git commit -m "feat(recipes): add platform constraints from validation
+
+Automated platform constraint additions based on full recipe validation.
+Recipes failing on specific platforms now have explicit constraints.
+
+Validation covered 11 platforms:
+- 5 Linux x86_64 families (debian, rhel, arch, suse, alpine)
+- 4 Linux arm64 families (debian, rhel, suse, alpine)
+- 2 macOS architectures (arm64, x86_64)"
+
+          git push -u origin "$BRANCH"
+
+          gh pr create \
+            --title "feat(recipes): add platform constraints from validation" \
+            --body "Automated PR from \`recipe-platform-validation\` workflow.
+
+## Summary
+
+Added platform constraints to recipes that failed validation on specific platforms.
+
+See workflow run for detailed validation results: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+## Next Steps
+
+Review the added constraints and merge if they look correct." \
+            --base main


### PR DESCRIPTION
Replace full-recipe-validation.yml with a new recipe-platform-validation.yml
to bypass GitHub's corrupted workflow state. The workflow deletion and
recreation forces GitHub to create a fresh workflow entry.

---

## What This Fixes

GitHub's workflow indexer was corrupted for the recipe validation workflow:
- API rejected workflow_dispatch calls (HTTP 422: "no workflow_dispatch trigger")
- Workflow name showed as file path instead of display name
- Runs triggered by phantom push events not in the config
- Multiple attempts to fix (comment, rename) failed to clear cached state

This PR deletes the old workflow entirely and adds a new one with a different
filename, forcing GitHub to create a completely new workflow entry.

## Changes

- Delete: `full-recipe-validation.yml`
- Add: `recipe-platform-validation.yml`
- Simplify `auto_constrain` input from `choice` to `boolean` type

## Test Plan

- [ ] After merge, verify new workflow appears with "Run workflow" button
- [ ] `gh workflow run recipe-platform-validation.yml` succeeds
- [ ] Old workflows (`validate-all-recipes.yml`, `full-recipe-validation.yml`) become inactive

Ref #1540