### PR TITLE
feat(recipe): add koto recipe

### DIFF
--- a/recipes/k/koto.toml
+++ b/recipes/k/koto.toml
@@ -1,0 +1,15 @@
+[metadata]
+name = "koto"
+description = "Workflow orchestration engine for AI agents"
+homepage = "https://github.com/tsukumogami/koto"
+version_format = "semver"
+
+[[steps]]
+action = "github_file"
+repo = "tsukumogami/koto"
+asset_pattern = "koto-{os}-{arch}"
+binary = "koto"
+
+[verify]
+command = "koto version"
+pattern = "{version}"


### PR DESCRIPTION
Add koto recipe using github_file action for raw binary download.
Validates koto's GitHub release assets as a distribution source.

---

Recipe for the koto workflow orchestration engine. Uses github_file
action since GoReleaser produces raw binaries (format: binary).

Ref tsukumogami/koto#28