### PR TITLE
docs(design): mark DESIGN-disambiguation.md as current

### DIFF
--- a/docs/designs/DESIGN-registry-scale-strategy.md
+++ b/docs/designs/DESIGN-registry-scale-strategy.md
@@ -72,19 +72,6 @@ Implements [#1189](https://github.com/tsukumogami/tsuku/issues/1189). See [DESIG
 |-------|-------|--------------|------|
 | [#1191](https://github.com/tsukumogami/tsuku/issues/1191) | design system library backfill strategy | [#1190](https://github.com/tsukumogami/tsuku/issues/1190) | simple |
 
-### Milestone: [Ecosystem Disambiguation](https://github.com/tsukumogami/tsuku/milestone/81)
-
-| Issue | Title | Dependencies | Tier |
-|-------|-------|--------------|------|
-| ~~[#1648](https://github.com/tsukumogami/tsuku/issues/1648)~~ | ~~core disambiguation with ranking~~ | ~~None~~ | ~~testable~~ |
-| ~~[#1649](https://github.com/tsukumogami/tsuku/issues/1649)~~ | ~~typosquatting detection~~ | ~~None~~ | ~~testable~~ |
-| ~~[#1650](https://github.com/tsukumogami/tsuku/issues/1650)~~ | ~~ConfirmDisambiguationFunc callback~~ | ~~[#1648](https://github.com/tsukumogami/tsuku/issues/1648)~~ | ~~testable~~ |
-| ~~[#1651](https://github.com/tsukumogami/tsuku/issues/1651)~~ | ~~disambiguation prompt in CLI~~ | ~~[#1648](https://github.com/tsukumogami/tsuku/issues/1648), [#1650](https://github.com/tsukumogami/tsuku/issues/1650)~~ | ~~testable~~ |
-| ~~[#1652](https://github.com/tsukumogami/tsuku/issues/1652)~~ | ~~AmbiguousMatchError type~~ | ~~[#1648](https://github.com/tsukumogami/tsuku/issues/1648)~~ | ~~testable~~ |
-| ~~[#1653](https://github.com/tsukumogami/tsuku/issues/1653)~~ | ~~CLI error handling for --from~~ | ~~[#1652](https://github.com/tsukumogami/tsuku/issues/1652)~~ | ~~testable~~ |
-| ~~[#1654](https://github.com/tsukumogami/tsuku/issues/1654)~~ | ~~DisambiguationRecord tracking~~ | ~~[#1648](https://github.com/tsukumogami/tsuku/issues/1648)~~ | ~~testable~~ |
-| ~~[#1655](https://github.com/tsukumogami/tsuku/issues/1655)~~ | ~~dashboard metrics display~~ | ~~[#1654](https://github.com/tsukumogami/tsuku/issues/1654)~~ | ~~simple~~ |
-
 ### Dependency Graph
 
 ```mermaid
@@ -126,17 +113,6 @@ graph TD
         I1191["#1191: System library backfill"]
     end
 
-    subgraph M_Disambiguation["Ecosystem Disambiguation"]
-        I1648["#1648: Core disambiguation"]
-        I1649["#1649: Typosquatting"]
-        I1650["#1650: Callback type"]
-        I1651["#1651: CLI prompt"]
-        I1652["#1652: AmbiguousMatchError"]
-        I1653["#1653: CLI error handling"]
-        I1654["#1654: Batch tracking"]
-        I1655["#1655: Dashboard metrics"]
-    end
-
     I1186 --> I1199
     I1186 --> I1200
     I1199 --> I1201
@@ -156,13 +132,6 @@ graph TD
     I1189 --> I1190
     I1190 --> I1191
     I1277 --> I1278
-    I1648 --> I1650
-    I1650 --> I1651
-    I1648 --> I1651
-    I1648 --> I1652
-    I1652 --> I1653
-    I1648 --> I1654
-    I1654 --> I1655
 
     classDef done fill:#c8e6c9
     classDef ready fill:#bbdefb
@@ -187,7 +156,6 @@ graph TD
     class I1278 blocked
     class I1412 done
     class I1191 blocked
-    class I1648,I1649,I1650,I1651,I1652,I1653,I1654,I1655 done
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design

--- a/docs/designs/current/DESIGN-disambiguation.md
+++ b/docs/designs/current/DESIGN-disambiguation.md
@@ -1,5 +1,5 @@
 ---
-status: Planned
+status: Current
 problem: |
   When multiple ecosystem registries return matches for a tool name (e.g., "bat" exists
   on crates.io as sharkdp/bat and on npm as bat-cli), the ecosystem probe stage silently
@@ -24,11 +24,11 @@ rationale: |
 
 ## Status
 
-Planned
+Current
 
 ## Implementation Issues
 
-### Milestone: [Ecosystem Disambiguation](https://github.com/tsukumogami/tsuku/milestone/81)
+### Milestone: [Ecosystem Disambiguation](https://github.com/tsukumogami/tsuku/milestone/81) (Closed)
 
 | Issue | Dependencies | Tier |
 |-------|--------------|------|
@@ -44,52 +44,10 @@ Planned
 | _Enhances `AmbiguousMatchError` with formatted `--from` suggestions for CI/pipeline usage. Error message includes ranked matches with source identifiers for copy-paste convenience._ | | |
 | ~~[#1653: feat(cli): handle AmbiguousMatchError with --from suggestions](https://github.com/tsukumogami/tsuku/issues/1653)~~ | ~~[#1652](https://github.com/tsukumogami/tsuku/issues/1652)~~ | ~~testable~~ |
 | _Adds CLI error handling that displays `AmbiguousMatchError` with actionable `--from` suggestions in create and install commands. Provides clear guidance for non-interactive resolution._ | | |
-| ~~[#1654: feat(batch): add DisambiguationRecord tracking](https://github.com/tsukumogami/tsuku/issues/1654)~~ | [#1648](https://github.com/tsukumogami/tsuku/issues/1648) | testable |
+| ~~[#1654: feat(batch): add DisambiguationRecord tracking](https://github.com/tsukumogami/tsuku/issues/1654)~~ | ~~[#1648](https://github.com/tsukumogami/tsuku/issues/1648)~~ | ~~testable~~ |
 | _Creates `DisambiguationRecord` type for batch orchestrator to track tool selections. Records selection reason (single_match, 10x_popularity_gap, priority_fallback) and sets `HighRisk` flag for fallback selections._ | | |
 | ~~[#1655: feat(dashboard): display disambiguation metrics](https://github.com/tsukumogami/tsuku/issues/1655)~~ | ~~[#1654](https://github.com/tsukumogami/tsuku/issues/1654)~~ | ~~simple~~ |
 | _Adds disambiguation statistics to the pipeline dashboard showing counts by selection reason and highlighting high-risk fallback selections for human review._ | | |
-
-### Dependency Graph
-
-```mermaid
-graph TD
-    subgraph Phase1["Phase 1: Core"]
-        I1648["#1648: Core disambiguation"]
-        I1649["#1649: Typosquatting"]
-    end
-
-    subgraph Phase2["Phase 2: Interactive"]
-        I1650["#1650: Callback type"]
-        I1651["#1651: CLI prompt"]
-    end
-
-    subgraph Phase3["Phase 3: Non-Interactive"]
-        I1652["#1652: AmbiguousMatchError"]
-        I1653["#1653: CLI error handling"]
-    end
-
-    subgraph Phase4["Phase 4: Batch"]
-        I1654["#1654: Batch tracking"]
-        I1655["#1655: Dashboard metrics"]
-    end
-
-    I1648 --> I1650
-    I1650 --> I1651
-    I1648 --> I1651
-    I1648 --> I1652
-    I1652 --> I1653
-    I1648 --> I1654
-    I1654 --> I1655
-
-    classDef done fill:#c8e6c9
-    classDef ready fill:#bbdefb
-    classDef blocked fill:#fff9c4
-    classDef needsDesign fill:#e1bee7
-
-    class I1648,I1649,I1650,I1651,I1652,I1653,I1654,I1655 done
-```
-
-**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design
 
 ## Upstream Design Reference
 


### PR DESCRIPTION
Move DESIGN-disambiguation.md to docs/designs/current/ and update status to
Current. Remove the M81 (Ecosystem Disambiguation) section from
DESIGN-registry-scale-strategy.md since the milestone is now closed.

---

## What This Accomplishes

Finalizes DESIGN-disambiguation.md as a completed design:
- Updates status from "Planned" to "Current"
- Moves from `docs/designs/` to `docs/designs/current/`
- Removes Implementation Issues section (not allowed in Current status)

The implementation (disambiguation ranking, typosquatting detection, CLI prompts,
batch tracking) was completed across issues #1648-#1655.