### PR TITLE
chore(ci): update design doc validation

### DIFF
--- a/.github/scripts/checks/common.sh
+++ b/.github/scripts/checks/common.sh
@@ -44,8 +44,13 @@ emit_pass() {
 
 # emit_fail - Output a failing check message
 # Usage: emit_fail "Check failed: reason"
+# If VALIDATE_DOC_PATH is set (exported by the orchestrator), it is included.
 emit_fail() {
-    echo "[FAIL] $1" >&2
+    if [[ -n "${VALIDATE_DOC_PATH:-}" ]]; then
+        echo "[FAIL] $VALIDATE_DOC_PATH: $1" >&2
+    else
+        echo "[FAIL] $1" >&2
+    fi
 }
 
 # extract_frontmatter - Extract YAML frontmatter from a document

--- a/.github/scripts/checks/issue-status.sh
+++ b/.github/scripts/checks/issue-status.sh
@@ -61,6 +61,9 @@ if [[ ! -f "$DOC_PATH" ]]; then
     exit $EXIT_ERROR
 fi
 
+# Export for emit_fail to include in error messages (when called standalone)
+export VALIDATE_DOC_PATH="${VALIDATE_DOC_PATH:-$DOC_PATH}"
+
 # Check for required tools
 if ! command -v gh &> /dev/null; then
     echo "Warning: gh CLI not found, skipping issue status validation" >&2

--- a/.github/scripts/checks/mermaid.sh
+++ b/.github/scripts/checks/mermaid.sh
@@ -112,6 +112,9 @@ if [[ ! -f "$DOC_PATH" ]]; then
     exit $EXIT_ERROR
 fi
 
+# Export for emit_fail to include in error messages (when called standalone)
+export VALIDATE_DOC_PATH="${VALIDATE_DOC_PATH:-$DOC_PATH}"
+
 # Get normalized status from frontmatter (uses shared function from common.sh)
 FM_STATUS=$(get_frontmatter_status "$DOC_PATH")
 

--- a/.github/scripts/validate-design-doc.sh
+++ b/.github/scripts/validate-design-doc.sh
@@ -112,6 +112,9 @@ fi
 
 [[ "${QUIET_MODE:-0}" -ne 1 ]] && echo "Validating $DOC_PATH..."
 
+# Export for emit_fail to include in error messages
+export VALIDATE_DOC_PATH="$DOC_PATH"
+
 FAILED=0
 
 # Inline check: Location - must be under docs/designs/


### PR DESCRIPTION
Update design document validation scripts and workflow.

---

## What This Changes

- `.github/scripts/validate-design-doc.sh` - Orchestrator that runs modular validation checks
- `.github/scripts/checks/` - Modular check scripts (common.sh, frontmatter.sh, etc.)
- `.github/workflows/validate-design-docs.yml` - Runs validation on all PRs

## How It Works

The workflow finds all DESIGN-*.md files in the repo and validates each one:
- Location: must be under docs/designs/
- Naming: must start with DESIGN-
- Frontmatter: must have valid YAML frontmatter