### PR TITLE
fix(create): only block on satisfies matches, not exact name matches

### DIFF
--- a/cmd/tsuku/create.go
+++ b/cmd/tsuku/create.go
@@ -478,18 +478,14 @@ func checkExistingRecipe(l *recipe.Loader, toolName string) (string, bool) {
 func runCreate(cmd *cobra.Command, args []string) {
 	toolName := args[0]
 
-	// Check for existing recipe before any builder work, API calls, or
-	// toolchain checks. The loader covers all tiers (cache, local,
-	// embedded, registry) plus the satisfies fallback, so ecosystem
-	// aliases like "openssl@3" are caught here too.
+	// Check whether a different recipe already covers this tool name via
+	// its satisfies metadata. Only block when the canonical name differs
+	// (e.g., "openssl@3" → "openssl"). Exact name matches are allowed
+	// so that `tsuku create <tool>` can regenerate an existing recipe.
 	if !createForce {
-		if canonicalName, found := checkExistingRecipe(loader, toolName); found {
-			if canonicalName == toolName {
-				fmt.Fprintf(os.Stderr, "Error: recipe '%s' already exists. Use --force to create anyway.\n", toolName)
-			} else {
-				fmt.Fprintf(os.Stderr, "Error: recipe '%s' already satisfies '%s'. Use --force to create anyway.\n",
-					canonicalName, toolName)
-			}
+		if canonicalName, found := checkExistingRecipe(loader, toolName); found && canonicalName != toolName {
+			fmt.Fprintf(os.Stderr, "Error: recipe '%s' already satisfies '%s'. Use --force to create anyway.\n",
+				canonicalName, toolName)
 			exitWithCode(ExitGeneral)
 		}
 	}


### PR DESCRIPTION
The ecosystem name resolution feature (#1824) introduced a pre-creation check
that blocked `tsuku create` when any existing recipe matched the requested name.
This was too aggressive: it prevented `tsuku create <tool>` from regenerating
an existing recipe, which is valid and expected behavior.

Now the check only blocks when a *different* recipe covers the requested name
via `satisfies` metadata (e.g., `tsuku create openssl@3` is blocked because
the `openssl` recipe already satisfies that name). Exact name matches proceed
as before.

---

Fixes the functional test failures introduced by #1824:
- `tsuku create prettier --from npm` no longer blocked
- `tsuku create jekyll --from gem` no longer blocked
- `tsuku create ruff --from pypi` no longer blocked

Satisfies matches still work:
- `tsuku create openssl@3` correctly blocked ("recipe 'openssl' already satisfies 'openssl@3'")