### PR TITLE
fix(batch): transition breakers in merge job before updating outcomes

### DIFF
--- a/.github/workflows/batch-generate.yml
+++ b/.github/workflows/batch-generate.yml
@@ -977,6 +977,16 @@ jobs:
             exit 0
           fi
 
+          # Transition open breakers to half-open before updating outcomes.
+          # The generate job does this on its runner, but the merge job has a
+          # fresh checkout so the file still says "open". check_breaker.sh
+          # transitions open -> half-open when opens_at has passed, which lets
+          # update_breaker.sh correctly handle the half-open + failure -> open
+          # (with fresh timeout) transition.
+          for eco in $(jq -r '.per_ecosystem | keys[]' "$RESULTS_FILE" 2>/dev/null); do
+            ./scripts/check_breaker.sh "$eco"
+          done
+
           # Iterate over each ecosystem in per_ecosystem breakdown
           for eco in $(jq -r '.per_ecosystem | keys[]' "$RESULTS_FILE" 2>/dev/null); do
             FAILED=$(jq -r --arg e "$eco" '.per_ecosystem[$e].failed // 0' "$RESULTS_FILE")


### PR DESCRIPTION
The generate and merge jobs in batch-generate.yml run on separate GitHub
Actions runners. The generate job (from #1798) now transitions open
breakers to half-open in its local batch-control.json, but the merge job
checks out a fresh copy of main where the state is still "open". When
update_breaker.sh sees state="open" with outcome="failure", it hits the
unexpected-state warning path and does nothing -- the breaker never gets
a fresh recovery timeout.

This adds check_breaker.sh calls for each participating ecosystem in the
merge job before calling update_breaker.sh. This transitions open ->
half-open in the merge job's copy of the file so update_breaker.sh
correctly handles the half-open + failure -> open (with fresh timeout)
path.

---

## Context

Follow-up to #1798 which fixed the generate job side. The manual dispatch
run confirmed all 6 ecosystems correctly transitioned to half-open and
got probe candidates, but the merge job logged `update_breaker called for
<eco> in open state (unexpected)` for all 6 because of the separate
runner issue.

## Test plan

- Verified by inspecting logs from manual dispatch run 22246725556
- check_breaker.sh already has the transition logic; this just calls it
  at the right point in the merge job