### PR TITLE
fix(workflows): increase validation job timeout to 120 minutes

### DIFF
--- a/.github/workflows/recipe-validation-core.yml
+++ b/.github/workflows/recipe-validation-core.yml
@@ -106,7 +106,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.has_recipes == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -214,7 +214,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.has_recipes == 'true'
     runs-on: ubuntu-24.04-arm
-    timeout-minutes: 60
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:
@@ -318,7 +318,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.has_recipes == 'true'
     runs-on: macos-14
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -387,7 +387,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.has_recipes == 'true'
     runs-on: macos-15-intel
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Some distros need more than 60 minutes to validate 262 recipes.

---

## Problem

The previous run had 4 jobs cancelled due to hitting the 60-minute timeout:
- Linux debian x86_64
- Linux rhel x86_64
- Linux suse x86_64
- Linux suse arm64

## Solution

Restore the 120-minute timeout for all validation jobs.

## Test Plan

- [ ] After merge, re-trigger validation workflow
- [ ] All 11 jobs complete without timeout

Ref #1540