### PR TITLE
fix(batch): correct batch-results.json path in merge job

### DIFF
--- a/.github/workflows/batch-generate.yml
+++ b/.github/workflows/batch-generate.yml
@@ -971,7 +971,7 @@ jobs:
         run: |
           # Read per-ecosystem outcomes from batch-results.json written by the orchestrator.
           # Each ecosystem that participated in the batch gets its breaker updated.
-          RESULTS_FILE="data/batch-results.json"
+          RESULTS_FILE="data/queues/batch-results.json"
           if [ ! -f "$RESULTS_FILE" ] || [ ! -s "$RESULTS_FILE" ]; then
             echo "No batch results file found, skipping circuit breaker update"
             exit 0
@@ -1032,7 +1032,7 @@ jobs:
 
           # Read ecosystem breakdown from batch results
           ECOSYSTEMS_JSON="{}"
-          RESULTS_FILE="data/batch-results.json"
+          RESULTS_FILE="data/queues/batch-results.json"
           if [ -f "$RESULTS_FILE" ] && [ -s "$RESULTS_FILE" ]; then
             ECOSYSTEMS_JSON=$(jq -c '.ecosystems // {}' "$RESULTS_FILE")
           fi
@@ -1097,7 +1097,7 @@ jobs:
         run: |
           # Update queue statuses for processed recipes using batch results
           QUEUE_FILE="data/queues/priority-queue.json"
-          RESULTS_FILE="data/batch-results.json"
+          RESULTS_FILE="data/queues/batch-results.json"
           if [ -f "$RESULTS_FILE" ] && [ -s "$RESULTS_FILE" ]; then
             # Mark succeeded entries
             for pkg_id in $(jq -r '.recipes // [] | .[]' "$RESULTS_FILE" 2>/dev/null | while read -r path; do basename "$path" .toml; done); do
@@ -1132,7 +1132,7 @@ jobs:
 
           # Read ecosystem breakdown for commit message
           ECO_SUMMARY=""
-          RESULTS_FILE="data/batch-results.json"
+          RESULTS_FILE="data/queues/batch-results.json"
           if [ -f "$RESULTS_FILE" ] && [ -s "$RESULTS_FILE" ]; then
             ECO_SUMMARY=$(jq -r '.ecosystems // {} | to_entries | map("\(.value) \(.key)") | join(", ")' "$RESULTS_FILE")
           fi


### PR DESCRIPTION
Correct the file path for `batch-results.json` in 4 steps of the
merge job in `batch-generate.yml`. The orchestrator writes the file
to `data/queues/batch-results.json` (same directory as the queue
file), but the workflow referenced `data/batch-results.json`.

---

## What This Fixes

The SLI metrics, circuit breaker update, queue status update, and
commit message steps all read `batch-results.json` for ecosystem
data. With the wrong path, the file-existence check silently fell
through to defaults: empty `ecosystems` in metrics, no breaker
updates, and no ecosystem breakdown in commit messages.

Observed on batch run 2026-02-18: the `batch-runs-*.jsonl` metrics
file had `"ecosystems": {}` despite `batch-results.json` containing
`{"github": 9, "homebrew": 16}`.

## Changes

- `.github/workflows/batch-generate.yml`: 4 path corrections from
  `data/batch-results.json` to `data/queues/batch-results.json`
  (lines 974, 1035, 1100, 1135)