### PR TITLE
docs: fix broken links and simplify README in design docs

### DIFF
--- a/docs/designs/DESIGN-registry-scale-strategy.md
+++ b/docs/designs/DESIGN-registry-scale-strategy.md
@@ -32,11 +32,11 @@ Planned
 
 ### Milestone: [Batch Operations Control Plane](https://github.com/tsukumogami/tsuku/milestone/55)
 
-Implements [#1187](https://github.com/tsukumogami/tsuku/issues/1187). See [DESIGN-batch-operations.md](DESIGN-batch-operations.md) for issue details.
+Implements [#1187](https://github.com/tsukumogami/tsuku/issues/1187). See [DESIGN-batch-operations.md](current/DESIGN-batch-operations.md) for issue details.
 
 ### Milestone: [Batch Operations Observability](https://github.com/tsukumogami/tsuku/milestone/56)
 
-Implements [#1187](https://github.com/tsukumogami/tsuku/issues/1187). See [DESIGN-batch-operations.md](DESIGN-batch-operations.md) for issue details.
+Implements [#1187](https://github.com/tsukumogami/tsuku/issues/1187). See [DESIGN-batch-operations.md](current/DESIGN-batch-operations.md) for issue details.
 
 ### Milestone: [Deterministic Homebrew Builder](https://github.com/tsukumogami/tsuku/milestone/51)
 

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -2,96 +2,25 @@
 
 This directory contains design documents for tsuku features and architectural decisions.
 
+## Directory Structure
+
+| Directory | Status | Description |
+|-----------|--------|-------------|
+| `docs/designs/` | Proposed, Accepted, Planned | Active designs under discussion or awaiting implementation |
+| `docs/designs/current/` | Current | Implemented designs representing current architecture |
+| `docs/designs/archive/` | Superseded | Replaced designs with links to their successors |
+
 ## Status Lifecycle
 
 Design documents progress through the following statuses:
 
-| Status | Description | Location |
-|--------|-------------|----------|
-| **Proposed** | Design under discussion, not yet approved | `docs/designs/` |
-| **Accepted** | Design approved, awaiting implementation | `docs/designs/` |
-| **Planned** | Design approved, issues and milestones created | `docs/designs/` |
-| **Current** | Implementation complete, stable | `docs/designs/current/` |
-| **Superseded** | Replaced by another design (includes link) | `docs/designs/archive/` |
-
-## Planned Designs
-
-These designs are approved with milestones created, but implementation is ongoing.
-
-| Design | Description |
+| Status | Description |
 |--------|-------------|
-| [DESIGN-library-verification.md](DESIGN-library-verification.md) | Tiered library verification (Tier 1-2 done, Tier 3-4 pending) |
-| [DESIGN-structured-install-guide.md](DESIGN-structured-install-guide.md) | Sandbox container building and full golden coverage |
-
-## Current Designs
-
-These designs are implemented and represent the current system architecture.
-
-### Core Infrastructure
-
-| Design | Description |
-|--------|-------------|
-| [DESIGN-deterministic-resolution.md](current/DESIGN-deterministic-resolution.md) | Plan-based installation and deterministic execution |
-| [DESIGN-dependency-pattern.md](current/DESIGN-dependency-pattern.md) | Implicit dependency system for actions |
-| [DESIGN-dependency-provisioning.md](current/DESIGN-dependency-provisioning.md) | Build essentials and system dependency provisioning |
-| [DESIGN-dependency-version-refs.md](current/DESIGN-dependency-version-refs.md) | Variable expansion for dependency versions |
-| [DESIGN-sandbox-dependencies.md](current/DESIGN-sandbox-dependencies.md) | Unified plan generation for sandbox mode |
-| [DESIGN-relocatable-library-deps.md](current/DESIGN-relocatable-library-deps.md) | Native library dependency management |
-
-### LLM & Builder Infrastructure
-
-| Design | Description |
-|--------|-------------|
-| [DESIGN-llm-builder-infrastructure.md](current/DESIGN-llm-builder-infrastructure.md) | LLM-powered recipe generation infrastructure |
-| [DESIGN-recipe-builders.md](current/DESIGN-recipe-builders.md) | Ecosystem-specific recipe builders |
-
-### Sandbox & Container Testing
-
-| Design | Description |
-|--------|-------------|
-| [DESIGN-install-sandbox.md](current/DESIGN-install-sandbox.md) | Centralized sandbox testing infrastructure |
-| [DESIGN-system-dependency-actions.md](current/DESIGN-system-dependency-actions.md) | System dependency action vocabulary |
-
-### Golden Files & Validation
-
-| Design | Description |
-|--------|-------------|
-| [DESIGN-golden-plan-testing.md](current/DESIGN-golden-plan-testing.md) | CI-driven regression testing for recipe plans |
-| [DESIGN-hardcoded-version-detection.md](current/DESIGN-hardcoded-version-detection.md) | Recipe validation for version templating |
-| [DESIGN-non-deterministic-validation.md](current/DESIGN-non-deterministic-validation.md) | Constrained evaluation for ecosystem recipe validation |
-| [DESIGN-version-verification.md](current/DESIGN-version-verification.md) | Version format transforms and verification modes |
-
-### Ecosystem Support
-
-| Design | Description |
-|--------|-------------|
-| [DESIGN-go-ecosystem.md](current/DESIGN-go-ecosystem.md) | Go toolchain, version provider, and go_install action |
-| [DESIGN-perl-ecosystem.md](current/DESIGN-perl-ecosystem.md) | Perl/CPAN support with cpan_install action |
-| [DESIGN-homebrew.md](current/DESIGN-homebrew.md) | Homebrew bottle integration |
-| [DESIGN-fossil-archive.md](current/DESIGN-fossil-archive.md) | Fossil SCM source archive support |
-
-### CLI & UX Features
-
-| Design | Description |
-|--------|-------------|
-| [DESIGN-info-enhancements.md](current/DESIGN-info-enhancements.md) | CLI info command improvements |
-| [DESIGN-telemetry-cli.md](current/DESIGN-telemetry-cli.md) | Anonymous usage telemetry |
-| [DESIGN-structured-logging.md](current/DESIGN-structured-logging.md) | Unified structured logging framework |
-| [DESIGN-multi-version-support.md](current/DESIGN-multi-version-support.md) | Multiple installed versions per tool |
-| [DESIGN-recipe-detail-pages.md](current/DESIGN-recipe-detail-pages.md) | Individual tool pages on tsuku.dev |
-| [DESIGN-when-clause-platform-tuples.md](current/DESIGN-when-clause-platform-tuples.md) | Platform tuple support in when clauses |
-
-### Security & Verification
-
-| Design | Description |
-|--------|-------------|
-| [DESIGN-checksum-pinning.md](current/DESIGN-checksum-pinning.md) | Post-installation binary integrity verification |
-| [DESIGN-pgp-verification.md](current/DESIGN-pgp-verification.md) | PGP signature verification for downloads |
-| [DESIGN-library-verify-deps.md](current/DESIGN-library-verify-deps.md) | Tier 2 dependency validation for library verification |
-
-## Archived Designs
-
-See [archive/](archive/) for superseded designs. Each archived design includes a link to its replacement.
+| **Proposed** | Design under discussion, not yet approved |
+| **Accepted** | Design approved, awaiting implementation |
+| **Planned** | Design approved, issues and milestones created |
+| **Current** | Implementation complete, stable |
+| **Superseded** | Replaced by another design (includes link to replacement) |
 
 ## Creating New Designs
 

--- a/docs/designs/archive/DESIGN-decomposable-actions.md
+++ b/docs/designs/archive/DESIGN-decomposable-actions.md
@@ -44,7 +44,7 @@ This design is implemented through the following GitHub issues:
 
 ## Upstream Design Reference
 
-This design implements part of [DESIGN-deterministic-resolution.md](DESIGN-deterministic-resolution.md).
+This design implements part of [DESIGN-deterministic-resolution.md](../current/DESIGN-deterministic-resolution.md).
 
 **Relevant sections:**
 - Core Insight: Split installation into evaluation and execution phases
@@ -563,7 +563,9 @@ Based on investigation results, implement each ecosystem primitive:
 
 ## Appendix A: Ecosystem Investigation Results
 
-Detailed research was conducted for each supported ecosystem. Full reports are available in `docs/deterministic-builds/`. This appendix summarizes key findings.
+Detailed research was conducted for each supported ecosystem. This appendix summarizes key findings.
+
+> **Note**: The detailed ecosystem research files referenced below (`docs/deterministic-builds/*.md`) were planned but not created before this design was superseded. This appendix summarizes key findings.
 
 ### Summary Table
 
@@ -579,7 +581,7 @@ Detailed research was conducted for each supported ecosystem. Full reports are a
 
 ### Go
 
-> Full details: [ecosystem_go.md](deterministic-builds/ecosystem_go.md)
+> Full details were planned for `deterministic-builds/ecosystem_go.md`.
 
 **Lock mechanism**: `go.sum` contains cryptographic checksums for all module dependencies. Go's Minimum Version Selection (MVS) algorithm ensures reproducible dependency resolution.
 
@@ -615,7 +617,7 @@ type GoBuildParams struct {
 
 ### Cargo
 
-> Full details: [ecosystem_cargo.md](deterministic-builds/ecosystem_cargo.md)
+> Full details were planned for `deterministic-builds/ecosystem_cargo.md`.
 
 **Lock mechanism**: `Cargo.lock` contains SHA-256 checksums for all crate dependencies in TOML format.
 
@@ -648,7 +650,7 @@ type CargoBuildParams struct {
 
 ### npm
 
-> Full details: [ecosystem_npm.md](deterministic-builds/ecosystem_npm.md)
+> Full details were planned for `deterministic-builds/ecosystem_npm.md`.
 
 **Lock mechanism**: `package-lock.json` v2/v3 contains complete dependency tree with SHA-512 integrity hashes.
 
@@ -681,7 +683,7 @@ type NpmExecParams struct {
 
 ### pip
 
-> Full details: [ecosystem_pip.md](deterministic-builds/ecosystem_pip.md)
+> Full details were planned for `deterministic-builds/ecosystem_pip.md`.
 
 **Lock mechanism**: `requirements.txt` with hashes (via pip-tools). Format: `package==version --hash=sha256:...`
 
@@ -714,7 +716,7 @@ type PipInstallParams struct {
 
 ### gem
 
-> Full details: [ecosystem_gem.md](deterministic-builds/ecosystem_gem.md)
+> Full details were planned for `deterministic-builds/ecosystem_gem.md`.
 
 **Lock mechanism**: `Gemfile.lock` with SHA-256 checksums (Bundler 2.6+).
 
@@ -746,7 +748,7 @@ type GemExecParams struct {
 
 ### Nix
 
-> Full details: [ecosystem_nix.md](deterministic-builds/ecosystem_nix.md)
+> Full details were planned for `deterministic-builds/ecosystem_nix.md`.
 
 **Lock mechanism**: `flake.lock` (JSON) pins all flake inputs. Derivation hashes provide content-addressable builds.
 
@@ -783,7 +785,7 @@ type NixRealizeParams struct {
 
 ### CPAN
 
-> Full details: [ecosystem_cpan.md](deterministic-builds/ecosystem_cpan.md)
+> Full details were planned for `deterministic-builds/ecosystem_cpan.md`.
 
 **Lock mechanism**: `cpanfile.snapshot` (via Carton) captures distribution versions and dependency graph.
 

--- a/docs/designs/archive/DESIGN-deterministic-execution.md
+++ b/docs/designs/archive/DESIGN-deterministic-execution.md
@@ -33,7 +33,7 @@ rationale: This design ensures all installations are deterministic by default, d
 
 ## Upstream Design Reference
 
-This design implements Milestone 2 of [DESIGN-deterministic-resolution.md](DESIGN-deterministic-resolution.md).
+This design implements Milestone 2 of [DESIGN-deterministic-resolution.md](../current/DESIGN-deterministic-resolution.md).
 
 **Relevant sections:**
 - Vision: "A recipe is a program that produces a deterministic installation plan"

--- a/docs/designs/archive/DESIGN-installation-plans-eval.md
+++ b/docs/designs/archive/DESIGN-installation-plans-eval.md
@@ -16,7 +16,7 @@ rationale: Plans enable golden file testing for recipe validation, provide users
 
 ## Upstream Design Reference
 
-This design implements Milestone 1 of [DESIGN-deterministic-resolution.md](DESIGN-deterministic-resolution.md).
+This design implements Milestone 1 of [DESIGN-deterministic-resolution.md](../current/DESIGN-deterministic-resolution.md).
 
 **Relevant sections:**
 - Vision: "A recipe is a program that produces a deterministic installation plan"

--- a/docs/designs/archive/DESIGN-llm-productionize.md
+++ b/docs/designs/archive/DESIGN-llm-productionize.md
@@ -9,7 +9,7 @@ rationale: These controls ensure users can see and control LLM costs, review gen
 
 **Status**: Superseded by [DESIGN-llm-builder-infrastructure.md](../current/DESIGN-llm-builder-infrastructure.md)
 
-**Parent Design**: [DESIGN-llm-builder-infrastructure.md](docs/DESIGN-llm-builder-infrastructure.md)
+**Parent Design**: [DESIGN-llm-builder-infrastructure.md](../current/DESIGN-llm-builder-infrastructure.md)
 
 **Issue**: [#270 - Slice 4: Productionize](https://github.com/tsukumogami/tsuku/issues/270)
 
@@ -127,7 +127,7 @@ For this feature to be considered production-ready:
 
 ## Upstream Design Reference
 
-From [DESIGN-llm-builder-infrastructure.md](docs/DESIGN-llm-builder-infrastructure.md), Slice 4 specifies:
+From [DESIGN-llm-builder-infrastructure.md](../current/DESIGN-llm-builder-infrastructure.md), Slice 4 specifies:
 
 ### Deliverables
 - Update `tsuku create` to support `--from github`

--- a/docs/designs/archive/DESIGN-llm-slice-1-spike.md
+++ b/docs/designs/archive/DESIGN-llm-slice-1-spike.md
@@ -9,7 +9,7 @@ rationale: Building the critical path first surfaces integration issues early an
 
 **Status**: Superseded by [DESIGN-llm-builder-infrastructure.md](../current/DESIGN-llm-builder-infrastructure.md)
 
-**Parent Design**: [DESIGN-llm-builder-infrastructure.md](DESIGN-llm-builder-infrastructure.md)
+**Parent Design**: [DESIGN-llm-builder-infrastructure.md](../current/DESIGN-llm-builder-infrastructure.md)
 
 **Issue**: [#266 - Slice 1: End-to-End Spike](https://github.com/tsukumogami/tsuku/issues/266)
 

--- a/docs/designs/archive/DESIGN-llm-slice-3-repair-loop.md
+++ b/docs/designs/archive/DESIGN-llm-slice-3-repair-loop.md
@@ -9,7 +9,7 @@ rationale: Repair loops improve success rates by allowing the LLM to learn from 
 
 **Status**: Superseded by [DESIGN-llm-builder-infrastructure.md](../current/DESIGN-llm-builder-infrastructure.md)
 
-**Parent Design**: [DESIGN-llm-builder-infrastructure.md](DESIGN-llm-builder-infrastructure.md)
+**Parent Design**: [DESIGN-llm-builder-infrastructure.md](../current/DESIGN-llm-builder-infrastructure.md)
 
 **Issue**: [#269 - Slice 3: Repair Loop + Second Provider](https://github.com/tsukumogami/tsuku/issues/269)
 

--- a/docs/designs/archive/DESIGN-plan-based-installation.md
+++ b/docs/designs/archive/DESIGN-plan-based-installation.md
@@ -27,7 +27,7 @@ rationale: This completes the deterministic installation milestone by enabling U
 
 ## Upstream Design Reference
 
-This design implements Milestone 3 of [DESIGN-deterministic-resolution.md](DESIGN-deterministic-resolution.md).
+This design implements Milestone 3 of [DESIGN-deterministic-resolution.md](../current/DESIGN-deterministic-resolution.md).
 
 **Relevant sections:**
 - Vision: "A recipe is a program that produces a deterministic installation plan"

--- a/docs/designs/current/DESIGN-batch-operations.md
+++ b/docs/designs/current/DESIGN-batch-operations.md
@@ -13,7 +13,7 @@ Current
 
 ## Upstream Design Reference
 
-This design implements part of [DESIGN-registry-scale-strategy.md](DESIGN-registry-scale-strategy.md).
+This design implements part of [DESIGN-registry-scale-strategy.md](../DESIGN-registry-scale-strategy.md).
 
 **Relevant sections:**
 - Phase 0: Rollback scripts (tested against manually-created recipes)

--- a/docs/designs/current/DESIGN-batch-platform-validation.md
+++ b/docs/designs/current/DESIGN-batch-platform-validation.md
@@ -16,7 +16,7 @@ Current
 
 ## Upstream Design Reference
 
-This design implements the platform validation jobs (Job 3) and merge job platform-constraint writing (Job 4) from [DESIGN-batch-recipe-generation.md](DESIGN-batch-recipe-generation.md).
+This design implements the platform validation jobs (Job 3) and merge job platform-constraint writing (Job 4) from [DESIGN-batch-recipe-generation.md](../DESIGN-batch-recipe-generation.md).
 
 **Relevant sections:**
 - Job Architecture (Jobs 3-4)

--- a/docs/designs/current/DESIGN-cask-support.md
+++ b/docs/designs/current/DESIGN-cask-support.md
@@ -23,7 +23,7 @@ Current
 
 ## Upstream Design Reference
 
-This design extends [DESIGN-homebrew.md](designs/current/DESIGN-homebrew.md) which describes tsuku's Homebrew integration architecture for formula bottles.
+This design extends [DESIGN-homebrew.md](DESIGN-homebrew.md) which describes tsuku's Homebrew integration architecture for formula bottles.
 
 **Relevant sections:**
 - HomebrewBuilder architecture for recipe generation

--- a/docs/designs/current/DESIGN-consolidate-system-deps.md
+++ b/docs/designs/current/DESIGN-consolidate-system-deps.md
@@ -1,5 +1,5 @@
 ---
-status: Accepted
+status: Current
 problem: |
   Two overlapping implementations extract system packages from recipes and plans:
   executor/system_deps.go (5 actions, packages only) and sandbox/packages.go
@@ -27,11 +27,11 @@ rationale: |
 
 ## Status
 
-**Accepted**
+**Current**
 
 ## Upstream Design Reference
 
-This design supersedes the "Code Reuse with Sandbox" section of [DESIGN-recipe-driven-ci-testing.md](current/DESIGN-recipe-driven-ci-testing.md), which established the original intent for shared extraction code between `tsuku info` and sandbox mode.
+This design supersedes the "Code Reuse with Sandbox" section of [DESIGN-recipe-driven-ci-testing.md](DESIGN-recipe-driven-ci-testing.md), which established the original intent for shared extraction code between `tsuku info` and sandbox mode.
 
 ## Context and Problem Statement
 

--- a/docs/designs/current/DESIGN-discovery-registry-bootstrap.md
+++ b/docs/designs/current/DESIGN-discovery-registry-bootstrap.md
@@ -46,7 +46,7 @@ Current
 
 ## Upstream Design Reference
 
-This design implements Phase 2 of [DESIGN-discovery-resolver.md](DESIGN-discovery-resolver.md), extending the discovery registry schema with optional metadata fields.
+This design implements Phase 2 of [DESIGN-discovery-resolver.md](../DESIGN-discovery-resolver.md), extending the discovery registry schema with optional metadata fields.
 
 **Relevant upstream sections:**
 - Discovery Registry Format (current): `{builder, source, binary?}`
@@ -55,8 +55,8 @@ This design implements Phase 2 of [DESIGN-discovery-resolver.md](DESIGN-discover
 - Registry is fetched from recipes repository, cached locally
 
 **Related designs:**
-- [DESIGN-registry-scale-strategy.md](DESIGN-registry-scale-strategy.md): Batch recipe generation from priority queue. As recipes get generated, tools graduate out of the discovery registry.
-- [DESIGN-batch-recipe-generation.md](DESIGN-batch-recipe-generation.md): CI pipeline for deterministic recipe generation.
+- [DESIGN-registry-scale-strategy.md](../DESIGN-registry-scale-strategy.md): Batch recipe generation from priority queue. As recipes get generated, tools graduate out of the discovery registry.
+- [DESIGN-batch-recipe-generation.md](../DESIGN-batch-recipe-generation.md): CI pipeline for deterministic recipe generation.
 
 ## Context and Problem Statement
 

--- a/docs/designs/current/DESIGN-ecosystem-probe.md
+++ b/docs/designs/current/DESIGN-ecosystem-probe.md
@@ -16,7 +16,7 @@ Current
 
 ## Upstream Design Reference
 
-This design implements the Ecosystem Probe stage described in [DESIGN-discovery-resolver.md](DESIGN-discovery-resolver.md) (Solution Architecture: Ecosystem Probe section). It addresses the design questions raised in issue 1317.
+This design implements the Ecosystem Probe stage described in [DESIGN-discovery-resolver.md](../DESIGN-discovery-resolver.md) (Solution Architecture: Ecosystem Probe section). It addresses the design questions raised in issue 1317.
 
 ## Context and Problem Statement
 
@@ -74,7 +74,7 @@ Instead of popularity thresholds, use two signals:
 1. **Exact name match**: The queried tool name must exactly match the package name in the registry (case-insensitive). This rejects packages where the tool name is a substring or slight variation.
 2. **Static priority ranking**: When multiple ecosystems match, rank by ecosystem reliability rather than per-package popularity. The order reflects which ecosystems are most likely to contain the "canonical" version of a tool: Homebrew Cask > crates.io > PyPI > npm > RubyGems > Go > CPAN.
 
-Quality filtering was deferred to a follow-up design ([DESIGN-probe-quality-filtering.md](current/DESIGN-probe-quality-filtering.md)) which uses version count and repository presence rather than age thresholds.
+Quality filtering was deferred to a follow-up design ([DESIGN-probe-quality-filtering.md](DESIGN-probe-quality-filtering.md)) which uses version count and repository presence rather than age thresholds.
 
 #### Alternatives Considered
 
@@ -120,7 +120,7 @@ The parent design's filtering thresholds assumed API metadata that doesn't exist
 ### Trade-offs Accepted
 
 - **Less precise disambiguation**: Without download counts, we can't distinguish between a popular crate and an obscure one. A static priority list is a rough proxy. This is acceptable because disambiguation (#1321) will present options to the user in ambiguous cases.
-- **Quality filtering deferred**: Initial implementation doesn't filter by download counts or age. Mitigated by exact name matching, curated registry precedence, and the follow-up [quality filtering design](current/DESIGN-probe-quality-filtering.md).
+- **Quality filtering deferred**: Initial implementation doesn't filter by download counts or age. Mitigated by exact name matching, curated registry precedence, and the follow-up [quality filtering design](DESIGN-probe-quality-filtering.md).
 - **Cask may produce noise**: Including Cask means macOS GUI apps might match tool names. Can be excluded in a follow-up if it's a problem.
 
 ## Solution Architecture

--- a/docs/designs/current/DESIGN-fossil-archive.md
+++ b/docs/designs/current/DESIGN-fossil-archive.md
@@ -23,7 +23,7 @@ Current
 
 ## Context and Problem Statement
 
-Tsuku's [Build Essentials](BUILD-ESSENTIALS.md) infrastructure enables building tools from source when pre-built binaries aren't available. This design extends that capability to support [Fossil SCM](https://fossil-scm.org/), a distributed version control system used by several important open-source projects.
+Tsuku's [Build Essentials](../../BUILD-ESSENTIALS.md) infrastructure enables building tools from source when pre-built binaries aren't available. This design extends that capability to support [Fossil SCM](https://fossil-scm.org/), a distributed version control system used by several important open-source projects.
 
 ### Recipe Philosophy
 

--- a/docs/designs/current/DESIGN-homebrew-deterministic-mode.md
+++ b/docs/designs/current/DESIGN-homebrew-deterministic-mode.md
@@ -13,7 +13,7 @@ Current
 
 ## Upstream Design Reference
 
-This design implements part of [DESIGN-registry-scale-strategy.md](DESIGN-registry-scale-strategy.md).
+This design implements part of [DESIGN-registry-scale-strategy.md](../DESIGN-registry-scale-strategy.md).
 
 **Relevant sections:**
 - Decision 1: Fully deterministic batch generation

--- a/docs/designs/current/DESIGN-library-verify-integrity.md
+++ b/docs/designs/current/DESIGN-library-verify-integrity.md
@@ -23,7 +23,7 @@ Current
 
 ## Upstream Design Reference
 
-This design implements Level 4 of the tiered library verification system defined in [DESIGN-library-verification.md](docs/designs/DESIGN-library-verification.md).
+This design implements Level 4 of the tiered library verification system defined in [DESIGN-library-verification.md](DESIGN-library-verification.md).
 
 **Relevant sections:**
 - Solution Architecture: Level 4 - Integrity Check

--- a/docs/designs/current/DESIGN-llm-discovery-implementation.md
+++ b/docs/designs/current/DESIGN-llm-discovery-implementation.md
@@ -30,7 +30,7 @@ Current
 
 ## Upstream Design Reference
 
-This design implements Phase 5 (LLM Discovery) of [DESIGN-discovery-resolver.md](DESIGN-discovery-resolver.md). It addresses the design questions raised in [issue #1318](https://github.com/tsukumogami/tsuku/issues/1318):
+This design implements Phase 5 (LLM Discovery) of [DESIGN-discovery-resolver.md](../DESIGN-discovery-resolver.md). It addresses the design questions raised in [issue #1318](https://github.com/tsukumogami/tsuku/issues/1318):
 
 - LLM integration: How to connect to the existing LLM infrastructure
 - Prompt design: System prompts for reliable structured output

--- a/docs/designs/current/DESIGN-merge-job-completion.md
+++ b/docs/designs/current/DESIGN-merge-job-completion.md
@@ -42,7 +42,7 @@ Observability and scale improvements: SLI metrics for trend analysis and auto-me
 
 ## Upstream Design Reference
 
-This design completes the merge job (Job 4) from [DESIGN-batch-recipe-generation.md](DESIGN-batch-recipe-generation.md). The platform validation foundation was delivered by [DESIGN-batch-platform-validation.md](DESIGN-batch-platform-validation.md) (M60).
+This design completes the merge job (Job 4) from [DESIGN-batch-recipe-generation.md](../DESIGN-batch-recipe-generation.md). The platform validation foundation was delivered by [DESIGN-batch-platform-validation.md](DESIGN-batch-platform-validation.md) (M60).
 
 **Relevant upstream sections:**
 - Job Architecture (Job 4: merge)

--- a/docs/designs/current/DESIGN-pipeline-dashboard.md
+++ b/docs/designs/current/DESIGN-pipeline-dashboard.md
@@ -100,7 +100,7 @@ This is the right long-term solution, but it's weeks of work. Meanwhile, the dat
 
 ### Upstream Reference
 
-This design supports the broader [Registry Scale Strategy](DESIGN-registry-scale-strategy.md) and specifically provides an intermediate solution for #1190 (Failure Analysis Backend). The goal is to deliver immediate visibility without requiring the full Cloudflare D1 infrastructure.
+This design supports the broader [Registry Scale Strategy](../DESIGN-registry-scale-strategy.md) and specifically provides an intermediate solution for #1190 (Failure Analysis Backend). The goal is to deliver immediate visibility without requiring the full Cloudflare D1 infrastructure.
 
 ### Existing Patterns
 

--- a/docs/designs/current/DESIGN-priority-queue.md
+++ b/docs/designs/current/DESIGN-priority-queue.md
@@ -26,7 +26,7 @@ Current
 
 ## Upstream Design Reference
 
-This design implements Phase 0 (Visibility Infrastructure) of [DESIGN-registry-scale-strategy.md](./DESIGN-registry-scale-strategy.md).
+This design implements Phase 0 (Visibility Infrastructure) of [DESIGN-registry-scale-strategy.md](../DESIGN-registry-scale-strategy.md).
 
 **Relevant sections:**
 - Phase 0: Visibility Infrastructure

--- a/docs/designs/current/DESIGN-probe-quality-filtering.md
+++ b/docs/designs/current/DESIGN-probe-quality-filtering.md
@@ -29,7 +29,7 @@ Current
 
 ## Upstream Design Reference
 
-This design addresses a gap discovered during implementation of [DESIGN-ecosystem-probe.md](DESIGN-ecosystem-probe.md). That design assumed registry APIs don't expose download counts, but research shows at least crates.io and RubyGems do. This design also intersects with the discovery registry seeding process described in [DESIGN-discovery-resolver.md](DESIGN-discovery-resolver.md) and the batch pipeline described in [DESIGN-registry-scale-strategy.md](DESIGN-registry-scale-strategy.md).
+This design addresses a gap discovered during implementation of [DESIGN-ecosystem-probe.md](DESIGN-ecosystem-probe.md). That design assumed registry APIs don't expose download counts, but research shows at least crates.io and RubyGems do. This design also intersects with the discovery registry seeding process described in [DESIGN-discovery-resolver.md](../DESIGN-discovery-resolver.md) and the batch pipeline described in [DESIGN-registry-scale-strategy.md](../DESIGN-registry-scale-strategy.md).
 
 **Key architectural insight**: The discovery JSON files (`recipes/discovery/`) are already the universal interface for tool resolution. The batch seeding pipeline produces them, the `RegistryLookup` resolver consumes them, and LLM discovery will eventually produce them dynamically. Quality filtering needs to work for both the runtime probe and the seeding pipeline. An import cycle between `builders` and `discover` prevents `Probe()` from returning `RegistryEntry` directly, so `ProbeResult` carries the quality fields and a thin conversion at the boundary maps to `RegistryEntry` for storage. The `QualityFilter` operates on `ProbeResult`, and the seeding pipeline can call `Probe()` to get the same data.
 

--- a/docs/designs/current/DESIGN-recipe-driven-ci-testing.md
+++ b/docs/designs/current/DESIGN-recipe-driven-ci-testing.md
@@ -198,7 +198,7 @@ This matches current `tsuku info` behavior where dependencies shown are relevant
 
 ### Decision 3: Code Reuse with Sandbox
 
-> **Note:** This decision is superseded by [DESIGN-consolidate-system-deps.md](../DESIGN-consolidate-system-deps.md), which addresses the divergence between executor and sandbox implementations and extends `--deps-only --system` to include repository configurations.
+> **Note:** This decision is superseded by [DESIGN-consolidate-system-deps.md](DESIGN-consolidate-system-deps.md), which addresses the divergence between executor and sandbox implementations and extends `--deps-only --system` to include repository configurations.
 
 Both `tsuku info` (with new flags) and sandbox mode extract system packages from recipes. How should they share code?
 

--- a/docs/designs/current/DESIGN-tap-support.md
+++ b/docs/designs/current/DESIGN-tap-support.md
@@ -23,8 +23,8 @@ Current
 ## Upstream Design Reference
 
 This design extends:
-- [DESIGN-homebrew.md](current/DESIGN-homebrew.md) - Core formula bottle support
-- [DESIGN-cask-support.md](current/DESIGN-cask-support.md) - Cask support
+- [DESIGN-homebrew.md](DESIGN-homebrew.md) - Core formula bottle support
+- [DESIGN-cask-support.md](DESIGN-cask-support.md) - Cask support
 
 **Relevant patterns:**
 - Cask design's hybrid approach (version provider + generic action)


### PR DESCRIPTION
Simplified docs/designs/README.md to describe only directory structure and status
lifecycle. Removed the manually-maintained list of design documents that was prone
to becoming outdated and required manual updates whenever designs were created,
moved, or archived.

Fixed 37 broken internal links across design documents where relative path references
had incorrect prefixes (current/ when in current/, ../ when not needed, etc.).

Transitioned DESIGN-consolidate-system-deps.md from Accepted to Current status and
moved to current/ directory following PR #1626 merge.

---

## Changes

- **README.md**: Simplified to folder structure overview only
- **25 files**: Fixed relative link paths
- **DESIGN-consolidate-system-deps.md**: Status Accepted → Current, moved to current/