### PR TITLE
fix(batch): resolve circuit breaker open-state deadlock

### DIFF
--- a/cmd/batch-generate/main.go
+++ b/cmd/batch-generate/main.go
@@ -6,16 +6,37 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/tsukumogami/tsuku/internal/batch"
 )
 
 // batchControlFile represents the structure of batch-control.json, used to
-// extract per-ecosystem circuit breaker state.
+// extract and update per-ecosystem circuit breaker state.
 type batchControlFile struct {
-	CircuitBreaker map[string]struct {
-		State string `json:"state"`
-	} `json:"circuit_breaker"`
+	Enabled            bool                            `json:"enabled"`
+	DisabledEcosystems []string                        `json:"disabled_ecosystems"`
+	Reason             string                          `json:"reason"`
+	IncidentURL        string                          `json:"incident_url"`
+	DisabledBy         string                          `json:"disabled_by"`
+	DisabledAt         string                          `json:"disabled_at"`
+	ExpectedResume     string                          `json:"expected_resume"`
+	CircuitBreaker     map[string]*circuitBreakerEntry `json:"circuit_breaker"`
+	Budget             *budgetEntry                    `json:"budget"`
+}
+
+type circuitBreakerEntry struct {
+	State       string `json:"state"`
+	Failures    int    `json:"failures"`
+	LastFailure string `json:"last_failure"`
+	OpensAt     string `json:"opens_at"`
+}
+
+type budgetEntry struct {
+	MacosMinutesUsed int    `json:"macos_minutes_used"`
+	LinuxMinutesUsed int    `json:"linux_minutes_used"`
+	WeekStart        string `json:"week_start"`
+	SamplingActive   bool   `json:"sampling_active"`
 }
 
 func main() {
@@ -34,13 +55,22 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Read circuit breaker state from batch-control.json.
+	// Read circuit breaker state from batch-control.json. Open breakers past
+	// their recovery timeout are transitioned to half-open so the orchestrator
+	// allows a single probe entry per ecosystem.
 	breakerState := make(map[string]string)
 	if data, err := os.ReadFile(*controlFile); err == nil {
 		var ctrl batchControlFile
 		if err := json.Unmarshal(data, &ctrl); err == nil {
-			for eco, cb := range ctrl.CircuitBreaker {
-				breakerState[eco] = cb.State
+			var modified bool
+			breakerState, modified = transitionOpenBreakers(&ctrl, time.Now().UTC())
+			if modified {
+				if updated, err := json.MarshalIndent(ctrl, "", "  "); err == nil {
+					updated = append(updated, '\n')
+					if err := os.WriteFile(*controlFile, updated, 0644); err != nil {
+						fmt.Fprintf(os.Stderr, "warning: could not update control file: %v\n", err)
+					}
+				}
 			}
 		}
 	}
@@ -76,4 +106,27 @@ func main() {
 	if err := os.WriteFile(summaryPath, []byte(result.Summary()), 0644); err != nil {
 		fmt.Fprintf(os.Stderr, "warning: could not write summary: %v\n", err)
 	}
+}
+
+// transitionOpenBreakers checks each ecosystem's circuit breaker state and
+// transitions open breakers to half-open when their recovery timeout (opens_at)
+// has elapsed. It returns the effective breaker state map for the orchestrator
+// and whether any transitions were made (indicating the control file should be
+// rewritten).
+func transitionOpenBreakers(ctrl *batchControlFile, now time.Time) (map[string]string, bool) {
+	state := make(map[string]string)
+	modified := false
+	for eco, cb := range ctrl.CircuitBreaker {
+		state[eco] = cb.State
+		if cb.State == "open" && cb.OpensAt != "" {
+			opensAt, err := time.Parse("2006-01-02T15:04:05Z", cb.OpensAt)
+			if err == nil && now.After(opensAt) {
+				cb.State = "half-open"
+				state[eco] = "half-open"
+				modified = true
+				fmt.Fprintf(os.Stderr, "Circuit breaker half-open for %s (recovery timeout elapsed)\n", eco)
+			}
+		}
+	}
+	return state, modified
 }

--- a/cmd/batch-generate/main_test.go
+++ b/cmd/batch-generate/main_test.go
@@ -1,0 +1,290 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTransitionOpenBreakers_pastTimeout(t *testing.T) {
+	ctrl := &batchControlFile{
+		CircuitBreaker: map[string]*circuitBreakerEntry{
+			"npm": {
+				State:   "open",
+				OpensAt: "2026-02-19T10:00:00Z",
+			},
+		},
+	}
+
+	now, _ := time.Parse("2006-01-02T15:04:05Z", "2026-02-19T11:00:00Z")
+	state, modified := transitionOpenBreakers(ctrl, now)
+
+	if !modified {
+		t.Fatal("expected modified=true when opens_at has passed")
+	}
+	if state["npm"] != "half-open" {
+		t.Errorf("state[npm] = %q, want %q", state["npm"], "half-open")
+	}
+	if ctrl.CircuitBreaker["npm"].State != "half-open" {
+		t.Errorf("ctrl entry not updated: got %q, want %q", ctrl.CircuitBreaker["npm"].State, "half-open")
+	}
+}
+
+func TestTransitionOpenBreakers_beforeTimeout(t *testing.T) {
+	ctrl := &batchControlFile{
+		CircuitBreaker: map[string]*circuitBreakerEntry{
+			"npm": {
+				State:   "open",
+				OpensAt: "2026-02-19T12:00:00Z",
+			},
+		},
+	}
+
+	now, _ := time.Parse("2006-01-02T15:04:05Z", "2026-02-19T11:00:00Z")
+	state, modified := transitionOpenBreakers(ctrl, now)
+
+	if modified {
+		t.Fatal("expected modified=false when opens_at is in the future")
+	}
+	if state["npm"] != "open" {
+		t.Errorf("state[npm] = %q, want %q", state["npm"], "open")
+	}
+}
+
+func TestTransitionOpenBreakers_closedUnchanged(t *testing.T) {
+	ctrl := &batchControlFile{
+		CircuitBreaker: map[string]*circuitBreakerEntry{
+			"npm": {State: "closed"},
+		},
+	}
+
+	now := time.Now().UTC()
+	state, modified := transitionOpenBreakers(ctrl, now)
+
+	if modified {
+		t.Fatal("expected modified=false for closed breaker")
+	}
+	if state["npm"] != "closed" {
+		t.Errorf("state[npm] = %q, want %q", state["npm"], "closed")
+	}
+}
+
+func TestTransitionOpenBreakers_halfOpenUnchanged(t *testing.T) {
+	ctrl := &batchControlFile{
+		CircuitBreaker: map[string]*circuitBreakerEntry{
+			"npm": {State: "half-open"},
+		},
+	}
+
+	now := time.Now().UTC()
+	state, modified := transitionOpenBreakers(ctrl, now)
+
+	if modified {
+		t.Fatal("expected modified=false for half-open breaker")
+	}
+	if state["npm"] != "half-open" {
+		t.Errorf("state[npm] = %q, want %q", state["npm"], "half-open")
+	}
+}
+
+func TestTransitionOpenBreakers_emptyOpensAt(t *testing.T) {
+	ctrl := &batchControlFile{
+		CircuitBreaker: map[string]*circuitBreakerEntry{
+			"npm": {
+				State:   "open",
+				OpensAt: "",
+			},
+		},
+	}
+
+	now := time.Now().UTC()
+	state, modified := transitionOpenBreakers(ctrl, now)
+
+	if modified {
+		t.Fatal("expected modified=false when opens_at is empty")
+	}
+	if state["npm"] != "open" {
+		t.Errorf("state[npm] = %q, want %q", state["npm"], "open")
+	}
+}
+
+func TestTransitionOpenBreakers_multipleEcosystems(t *testing.T) {
+	ctrl := &batchControlFile{
+		CircuitBreaker: map[string]*circuitBreakerEntry{
+			"homebrew": {
+				State:   "open",
+				OpensAt: "2026-02-19T08:00:00Z",
+			},
+			"npm": {
+				State: "closed",
+			},
+			"pypi": {
+				State:   "open",
+				OpensAt: "2026-02-20T12:00:00Z",
+			},
+		},
+	}
+
+	now, _ := time.Parse("2006-01-02T15:04:05Z", "2026-02-19T10:00:00Z")
+	state, modified := transitionOpenBreakers(ctrl, now)
+
+	if !modified {
+		t.Fatal("expected modified=true (homebrew should transition)")
+	}
+	if state["homebrew"] != "half-open" {
+		t.Errorf("homebrew = %q, want %q", state["homebrew"], "half-open")
+	}
+	if state["npm"] != "closed" {
+		t.Errorf("npm = %q, want %q", state["npm"], "closed")
+	}
+	if state["pypi"] != "open" {
+		t.Errorf("pypi = %q, want %q (opens_at in the future)", state["pypi"], "open")
+	}
+}
+
+func TestTransitionOpenBreakers_jsonRoundTrip(t *testing.T) {
+	input := `{
+  "enabled": true,
+  "disabled_ecosystems": [],
+  "reason": "",
+  "incident_url": "",
+  "disabled_by": "",
+  "disabled_at": "",
+  "expected_resume": "",
+  "circuit_breaker": {
+    "homebrew": {
+      "state": "open",
+      "failures": 5,
+      "last_failure": "2026-02-19T07:07:22Z",
+      "opens_at": "2026-02-19T08:07:22Z"
+    },
+    "npm": {
+      "state": "closed",
+      "failures": 0,
+      "last_failure": "",
+      "opens_at": ""
+    }
+  },
+  "budget": {
+    "macos_minutes_used": 0,
+    "linux_minutes_used": 0,
+    "week_start": "",
+    "sampling_active": false
+  }
+}
+`
+	var ctrl batchControlFile
+	if err := json.Unmarshal([]byte(input), &ctrl); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	now, _ := time.Parse("2006-01-02T15:04:05Z", "2026-02-19T10:00:00Z")
+	state, modified := transitionOpenBreakers(&ctrl, now)
+
+	if !modified {
+		t.Fatal("expected modified=true")
+	}
+	if state["homebrew"] != "half-open" {
+		t.Errorf("homebrew = %q, want half-open", state["homebrew"])
+	}
+
+	// Verify the JSON round-trip preserves structure.
+	output, err := json.MarshalIndent(ctrl, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	outputStr := string(output)
+
+	if !strings.Contains(outputStr, `"state": "half-open"`) {
+		t.Error("marshaled output missing half-open state for homebrew")
+	}
+	if !strings.Contains(outputStr, `"enabled": true`) {
+		t.Error("marshaled output missing top-level enabled field")
+	}
+	if !strings.Contains(outputStr, `"macos_minutes_used": 0`) {
+		t.Error("marshaled output missing budget fields")
+	}
+}
+
+func TestTransitionOpenBreakers_writesFile(t *testing.T) {
+	dir := t.TempDir()
+	controlPath := filepath.Join(dir, "batch-control.json")
+	input := `{
+  "enabled": true,
+  "disabled_ecosystems": [],
+  "reason": "",
+  "incident_url": "",
+  "disabled_by": "",
+  "disabled_at": "",
+  "expected_resume": "",
+  "circuit_breaker": {
+    "npm": {
+      "state": "open",
+      "failures": 5,
+      "last_failure": "2026-02-19T07:00:00Z",
+      "opens_at": "2026-02-19T08:00:00Z"
+    }
+  },
+  "budget": {
+    "macos_minutes_used": 0,
+    "linux_minutes_used": 0,
+    "week_start": "",
+    "sampling_active": false
+  }
+}
+`
+	if err := os.WriteFile(controlPath, []byte(input), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Simulate what main() does: read, transition, write back.
+	data, err := os.ReadFile(controlPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var ctrl batchControlFile
+	if err := json.Unmarshal(data, &ctrl); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	now, _ := time.Parse("2006-01-02T15:04:05Z", "2026-02-19T10:00:00Z")
+	state, modified := transitionOpenBreakers(&ctrl, now)
+
+	if !modified {
+		t.Fatal("expected modified=true")
+	}
+	if state["npm"] != "half-open" {
+		t.Fatalf("npm = %q, want half-open", state["npm"])
+	}
+
+	updated, err := json.MarshalIndent(ctrl, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	updated = append(updated, '\n')
+	if err := os.WriteFile(controlPath, updated, 0644); err != nil {
+		t.Fatalf("write back: %v", err)
+	}
+
+	// Re-read and verify the file has the updated state.
+	data2, err := os.ReadFile(controlPath)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	var ctrl2 batchControlFile
+	if err := json.Unmarshal(data2, &ctrl2); err != nil {
+		t.Fatalf("re-unmarshal: %v", err)
+	}
+	if ctrl2.CircuitBreaker["npm"].State != "half-open" {
+		t.Errorf("file state = %q, want half-open", ctrl2.CircuitBreaker["npm"].State)
+	}
+	if ctrl2.CircuitBreaker["npm"].Failures != 5 {
+		t.Errorf("failures = %d, want 5 (should be preserved)", ctrl2.CircuitBreaker["npm"].Failures)
+	}
+	if !ctrl2.Enabled {
+		t.Error("enabled should be preserved as true")
+	}
+}


### PR DESCRIPTION
The batch-generate orchestrator reads circuit breaker state from
batch-control.json but only parses the `state` field, not `opens_at`.
When a breaker is "open", the orchestrator skips all entries for that
ecosystem. Since skipped ecosystems produce no results, `update_breaker.sh`
is never called for them in the merge job, so the breaker stays open
permanently. All 6 ecosystems are currently stuck in this state.

`transitionOpenBreakers()` in cmd/batch-generate/main.go now checks
`opens_at` for open breakers and transitions them to half-open when
the recovery timeout has elapsed. This runs at startup before candidate
selection and writes the updated state back to batch-control.json so
the downstream `update_breaker.sh` call sees the correct half-open state.

The `batchControlFile` struct is expanded to parse the full control file
schema (including `opens_at`, `failures`, budget fields) so JSON
round-trips preserve the file structure.

---

## Root cause

`selectCandidates()` in `internal/batch/orchestrator.go` hard-skips entries
where `BreakerState[eco] == "open"`. The `batchControlFile` struct in
`cmd/batch-generate/main.go` only parsed the `state` field and never
checked `opens_at`, so open breakers could never transition to half-open.

The `batch-operations.yml` workflow was supposed to handle this via
`check_breaker.sh`, but it passes `matrix.ecosystem || 'default'` with
no matrix defined, so it operates on a phantom "default" ecosystem.

## Test plan

- 8 unit tests covering: past timeout, before timeout, closed/half-open
  unchanged, empty opens_at, multiple ecosystems with mixed states, JSON
  round-trip preservation, and file write-back verification
- `go vet ./...` clean
- `go test ./...` passes (pre-existing failure in `internal/builders`
  unrelated to this change)