### PR TITLE
docs: remove block numbers from issue titles

### DIFF
--- a/docs/designs/DESIGN-shell-integration-building-blocks.md
+++ b/docs/designs/DESIGN-shell-integration-building-blocks.md
@@ -20,15 +20,15 @@ Planned
 
 | Issue | Dependencies | Tier |
 |-------|--------------|------|
-| [#1677: docs: design binary index (Block 1)](https://github.com/tsukumogami/tsuku/issues/1677) | None | testable |
+| [#1677: docs: design binary index](https://github.com/tsukumogami/tsuku/issues/1677) | None | testable |
 | _Design the SQLite-backed index that maps command names to recipes. Defines the `BinaryIndex` interface, conflict resolution policy, and ~50ms lookup requirement. Foundation for all command-to-recipe lookups._ | | |
-| [#1678: docs: design command-not-found handler (Block 2)](https://github.com/tsukumogami/tsuku/issues/1678) | [#1677](https://github.com/tsukumogami/tsuku/issues/1677) | testable |
+| [#1678: docs: design command-not-found handler](https://github.com/tsukumogami/tsuku/issues/1678) | [#1677](https://github.com/tsukumogami/tsuku/issues/1677) | testable |
 | _Shell hooks for bash, zsh, and fish that intercept unknown commands. Specifies `tsuku suggest` output format, hook installation mechanism, and security analysis for shell injection prevention._ | | |
-| [#1679: docs: design auto-install flow (Block 3)](https://github.com/tsukumogami/tsuku/issues/1679) | [#1677](https://github.com/tsukumogami/tsuku/issues/1677) | testable |
+| [#1679: docs: design auto-install flow](https://github.com/tsukumogami/tsuku/issues/1679) | [#1677](https://github.com/tsukumogami/tsuku/issues/1677) | testable |
 | _The `tsuku run` command that installs tools on first use. Defines suggest/confirm/auto modes, TTY detection for interactive prompts, and security considerations for auto-install consent._ | | |
-| [#1680: docs: design project configuration (Block 4)](https://github.com/tsukumogami/tsuku/issues/1680) | None | testable |
+| [#1680: docs: design project configuration](https://github.com/tsukumogami/tsuku/issues/1680) | None | testable |
 | _Per-directory `.tsuku.toml` format specifying tool requirements. Defines the TOML schema, version constraint syntax, directory traversal behavior, and `LoadProjectConfig` interface._ | | |
-| [#1681: docs: design shell environment activation (Block 5)](https://github.com/tsukumogami/tsuku/issues/1681) | [#1680](https://github.com/tsukumogami/tsuku/issues/1680) | testable |
+| [#1681: docs: design shell environment activation](https://github.com/tsukumogami/tsuku/issues/1681) | [#1680](https://github.com/tsukumogami/tsuku/issues/1680) | testable |
 | _Dynamic PATH modification based on current directory. Specifies activation via prompt hooks or `tsuku shell`, state tracking for active projects, and deactivation behavior._ | | |
 
 ### Dependency Graph


### PR DESCRIPTION
Remove redundant "(Block N)" suffix from issue titles in the shell integration building blocks design document. Block numbers were arbitrary and added noise to the titles.

---

## What Changed

- Updated issue table in `docs/designs/DESIGN-shell-integration-building-blocks.md`
- GitHub issues #1677-#1681 titles updated to match
- Issue bodies updated to use issue links instead of "Block N" references