### PR TITLE
docs: mark M61 as done in batch-recipe-generation diagram

### DIFF
--- a/docs/designs/DESIGN-batch-recipe-generation.md
+++ b/docs/designs/DESIGN-batch-recipe-generation.md
@@ -82,7 +82,7 @@ graph LR
     class I1252 done
     class I1255 done
     class I1258 done
-    class M61 ready
+    class M61 done
     class I1253 ready
     class M64 done
 ```


### PR DESCRIPTION
Update the dependency diagram in DESIGN-batch-recipe-generation.md to
mark milestone M61 (Platform Validation Refinements) as done. The
milestone was closed after PR #1601 merged.

---

Trivial documentation update - no issue created.