### PR TITLE
fix(recipes): use HTTPS for ansifilter homepage URL

### DIFF
--- a/recipes/a/ansifilter.toml
+++ b/recipes/a/ansifilter.toml
@@ -1,7 +1,7 @@
 [metadata]
   name = "ansifilter"
   description = "Strip or convert ANSI codes into HTML, (La)Tex, RTF, or BBCode"
-  homepage = "http://andre-simon.de/doku/ansifilter/en/ansifilter.php"
+  homepage = "https://andre-simon.de/doku/ansifilter/en/ansifilter.php"
   version_format = ""
   requires_sudo = false
   tier = 0


### PR DESCRIPTION
The ansifilter recipe homepage URL used HTTP, which fails the registry
validation in generate-registry.py (requires https:// prefix). The site
supports HTTPS, so this updates the URL accordingly.

This unblocks the deploy-website workflow which was failing on the
recipes.json generation step.

---

One-line fix: `http://` to `https://` in ansifilter.toml homepage field.