### PR TITLE
feat(recipes): add glib-dependent libraries and tools

### DIFF
--- a/recipes/a/aarch64-elf-gdb.toml
+++ b/recipes/a/aarch64-elf-gdb.toml
@@ -1,0 +1,44 @@
+[metadata]
+  name = "aarch64-elf-gdb"
+  description = "GNU debugger for aarch64-elf cross development"
+  homepage = "https://www.gnu.org/software/gdb/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = [
+    "gmp",
+    "mpfr",
+    "ncurses",
+    "readline",
+    "xz",
+    "zstd",
+  ]
+  # macOS: blocked by rpath issue (https://github.com/tsukumogami/tsuku/issues/1965)
+  unsupported_platforms = ["darwin/arm64", "darwin/amd64"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "aarch64-elf-gdb"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "aarch64-elf-gdb"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/aarch64-elf-gdb", "bin/aarch64-elf-gdb-add-index", "bin/aarch64-elf-gstack"]
+
+[verify]
+  command = "aarch64-elf-gdb --version"
+  pattern = ""

--- a/recipes/a/aerc.toml
+++ b/recipes/a/aerc.toml
@@ -1,0 +1,37 @@
+[metadata]
+  name = "aerc"
+  description = "Email client that runs in your terminal"
+  homepage = "https://aerc-mail.org/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["notmuch"]
+  # macOS: blocked by rpath issue (https://github.com/tsukumogami/tsuku/issues/1965)
+  unsupported_platforms = ["darwin/arm64", "darwin/amd64"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "aerc"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "aerc"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/aerc", "bin/carddav-query"]
+
+[verify]
+  command = "aerc --version"
+  pattern = ""

--- a/recipes/a/arm-none-eabi-gdb.toml
+++ b/recipes/a/arm-none-eabi-gdb.toml
@@ -1,0 +1,44 @@
+[metadata]
+  name = "arm-none-eabi-gdb"
+  description = "GNU debugger for arm-none-eabi cross development"
+  homepage = "https://www.gnu.org/software/gdb/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = [
+    "gmp",
+    "mpfr",
+    "ncurses",
+    "readline",
+    "xz",
+    "zstd",
+  ]
+  # macOS: blocked by rpath issue (https://github.com/tsukumogami/tsuku/issues/1965)
+  unsupported_platforms = ["darwin/arm64", "darwin/amd64"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "arm-none-eabi-gdb"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "arm-none-eabi-gdb"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/arm-none-eabi-gdb", "bin/arm-none-eabi-gdb-add-index", "bin/arm-none-eabi-gstack"]
+
+[verify]
+  command = "arm-none-eabi-gdb --version"
+  pattern = ""

--- a/recipes/d/dissent.toml
+++ b/recipes/d/dissent.toml
@@ -1,0 +1,42 @@
+[metadata]
+  name = "dissent"
+  description = "GTK4 Discord client in Go"
+  homepage = "https://github.com/diamondburned/dissent"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = [
+    "cairo",
+    "gettext",
+    "glib",
+    "graphene",
+  ]
+  # macOS: blocked by rpath issue (https://github.com/tsukumogami/tsuku/issues/1965)
+  unsupported_platforms = ["darwin/arm64", "darwin/amd64"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "dissent"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "dissent"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/dissent"]
+
+[verify]
+  command = "dissent --version"
+  pattern = ""

--- a/recipes/g/graphene.toml
+++ b/recipes/g/graphene.toml
@@ -1,0 +1,51 @@
+[metadata]
+  name = "graphene"
+  description = "Thin layer of graphic data types"
+  homepage = "https://ebassi.github.io/graphene/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["glib", "gettext"]
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "graphene"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "graphene"
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libgraphene-1.0.so", "lib/libgraphene-1.0.so.0", "lib/libgraphene-1.0.so.0.1000.8", "lib/pkgconfig/graphene-1.0.pc", "lib/pkgconfig/graphene-gobject-1.0.pc", "include/graphene-1.0/graphene-box.h", "include/graphene-1.0/graphene-euler.h", "include/graphene-1.0/graphene-frustum.h", "include/graphene-1.0/graphene-gobject.h", "include/graphene-1.0/graphene-macros.h", "include/graphene-1.0/graphene-matrix.h", "include/graphene-1.0/graphene-plane.h", "include/graphene-1.0/graphene-point.h", "include/graphene-1.0/graphene-point3d.h", "include/graphene-1.0/graphene-quad.h", "include/graphene-1.0/graphene-quaternion.h", "include/graphene-1.0/graphene-ray.h", "include/graphene-1.0/graphene-rect.h", "include/graphene-1.0/graphene-simd4f.h", "include/graphene-1.0/graphene-simd4x4f.h", "include/graphene-1.0/graphene-size.h", "include/graphene-1.0/graphene-sphere.h", "include/graphene-1.0/graphene-triangle.h", "include/graphene-1.0/graphene-types.h", "include/graphene-1.0/graphene-vec2.h", "include/graphene-1.0/graphene-vec3.h", "include/graphene-1.0/graphene-vec4.h", "include/graphene-1.0/graphene-version-macros.h", "include/graphene-1.0/graphene-version.h", "include/graphene-1.0/graphene.h"]
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "homebrew"
+  formula = "graphene"
+  [steps.when]
+    os = ["darwin"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libgraphene-1.0.0.dylib", "lib/libgraphene-1.0.dylib", "lib/pkgconfig/graphene-1.0.pc", "lib/pkgconfig/graphene-gobject-1.0.pc", "include/graphene-1.0/graphene-box.h", "include/graphene-1.0/graphene-euler.h", "include/graphene-1.0/graphene-frustum.h", "include/graphene-1.0/graphene-gobject.h", "include/graphene-1.0/graphene-macros.h", "include/graphene-1.0/graphene-matrix.h", "include/graphene-1.0/graphene-plane.h", "include/graphene-1.0/graphene-point.h", "include/graphene-1.0/graphene-point3d.h", "include/graphene-1.0/graphene-quad.h", "include/graphene-1.0/graphene-quaternion.h", "include/graphene-1.0/graphene-ray.h", "include/graphene-1.0/graphene-rect.h", "include/graphene-1.0/graphene-simd4f.h", "include/graphene-1.0/graphene-simd4x4f.h", "include/graphene-1.0/graphene-size.h", "include/graphene-1.0/graphene-sphere.h", "include/graphene-1.0/graphene-triangle.h", "include/graphene-1.0/graphene-types.h", "include/graphene-1.0/graphene-vec2.h", "include/graphene-1.0/graphene-vec3.h", "include/graphene-1.0/graphene-vec4.h", "include/graphene-1.0/graphene-version-macros.h", "include/graphene-1.0/graphene-version.h", "include/graphene-1.0/graphene.h"]
+  [steps.when]
+    os = ["darwin"]

--- a/recipes/l/libgee.toml
+++ b/recipes/l/libgee.toml
@@ -1,0 +1,51 @@
+[metadata]
+  name = "libgee"
+  description = "Collection library providing GObject-based interfaces"
+  homepage = "https://wiki.gnome.org/Projects/Libgee"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["glib", "gettext"]
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "libgee"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "libgee"
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libgee-0.8.so", "lib/libgee-0.8.so.2", "lib/libgee-0.8.so.2.6.1", "lib/pkgconfig/gee-0.8.pc", "include/gee-0.8/gee.h"]
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "homebrew"
+  formula = "libgee"
+  [steps.when]
+    os = ["darwin"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libgee-0.8.2.dylib", "lib/libgee-0.8.dylib", "lib/pkgconfig/gee-0.8.pc", "include/gee-0.8/gee.h"]
+  [steps.when]
+    os = ["darwin"]

--- a/recipes/l/libidn2.toml
+++ b/recipes/l/libidn2.toml
@@ -1,0 +1,49 @@
+[metadata]
+name = "libidn2"
+description = "International domain name library (IDNA2008, Punycode and TR46)"
+homepage = "https://www.gnu.org/software/libidn/#libidn2"
+type = "library"
+dependencies = ["gettext"]
+
+[metadata.satisfies]
+homebrew = ["libidn2"]
+
+# glibc Linux: Homebrew bottle
+[[steps]]
+action = "homebrew"
+formula = "libidn2"
+when = { os = ["linux"], libc = ["glibc"] }
+
+[[steps]]
+action = "install_binaries"
+install_mode = "directory"
+outputs = [
+    "lib/libidn2.so",
+    "lib/libidn2.a",
+    "lib/pkgconfig/libidn2.pc",
+    "include/idn2.h",
+]
+when = { os = ["linux"], libc = ["glibc"] }
+
+# musl Linux: Alpine package
+[[steps]]
+action = "apk_install"
+packages = ["libidn2-dev"]
+when = { os = ["linux"], libc = ["musl"] }
+
+# macOS: Homebrew
+[[steps]]
+action = "homebrew"
+formula = "libidn2"
+when = { os = ["darwin"] }
+
+[[steps]]
+action = "install_binaries"
+install_mode = "directory"
+outputs = [
+    "lib/libidn2.dylib",
+    "lib/libidn2.a",
+    "lib/pkgconfig/libidn2.pc",
+    "include/idn2.h",
+]
+when = { os = ["darwin"] }

--- a/recipes/m/mpfr.toml
+++ b/recipes/m/mpfr.toml
@@ -1,0 +1,51 @@
+[metadata]
+  name = "mpfr"
+  description = "C library for multiple-precision floating-point computations"
+  homepage = "https://www.mpfr.org/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["gmp"]
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "mpfr"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "mpfr"
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libmpfr.a", "lib/libmpfr.so", "lib/libmpfr.so.6", "lib/libmpfr.so.6.2.2", "lib/pkgconfig/mpfr.pc", "include/mpf2mpfr.h", "include/mpfr.h"]
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "homebrew"
+  formula = "mpfr"
+  [steps.when]
+    os = ["darwin"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libmpfr.6.dylib", "lib/libmpfr.a", "lib/libmpfr.dylib", "lib/pkgconfig/mpfr.pc", "include/mpf2mpfr.h", "include/mpfr.h"]
+  [steps.when]
+    os = ["darwin"]

--- a/recipes/n/notmuch-mutt.toml
+++ b/recipes/n/notmuch-mutt.toml
@@ -1,0 +1,37 @@
+[metadata]
+  name = "notmuch-mutt"
+  description = "Notmuch integration for Mutt"
+  homepage = "https://notmuchmail.org/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["notmuch", "readline"]
+  # macOS: blocked by rpath issue (https://github.com/tsukumogami/tsuku/issues/1965)
+  unsupported_platforms = ["darwin/arm64", "darwin/amd64"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "notmuch-mutt"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "notmuch-mutt"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/notmuch-mutt"]
+
+[verify]
+  command = "notmuch-mutt --version"
+  pattern = ""

--- a/recipes/n/notmuch.toml
+++ b/recipes/n/notmuch.toml
@@ -1,0 +1,47 @@
+[metadata]
+name = "notmuch"
+description = "Thread-based email index, search, and tagging"
+homepage = "https://notmuchmail.org/"
+type = "library"
+dependencies = ["glib", "gettext"]
+
+[metadata.satisfies]
+homebrew = ["notmuch"]
+
+# glibc Linux: Homebrew bottle
+[[steps]]
+action = "homebrew"
+formula = "notmuch"
+when = { os = ["linux"], libc = ["glibc"] }
+
+[[steps]]
+action = "install_binaries"
+install_mode = "directory"
+outputs = [
+    "lib/libnotmuch.so",
+    "lib/libnotmuch.a",
+    "include/notmuch.h",
+]
+when = { os = ["linux"], libc = ["glibc"] }
+
+# musl Linux: Alpine package
+[[steps]]
+action = "apk_install"
+packages = ["notmuch-dev"]
+when = { os = ["linux"], libc = ["musl"] }
+
+# macOS: Homebrew
+[[steps]]
+action = "homebrew"
+formula = "notmuch"
+when = { os = ["darwin"] }
+
+[[steps]]
+action = "install_binaries"
+install_mode = "directory"
+outputs = [
+    "lib/libnotmuch.dylib",
+    "lib/libnotmuch.a",
+    "include/notmuch.h",
+]
+when = { os = ["darwin"] }


### PR DESCRIPTION
Add 10 homebrew recipes: 5 libraries (mpfr, libidn2, graphene, notmuch,
libgee) and 5 tools that depend on them (aarch64-elf-gdb, aerc,
arm-none-eabi-gdb, dissent, notmuch-mutt).

graphene, notmuch, and libgee depend on glib (landed in PR #1979).
Tools exclude macOS via unsupported_platforms due to the rpath issue.

---

## What This Enables

Lands the glib-dependent libraries (graphene, notmuch, libgee) which
unblock their own tool dependents in future PRs. mpfr unblocks GDB
cross-compilation tools.

## Test Plan

- [x] Local sandbox validation: all 10 recipes pass across 4 Linux families (debian, rhel, alpine, suse)
- [ ] CI validation via test-recipe workflow