### PR TITLE
ci(check-artifacts): skip on draft PRs and re-trigger on ready_for_review

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [main]
   schedule:
     # Run nightly at 00:00 UTC for recipe validation
@@ -13,8 +14,8 @@ jobs:
   # Ensure no temporary work artifacts are committed
   check-artifacts:
     name: Check Artifacts
-    # Skip on scheduled runs (nightly recipe validation)
-    if: ${{ github.event_name != 'schedule' }}
+    # Skip on scheduled runs and draft PRs (wip/ artifacts are expected during drafts)
+    if: ${{ github.event_name != 'schedule' && github.event.pull_request.draft != true }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2


### PR DESCRIPTION
Skip `check-artifacts` CI job on draft PRs and re-trigger it when a draft PR is marked ready for review. Other CI jobs (tests, linting) continue running on draft PRs for early feedback.

---

## Changes

- Add `types: [opened, synchronize, reopened, ready_for_review]` to the `pull_request` trigger in `test.yml`
- Add `github.event.pull_request.draft != true` to the `check-artifacts` job condition
- For push events, `github.event.pull_request.draft` is null, so `null != true` evaluates to `true` and push-to-main checks still run

## Test plan

- [ ] Draft PR has `check-artifacts` skipped (shown as "skipped" in checks)
- [ ] Other CI jobs (unit-tests, lint, etc.) still run on draft PRs
- [ ] Marking PR as ready triggers `ready_for_review` event and `check-artifacts` runs
- [ ] Push-to-main CI still runs all checks including `check-artifacts`