### PR TITLE
fix(dashboard): tighten verify subcategory pattern to avoid false positives

### DIFF
--- a/internal/dashboard/failures.go
+++ b/internal/dashboard/failures.go
@@ -72,7 +72,7 @@ func extractSubcategory(category, message string, exitCode int) string {
 		return "no_bottle"
 	case strings.Contains(msg, "no executables") || strings.Contains(msg, "no binaries"):
 		return "binary_discovery_failed"
-	case strings.Contains(msg, "version pattern") || strings.Contains(msg, "verify"):
+	case strings.Contains(msg, "version pattern") || strings.Contains(msg, "failed to verify") || strings.Contains(msg, "verification"):
 		return "verify_pattern_mismatch"
 	case strings.Contains(msg, "already exists") || strings.Contains(msg, "use --force"):
 		return "recipe_already_exists"

--- a/internal/dashboard/failures_test.go
+++ b/internal/dashboard/failures_test.go
@@ -97,8 +97,13 @@ func TestExtractSubcategory_regexPatterns(t *testing.T) {
 			want:    "verify_pattern_mismatch",
 		},
 		{
-			name:    "verify keyword",
+			name:    "failed to verify",
 			message: "failed to verify installation output",
+			want:    "verify_pattern_mismatch",
+		},
+		{
+			name:    "verification failed",
+			message: "verification failed: checksum does not match",
 			want:    "verify_pattern_mismatch",
 		},
 		{
@@ -140,6 +145,11 @@ func TestExtractSubcategory_regexPatterns(t *testing.T) {
 			name:    "deadline",
 			message: "context deadline exceeded",
 			want:    "timeout",
+		},
+		{
+			name:    "recipe not found with verify suggestion",
+			message: "Error: registry: recipe berkeley-db@5 not found in registry\n\nSuggestion: Verify the recipe name is correct.",
+			want:    "",
 		},
 		{
 			name:    "no match",


### PR DESCRIPTION
Narrow the "verify" substring match in `extractSubcategory` from bare
`"verify"` to `"failed to verify"` and `"verification"`. The old pattern
was too broad: `recipe_not_found` errors whose message included the
suggestion text "Verify the recipe name is correct" were miscategorized
with subcategory `verify_pattern_mismatch`.

---

## What This Fixes

The subcategory regex (Level 2) in `extractSubcategory` matched any
message containing "verify", including the suggestion text appended to
`recipe_not_found` errors. For example, `berkeley-db@5` showed
`category: recipe_not_found` (correct) but `subcategory:
verify_pattern_mismatch` (wrong).

The tightened patterns still match actual verification failures like
`"failed to verify installation output"` and `"verification failed:
checksum does not match"`.

## Test Plan

- [x] Existing tests pass with updated pattern
- [x] Regression test added for `recipe_not_found` with "Verify" suggestion text