### PR TITLE
fix(workflows): add write permissions for constraint PR creation

### DIFF
--- a/.github/workflows/recipe-validation-constrain.yml
+++ b/.github/workflows/recipe-validation-constrain.yml
@@ -5,6 +5,10 @@ name: Recipe Validation with Constraints
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   validate-and-constrain:
     uses: ./.github/workflows/recipe-validation-core.yml


### PR DESCRIPTION
The Phase 2 workflow failed because GITHUB_TOKEN lacked write permissions to
push the constraint branch and create the PR.

---

## Problem

```
remote: Permission to tsukumogami/tsuku.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/tsukumogami/tsuku/': The requested URL returned error: 403
```

## Solution

Add explicit permissions to the wrapper workflow:
- `contents: write` - to push the constraint branch
- `pull-requests: write` - to create the PR

## Test Plan

- [ ] After merge, re-trigger `recipe-validation-constrain.yml`
- [ ] Workflow creates constraint PR successfully

Ref #1540