### PR TITLE
fix(dashboard): sort runs by timestamp before selecting latest

### DIFF
--- a/internal/dashboard/dashboard.go
+++ b/internal/dashboard/dashboard.go
@@ -291,7 +291,7 @@ func Generate(opts Options) error {
 	// Load metrics
 	runs, metricsRecords, err := loadMetricsFromDir(opts.MetricsDir)
 	if err == nil && len(runs) > 0 {
-		// Take last 10, newest first
+		// Take last 10, newest first (runs are sorted by timestamp in loadMetricsFromDir)
 		if len(runs) > 10 {
 			runs = runs[len(runs)-10:]
 		}
@@ -666,6 +666,17 @@ func loadMetricsFromDir(dir string) ([]RunSummary, []MetricsRecord, error) {
 		allRuns = append(allRuns, runs...)
 		allRecords = append(allRecords, records...)
 	}
+
+	// Sort by timestamp so newest runs are last regardless of file load order.
+	// The legacy batch-runs.jsonl (no timestamp in filename) sorts after
+	// timestamped files alphabetically, which would otherwise put old runs
+	// at the end of the slice.
+	sort.Slice(allRuns, func(i, j int) bool {
+		return allRuns[i].Timestamp < allRuns[j].Timestamp
+	})
+	sort.Slice(allRecords, func(i, j int) bool {
+		return allRecords[i].Timestamp < allRecords[j].Timestamp
+	})
 
 	return allRuns, allRecords, nil
 }


### PR DESCRIPTION
Sort runs and metrics records by timestamp in `loadMetricsFromDir` so
the "last 10" selection in `Generate` picks the actual newest runs.
The legacy `batch-runs.jsonl` (no timestamp in filename) sorts after
all `batch-runs-2026-*.jsonl` files alphabetically, which put its
old entries at the end of the slice and hid newer timestamped data.

---

## What This Fixes

The dashboard's runs list showed only Feb 6 data despite 200+ newer
metrics files existing. The glob pattern `batch-runs*.jsonl` returns
files in alphabetical order, and `batch-runs.jsonl` (the legacy file)
sorts after `batch-runs-2026-02-18T14-41-33Z.jsonl`. Since runs were
appended in file order and the code took `runs[len-10:]`, the legacy
file's entries were always selected.

## Changes

- `internal/dashboard/dashboard.go`: Add `sort.Slice` by timestamp in
  `loadMetricsFromDir` for both runs and records slices
- `internal/dashboard/dashboard_test.go`: Add test with a timestamped
  file and legacy file verifying correct sort order