### PR TITLE
docs: add design for shell integration building blocks

### DIFF
--- a/docs/designs/DESIGN-shell-integration-building-blocks.md
+++ b/docs/designs/DESIGN-shell-integration-building-blocks.md
@@ -75,7 +75,7 @@ The vision is a fundamentally different UX where:
 - Tsuku identifies which recipe provides `jq`
 - Tsuku either auto-installs or prompts for confirmation
 - The command runs seamlessly
-- Optionally, LLM discovery helps find or create recipes for unknown commands
+- Optionally, LLM (large language model) discovery helps find or create recipes for unknown commands
 
 This vision requires several building blocks that don't exist today. This design identifies those building blocks so each can be designed and implemented independently.
 
@@ -368,7 +368,7 @@ This design produces five building blocks, each with its own detailed design doc
 │                                                                      │
 │  ┌──────────────┐     ┌──────────────┐     ┌──────────────┐        │
 │  │ Binary Index │     │   Project    │     │   Install    │        │
-│  │   (Block 1)  │◄────┤    Config    │     │   Manager    │        │
+│  │   (Block 1)  │     │    Config    │     │   Manager    │        │
 │  │              │     │   (Block 4)  │     │  (existing)  │        │
 │  └──────┬───────┘     └──────────────┘     └──────┬───────┘        │
 │         │                                          │                 │
@@ -488,7 +488,7 @@ type EnvActivator interface {
 
 ```
 1. User enters project directory with .tsuku.toml
-2. Shell's prompt hook invokes `tsuku env` (or user runs `eval $(tsuku shell)`)
+2. Shell's prompt hook invokes `tsuku shell` (or user runs `eval $(tsuku shell)`)
 3. EnvActivator calls LoadProjectConfig(".")
 4. For each tool in config, EnvActivator ensures version is installed
 5. EnvActivator returns PATH modification pointing to project tool versions


### PR DESCRIPTION
Add DESIGN-shell-integration-building-blocks.md proposing a five-block architecture for automatic command interception and on-demand tool provisioning. The blocks are: binary index (command-to-recipe mapping), command-not-found handler (shell hooks), auto-install flow (install on first use), project configuration (per-directory .tsuku.toml), and shell environment activation (dynamic PATH).

---

## Design Highlights

**Chosen Approach: Five-Block Architecture with Parallel Tracks**

Two independent implementation tracks:
- **Track A** (command interception): Binary Index -> Command-Not-Found -> Auto-Install
- **Track B** (project environments): Project Configuration -> Shell Environment Activation

**Key Decisions:**

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Block structure | Five independent blocks | Each provides standalone value; enables incremental delivery |
| Shell hooks | Optional convenience layer | All features work via explicit CLI (`tsuku run`, `tsuku shell`) |
| Binary index | Registry-derived, SQLite-backed | Knows commands before installation; 50ms lookup budget |
| Parallel tracks | A and B independent | Project config has no dependency on command interception |

**What This Enables:**

Creates `needs-design` issues for each block, allowing detailed design work to proceed in parallel on both tracks.