### PR TITLE
ci: re-trigger tests when PR is converted to draft

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     branches: [main]
   schedule:
     # Run nightly at 00:00 UTC for recipe validation


### PR DESCRIPTION
The check-artifacts job skips draft PRs, but the workflow only triggered
on `ready_for_review` (draft to ready), not `converted_to_draft` (ready
to draft). A failing check-artifacts result stayed red after converting
to draft because the workflow never re-ran. Adding `converted_to_draft`
to the trigger types re-runs the workflow so the check gets skipped and
clears.