### PR TITLE
ci(deploy): add workflow_dispatch trigger to deploy-website

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,6 +1,7 @@
 name: Deploy Website
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Add `workflow_dispatch` trigger to `deploy-website.yml` so the website
can be deployed manually when automated triggers are skipped (e.g. when
upstream workflows like coverage-update commit with `[skip ci]`).

---

## What This Fixes

The coverage update workflow commits regenerated `coverage.json` with
`[skip ci]` to avoid infinite loops, which also prevents the deploy
workflow from running. Without `workflow_dispatch`, there's no way to
trigger a deploy until the next unrelated push to main touches a
`website/**` path.