### PR TITLE
feat(recipe): add 30 homebrew recipes (15 libs + 15 tools)

### DIFF
--- a/recipes/a/abook.toml
+++ b/recipes/a/abook.toml
@@ -1,0 +1,35 @@
+[metadata]
+  name = "abook"
+  description = "Address book with mutt support"
+  homepage = "https://abook.sourceforge.io/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["readline", "gettext"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = ""
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = ""
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "abook"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/abook"]
+
+[verify]
+  command = "abook --version"
+  pattern = ""

--- a/recipes/c/clang-uml.toml
+++ b/recipes/c/clang-uml.toml
@@ -1,0 +1,35 @@
+[metadata]
+  name = "clang-uml"
+  description = "Customizable automatic UML diagram generator for C++ based on Clang"
+  homepage = "https://github.com/bkryza/clang-uml"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+  runtime_dependencies = ["yaml-cpp"]
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "clang-uml"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "clang-uml"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/clang-uml"]
+
+[verify]
+  command = "clang-uml --version"
+  pattern = ""

--- a/recipes/c/clifm.toml
+++ b/recipes/c/clifm.toml
@@ -1,0 +1,35 @@
+[metadata]
+  name = "clifm"
+  description = "Command-line Interface File Manager"
+  homepage = "https://github.com/leo-arch/clifm"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["gettext", "libmagic", "readline"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "clifm"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "clifm"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/clifm"]
+
+[verify]
+  command = "clifm --version"
+  pattern = ""

--- a/recipes/f/file-formula.toml
+++ b/recipes/f/file-formula.toml
@@ -1,0 +1,35 @@
+[metadata]
+  name = "file-formula"
+  description = "Utility to determine file types"
+  homepage = "https://darwinsys.com/file/"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+  runtime_dependencies = ["libmagic"]
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "file-formula"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "file-formula"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/file"]
+
+[verify]
+  command = "file --version"
+  pattern = ""

--- a/recipes/f/freeciv.toml
+++ b/recipes/f/freeciv.toml
@@ -1,0 +1,35 @@
+[metadata]
+  name = "freeciv"
+  description = "Free and Open Source empire-building strategy game"
+  homepage = "https://freeciv.org/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["cairo", "freetype", "gettext", "glib", "readline", "sdl2", "sqlite", "zstd"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "freeciv"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "freeciv"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/freeciv-gtk3.22", "bin/freeciv-manual", "bin/freeciv-mp-gtk3", "bin/freeciv-ruleup", "bin/freeciv-server"]
+
+[verify]
+  command = "freeciv-gtk3.22 --version"
+  pattern = ""

--- a/recipes/g/glfw.toml
+++ b/recipes/g/glfw.toml
@@ -1,0 +1,50 @@
+[metadata]
+  name = "glfw"
+  description = "Multi-platform library for OpenGL applications"
+  homepage = "https://www.glfw.org/"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "glfw"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "glfw"
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libglfw.so", "lib/libglfw.so.3", "lib/libglfw.so.3.4", "lib/pkgconfig/glfw3.pc", "include/GLFW/glfw3.h", "include/GLFW/glfw3native.h"]
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "homebrew"
+  formula = "glfw"
+  [steps.when]
+    os = ["darwin"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libglfw.3.4.dylib", "lib/libglfw.3.dylib", "lib/libglfw.dylib", "lib/pkgconfig/glfw3.pc", "include/GLFW/glfw3.h", "include/GLFW/glfw3native.h"]
+  [steps.when]
+    os = ["darwin"]

--- a/recipes/g/gnu-apl.toml
+++ b/recipes/g/gnu-apl.toml
@@ -1,0 +1,35 @@
+[metadata]
+  name = "gnu-apl"
+  description = "GNU implementation of the programming language APL"
+  homepage = "https://www.gnu.org/software/apl/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["cairo", "glib", "libpng", "pcre2", "readline", "sqlite", "gettext"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "gnu-apl"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "gnu-apl"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/AP100", "bin/AP210", "bin/APserver", "bin/Gtk_server", "bin/apl"]
+
+[verify]
+  command = "AP100 --version"
+  pattern = ""

--- a/recipes/g/gnu-units.toml
+++ b/recipes/g/gnu-units.toml
@@ -1,0 +1,35 @@
+[metadata]
+  name = "gnu-units"
+  description = "GNU unit conversion tool"
+  homepage = "https://www.gnu.org/software/units/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["readline"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "gnu-units"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "gnu-units"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/units"]
+
+[verify]
+  command = "units --version"
+  pattern = ""

--- a/recipes/g/gptfdisk.toml
+++ b/recipes/g/gptfdisk.toml
@@ -1,0 +1,35 @@
+[metadata]
+  name = "gptfdisk"
+  description = "Text-mode partitioning tools"
+  homepage = "https://www.rodsbooks.com/gdisk/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["popt"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "gptfdisk"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "gptfdisk"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/cgdisk", "bin/fixparts", "bin/gdisk", "bin/sgdisk"]
+
+[verify]
+  command = "cgdisk --version"
+  pattern = ""

--- a/recipes/i/i386-elf-gdb.toml
+++ b/recipes/i/i386-elf-gdb.toml
@@ -1,0 +1,42 @@
+[metadata]
+  name = "i386-elf-gdb"
+  description = "GNU debugger for i386-elf cross development"
+  homepage = "https://www.gnu.org/software/gdb/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = [
+    "gmp",
+    "mpfr",
+    "ncurses",
+    "readline",
+    "xz",
+    "zstd",
+  ]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "i386-elf-gdb"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "i386-elf-gdb"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/i386-elf-gdb", "bin/i386-elf-gdb-add-index", "bin/i386-elf-gstack"]
+
+[verify]
+  command = "i386-elf-gdb --version"
+  pattern = ""

--- a/recipes/i/imath.toml
+++ b/recipes/i/imath.toml
@@ -1,0 +1,50 @@
+[metadata]
+  name = "imath"
+  description = "Library of 2D and 3D vector, matrix, and math operations"
+  homepage = "https://imath.readthedocs.io/en/latest/"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "imath"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "imath"
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libImath-3_2.so", "lib/libImath-3_2.so.30", "lib/libImath-3_2.so.30.3.2.2", "lib/libImath.so", "lib/pkgconfig/Imath.pc", "include/Imath/ImathBox.h", "include/Imath/ImathBoxAlgo.h", "include/Imath/ImathColor.h", "include/Imath/ImathColorAlgo.h", "include/Imath/ImathConfig.h", "include/Imath/ImathEuler.h", "include/Imath/ImathExport.h", "include/Imath/ImathForward.h", "include/Imath/ImathFrame.h", "include/Imath/ImathFrustum.h", "include/Imath/ImathFrustumTest.h", "include/Imath/ImathFun.h", "include/Imath/ImathGL.h", "include/Imath/ImathGLU.h", "include/Imath/ImathInt64.h", "include/Imath/ImathInterval.h", "include/Imath/ImathLine.h", "include/Imath/ImathLineAlgo.h", "include/Imath/ImathMath.h", "include/Imath/ImathMatrix.h", "include/Imath/ImathMatrixAlgo.h", "include/Imath/ImathNamespace.h", "include/Imath/ImathPlane.h", "include/Imath/ImathPlatform.h", "include/Imath/ImathQuat.h", "include/Imath/ImathRandom.h", "include/Imath/ImathRoots.h", "include/Imath/ImathShear.h", "include/Imath/ImathSphere.h", "include/Imath/ImathTypeTraits.h", "include/Imath/ImathVec.h", "include/Imath/ImathVecAlgo.h", "include/Imath/half.h", "include/Imath/halfFunction.h", "include/Imath/halfLimits.h"]
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "homebrew"
+  formula = "imath"
+  [steps.when]
+    os = ["darwin"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libImath-3_2.30.3.2.2.dylib", "lib/libImath-3_2.30.dylib", "lib/libImath-3_2.dylib", "lib/libImath.dylib", "lib/pkgconfig/Imath.pc", "include/Imath/ImathBox.h", "include/Imath/ImathBoxAlgo.h", "include/Imath/ImathColor.h", "include/Imath/ImathColorAlgo.h", "include/Imath/ImathConfig.h", "include/Imath/ImathEuler.h", "include/Imath/ImathExport.h", "include/Imath/ImathForward.h", "include/Imath/ImathFrame.h", "include/Imath/ImathFrustum.h", "include/Imath/ImathFrustumTest.h", "include/Imath/ImathFun.h", "include/Imath/ImathGL.h", "include/Imath/ImathGLU.h", "include/Imath/ImathInt64.h", "include/Imath/ImathInterval.h", "include/Imath/ImathLine.h", "include/Imath/ImathLineAlgo.h", "include/Imath/ImathMath.h", "include/Imath/ImathMatrix.h", "include/Imath/ImathMatrixAlgo.h", "include/Imath/ImathNamespace.h", "include/Imath/ImathPlane.h", "include/Imath/ImathPlatform.h", "include/Imath/ImathQuat.h", "include/Imath/ImathRandom.h", "include/Imath/ImathRoots.h", "include/Imath/ImathShear.h", "include/Imath/ImathSphere.h", "include/Imath/ImathTypeTraits.h", "include/Imath/ImathVec.h", "include/Imath/ImathVecAlgo.h", "include/Imath/half.h", "include/Imath/halfFunction.h", "include/Imath/halfLimits.h"]
+  [steps.when]
+    os = ["darwin"]

--- a/recipes/j/jp2a.toml
+++ b/recipes/j/jp2a.toml
@@ -1,0 +1,35 @@
+[metadata]
+  name = "jp2a"
+  description = "Convert JPG images to ASCII"
+  homepage = "https://github.com/Talinx/jp2a"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["jpeg-turbo", "libexif", "libpng"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "jp2a"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "jp2a"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/jp2a"]
+
+[verify]
+  command = "jp2a --version"
+  pattern = ""

--- a/recipes/l/libexif.toml
+++ b/recipes/l/libexif.toml
@@ -1,0 +1,51 @@
+[metadata]
+  name = "libexif"
+  description = "EXIF parsing library"
+  homepage = "https://libexif.github.io/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["gettext"]
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "libexif"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "libexif"
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libexif.a", "lib/libexif.so", "lib/libexif.so.12", "lib/libexif.so.12.3.4", "lib/pkgconfig/libexif.pc", "include/libexif/_stdint.h", "include/libexif/exif-byte-order.h", "include/libexif/exif-content.h", "include/libexif/exif-data-type.h", "include/libexif/exif-data.h", "include/libexif/exif-entry.h", "include/libexif/exif-format.h", "include/libexif/exif-ifd.h", "include/libexif/exif-loader.h", "include/libexif/exif-log.h", "include/libexif/exif-mem.h", "include/libexif/exif-mnote-data.h", "include/libexif/exif-tag.h", "include/libexif/exif-utils.h"]
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "homebrew"
+  formula = "libexif"
+  [steps.when]
+    os = ["darwin"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libexif.12.dylib", "lib/libexif.a", "lib/libexif.dylib", "lib/pkgconfig/libexif.pc", "include/libexif/_stdint.h", "include/libexif/exif-byte-order.h", "include/libexif/exif-content.h", "include/libexif/exif-data-type.h", "include/libexif/exif-data.h", "include/libexif/exif-entry.h", "include/libexif/exif-format.h", "include/libexif/exif-ifd.h", "include/libexif/exif-loader.h", "include/libexif/exif-log.h", "include/libexif/exif-mem.h", "include/libexif/exif-mnote-data.h", "include/libexif/exif-tag.h", "include/libexif/exif-utils.h"]
+  [steps.when]
+    os = ["darwin"]

--- a/recipes/l/libmagic.toml
+++ b/recipes/l/libmagic.toml
@@ -1,0 +1,50 @@
+[metadata]
+  name = "libmagic"
+  description = "Implementation of the file(1) command"
+  homepage = "https://www.darwinsys.com/file/"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "libmagic"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "libmagic"
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libmagic.a", "lib/libmagic.so", "lib/libmagic.so.1", "lib/libmagic.so.1.0.0", "lib/pkgconfig/libmagic.pc", "include/magic.h"]
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "homebrew"
+  formula = "libmagic"
+  [steps.when]
+    os = ["darwin"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libmagic.1.dylib", "lib/libmagic.a", "lib/libmagic.dylib", "lib/pkgconfig/libmagic.pc", "include/magic.h"]
+  [steps.when]
+    os = ["darwin"]

--- a/recipes/l/libqalculate.toml
+++ b/recipes/l/libqalculate.toml
@@ -1,0 +1,40 @@
+[metadata]
+  name = "libqalculate"
+  description = "Library for Qalculate! program"
+  homepage = "https://qalculate.github.io/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = [
+    "gettext",
+    "gmp",
+    "mpfr",
+    "readline",
+  ]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "libqalculate"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "libqalculate"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/qalc"]
+
+[verify]
+  command = "qalc --version"
+  pattern = ""

--- a/recipes/l/librealsense.toml
+++ b/recipes/l/librealsense.toml
@@ -1,0 +1,35 @@
+[metadata]
+  name = "librealsense"
+  description = "Intel RealSense D400 series and SR300 capture"
+  homepage = "https://github.com/IntelRealSense/librealsense"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["glfw", "libusb"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "librealsense"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "librealsense"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/realsense-viewer", "bin/rs-align", "bin/rs-align-advanced", "bin/rs-align-gl", "bin/rs-benchmark", "bin/rs-callback", "bin/rs-capture", "bin/rs-color", "bin/rs-convert", "bin/rs-data-collect", "bin/rs-depth", "bin/rs-depth-quality", "bin/rs-distance", "bin/rs-embed", "bin/rs-embedded-filters", "bin/rs-enumerate-devices", "bin/rs-eth-config", "bin/rs-fw-logger", "bin/rs-fw-update", "bin/rs-gl", "bin/rs-hdr", "bin/rs-hello-realsense", "bin/rs-infrared", "bin/rs-labeled-pointcloud", "bin/rs-measure", "bin/rs-motion", "bin/rs-multicam", "bin/rs-on-chip-calib", "bin/rs-pointcloud", "bin/rs-post-processing", "bin/rs-record", "bin/rs-record-playback", "bin/rs-rosbag-inspector", "bin/rs-save-to-disk", "bin/rs-sensor-control", "bin/rs-software-device", "bin/rs-terminal"]
+
+[verify]
+  command = "realsense-viewer --version"
+  pattern = ""

--- a/recipes/l/librttopo.toml
+++ b/recipes/l/librttopo.toml
@@ -1,0 +1,51 @@
+[metadata]
+  name = "librttopo"
+  description = "RT Topology Library"
+  homepage = "https://git.osgeo.org/gitea/rttopo/librttopo"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["geos"]
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "librttopo"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "librttopo"
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/librttopo.a", "lib/librttopo.so", "lib/librttopo.so.1", "lib/librttopo.so.1.1.0", "lib/pkgconfig/rttopo.pc", "include/librttopo.h", "include/librttopo_geom.h"]
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "homebrew"
+  formula = "librttopo"
+  [steps.when]
+    os = ["darwin"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/librttopo.1.dylib", "lib/librttopo.a", "lib/librttopo.dylib", "lib/pkgconfig/rttopo.pc", "include/librttopo.h", "include/librttopo_geom.h"]
+  [steps.when]
+    os = ["darwin"]

--- a/recipes/l/libsodium.toml
+++ b/recipes/l/libsodium.toml
@@ -1,0 +1,50 @@
+[metadata]
+  name = "libsodium"
+  description = "NaCl networking and cryptography library"
+  homepage = "https://libsodium.org/"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "libsodium"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "libsodium"
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libsodium.a", "lib/libsodium.so", "lib/libsodium.so.26", "lib/libsodium.so.26.3.0", "lib/pkgconfig/libsodium.pc", "include/sodium/core.h", "include/sodium/crypto_aead_aegis128l.h", "include/sodium/crypto_aead_aegis256.h", "include/sodium/crypto_aead_aes256gcm.h", "include/sodium/crypto_aead_chacha20poly1305.h", "include/sodium/crypto_aead_xchacha20poly1305.h", "include/sodium/crypto_auth.h", "include/sodium/crypto_auth_hmacsha256.h", "include/sodium/crypto_auth_hmacsha512.h", "include/sodium/crypto_auth_hmacsha512256.h", "include/sodium/crypto_box.h", "include/sodium/crypto_box_curve25519xchacha20poly1305.h", "include/sodium/crypto_box_curve25519xsalsa20poly1305.h", "include/sodium/crypto_core_ed25519.h", "include/sodium/crypto_core_hchacha20.h", "include/sodium/crypto_core_hsalsa20.h", "include/sodium/crypto_core_keccak1600.h", "include/sodium/crypto_core_ristretto255.h", "include/sodium/crypto_core_salsa20.h", "include/sodium/crypto_core_salsa2012.h", "include/sodium/crypto_core_salsa208.h", "include/sodium/crypto_generichash.h", "include/sodium/crypto_generichash_blake2b.h", "include/sodium/crypto_hash.h", "include/sodium/crypto_hash_sha256.h", "include/sodium/crypto_hash_sha512.h", "include/sodium/crypto_ipcrypt.h", "include/sodium/crypto_kdf.h", "include/sodium/crypto_kdf_blake2b.h", "include/sodium/crypto_kdf_hkdf_sha256.h", "include/sodium/crypto_kdf_hkdf_sha512.h", "include/sodium/crypto_kx.h", "include/sodium/crypto_onetimeauth.h", "include/sodium/crypto_onetimeauth_poly1305.h", "include/sodium/crypto_pwhash.h", "include/sodium/crypto_pwhash_argon2i.h", "include/sodium/crypto_pwhash_argon2id.h", "include/sodium/crypto_pwhash_scryptsalsa208sha256.h", "include/sodium/crypto_scalarmult.h", "include/sodium/crypto_scalarmult_curve25519.h", "include/sodium/crypto_scalarmult_ed25519.h", "include/sodium/crypto_scalarmult_ristretto255.h", "include/sodium/crypto_secretbox.h", "include/sodium/crypto_secretbox_xchacha20poly1305.h", "include/sodium/crypto_secretbox_xsalsa20poly1305.h", "include/sodium/crypto_secretstream_xchacha20poly1305.h", "include/sodium/crypto_shorthash.h", "include/sodium/crypto_shorthash_siphash24.h", "include/sodium/crypto_sign.h", "include/sodium/crypto_sign_ed25519.h", "include/sodium/crypto_sign_edwards25519sha512batch.h", "include/sodium/crypto_stream.h", "include/sodium/crypto_stream_chacha20.h", "include/sodium/crypto_stream_salsa20.h", "include/sodium/crypto_stream_salsa2012.h", "include/sodium/crypto_stream_salsa208.h", "include/sodium/crypto_stream_xchacha20.h", "include/sodium/crypto_stream_xsalsa20.h", "include/sodium/crypto_verify_16.h", "include/sodium/crypto_verify_32.h", "include/sodium/crypto_verify_64.h", "include/sodium/crypto_xof_shake128.h", "include/sodium/crypto_xof_shake256.h", "include/sodium/crypto_xof_turboshake128.h", "include/sodium/crypto_xof_turboshake256.h", "include/sodium/export.h", "include/sodium/randombytes.h", "include/sodium/randombytes_internal_random.h", "include/sodium/randombytes_sysrandom.h", "include/sodium/runtime.h", "include/sodium/utils.h", "include/sodium/version.h", "include/sodium.h"]
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "homebrew"
+  formula = "libsodium"
+  [steps.when]
+    os = ["darwin"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libsodium.26.dylib", "lib/libsodium.a", "lib/libsodium.dylib", "lib/pkgconfig/libsodium.pc", "include/sodium/core.h", "include/sodium/crypto_aead_aegis128l.h", "include/sodium/crypto_aead_aegis256.h", "include/sodium/crypto_aead_aes256gcm.h", "include/sodium/crypto_aead_chacha20poly1305.h", "include/sodium/crypto_aead_xchacha20poly1305.h", "include/sodium/crypto_auth.h", "include/sodium/crypto_auth_hmacsha256.h", "include/sodium/crypto_auth_hmacsha512.h", "include/sodium/crypto_auth_hmacsha512256.h", "include/sodium/crypto_box.h", "include/sodium/crypto_box_curve25519xchacha20poly1305.h", "include/sodium/crypto_box_curve25519xsalsa20poly1305.h", "include/sodium/crypto_core_ed25519.h", "include/sodium/crypto_core_hchacha20.h", "include/sodium/crypto_core_hsalsa20.h", "include/sodium/crypto_core_keccak1600.h", "include/sodium/crypto_core_ristretto255.h", "include/sodium/crypto_core_salsa20.h", "include/sodium/crypto_core_salsa2012.h", "include/sodium/crypto_core_salsa208.h", "include/sodium/crypto_generichash.h", "include/sodium/crypto_generichash_blake2b.h", "include/sodium/crypto_hash.h", "include/sodium/crypto_hash_sha256.h", "include/sodium/crypto_hash_sha512.h", "include/sodium/crypto_ipcrypt.h", "include/sodium/crypto_kdf.h", "include/sodium/crypto_kdf_blake2b.h", "include/sodium/crypto_kdf_hkdf_sha256.h", "include/sodium/crypto_kdf_hkdf_sha512.h", "include/sodium/crypto_kx.h", "include/sodium/crypto_onetimeauth.h", "include/sodium/crypto_onetimeauth_poly1305.h", "include/sodium/crypto_pwhash.h", "include/sodium/crypto_pwhash_argon2i.h", "include/sodium/crypto_pwhash_argon2id.h", "include/sodium/crypto_pwhash_scryptsalsa208sha256.h", "include/sodium/crypto_scalarmult.h", "include/sodium/crypto_scalarmult_curve25519.h", "include/sodium/crypto_scalarmult_ed25519.h", "include/sodium/crypto_scalarmult_ristretto255.h", "include/sodium/crypto_secretbox.h", "include/sodium/crypto_secretbox_xchacha20poly1305.h", "include/sodium/crypto_secretbox_xsalsa20poly1305.h", "include/sodium/crypto_secretstream_xchacha20poly1305.h", "include/sodium/crypto_shorthash.h", "include/sodium/crypto_shorthash_siphash24.h", "include/sodium/crypto_sign.h", "include/sodium/crypto_sign_ed25519.h", "include/sodium/crypto_sign_edwards25519sha512batch.h", "include/sodium/crypto_stream.h", "include/sodium/crypto_stream_chacha20.h", "include/sodium/crypto_stream_salsa20.h", "include/sodium/crypto_stream_salsa2012.h", "include/sodium/crypto_stream_salsa208.h", "include/sodium/crypto_stream_xchacha20.h", "include/sodium/crypto_stream_xsalsa20.h", "include/sodium/crypto_verify_16.h", "include/sodium/crypto_verify_32.h", "include/sodium/crypto_verify_64.h", "include/sodium/crypto_xof_shake128.h", "include/sodium/crypto_xof_shake256.h", "include/sodium/crypto_xof_turboshake128.h", "include/sodium/crypto_xof_turboshake256.h", "include/sodium/export.h", "include/sodium/randombytes.h", "include/sodium/randombytes_internal_random.h", "include/sodium/randombytes_sysrandom.h", "include/sodium/runtime.h", "include/sodium/utils.h", "include/sodium/version.h", "include/sodium.h"]
+  [steps.when]
+    os = ["darwin"]

--- a/recipes/l/libtommath.toml
+++ b/recipes/l/libtommath.toml
@@ -1,0 +1,50 @@
+[metadata]
+  name = "libtommath"
+  description = "C library for number theoretic multiple-precision integers"
+  homepage = "https://www.libtom.net/LibTomMath/"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "libtommath"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "libtommath"
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libtommath.a", "lib/libtommath.so", "lib/libtommath.so.1", "lib/libtommath.so.1.3.0", "lib/pkgconfig/libtommath.pc", "include/tommath.h"]
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "homebrew"
+  formula = "libtommath"
+  [steps.when]
+    os = ["darwin"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libtommath.1.dylib", "lib/libtommath.a", "lib/libtommath.dylib", "lib/pkgconfig/libtommath.pc", "include/tommath.h"]
+  [steps.when]
+    os = ["darwin"]

--- a/recipes/l/libvpx.toml
+++ b/recipes/l/libvpx.toml
@@ -1,0 +1,50 @@
+[metadata]
+  name = "libvpx"
+  description = "VP8/VP9 video codec"
+  homepage = "https://www.webmproject.org/code/"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "libvpx"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "libvpx"
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libvpx.a", "lib/libvpx.so", "lib/libvpx.so.12", "lib/libvpx.so.12.0", "lib/libvpx.so.12.0.0", "lib/pkgconfig/vpx.pc", "include/vpx/vp8.h", "include/vpx/vp8cx.h", "include/vpx/vp8dx.h", "include/vpx/vpx_codec.h", "include/vpx/vpx_decoder.h", "include/vpx/vpx_encoder.h", "include/vpx/vpx_ext_ratectrl.h", "include/vpx/vpx_frame_buffer.h", "include/vpx/vpx_image.h", "include/vpx/vpx_integer.h", "include/vpx/vpx_tpl.h"]
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "homebrew"
+  formula = "libvpx"
+  [steps.when]
+    os = ["darwin"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libvpx.12.dylib", "lib/libvpx.a", "lib/libvpx.dylib", "lib/pkgconfig/vpx.pc", "include/vpx/vp8.h", "include/vpx/vp8cx.h", "include/vpx/vp8dx.h", "include/vpx/vpx_codec.h", "include/vpx/vpx_decoder.h", "include/vpx/vpx_encoder.h", "include/vpx/vpx_ext_ratectrl.h", "include/vpx/vpx_frame_buffer.h", "include/vpx/vpx_image.h", "include/vpx/vpx_integer.h", "include/vpx/vpx_tpl.h"]
+  [steps.when]
+    os = ["darwin"]

--- a/recipes/l/lzo.toml
+++ b/recipes/l/lzo.toml
@@ -1,0 +1,50 @@
+[metadata]
+  name = "lzo"
+  description = "Real-time data compression library"
+  homepage = "https://www.oberhumer.com/opensource/lzo/"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "lzo"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "lzo"
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/liblzo2.a", "lib/liblzo2.so", "lib/liblzo2.so.2", "lib/liblzo2.so.2.0.0", "lib/pkgconfig/lzo2.pc", "include/lzo/lzo1.h", "include/lzo/lzo1a.h", "include/lzo/lzo1b.h", "include/lzo/lzo1c.h", "include/lzo/lzo1f.h", "include/lzo/lzo1x.h", "include/lzo/lzo1y.h", "include/lzo/lzo1z.h", "include/lzo/lzo2a.h", "include/lzo/lzo_asm.h", "include/lzo/lzoconf.h", "include/lzo/lzodefs.h", "include/lzo/lzoutil.h"]
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "homebrew"
+  formula = "lzo"
+  [steps.when]
+    os = ["darwin"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/liblzo2.2.dylib", "lib/liblzo2.a", "lib/liblzo2.dylib", "lib/pkgconfig/lzo2.pc", "include/lzo/lzo1.h", "include/lzo/lzo1a.h", "include/lzo/lzo1b.h", "include/lzo/lzo1c.h", "include/lzo/lzo1f.h", "include/lzo/lzo1x.h", "include/lzo/lzo1y.h", "include/lzo/lzo1z.h", "include/lzo/lzo2a.h", "include/lzo/lzo_asm.h", "include/lzo/lzoconf.h", "include/lzo/lzodefs.h", "include/lzo/lzoutil.h"]
+  [steps.when]
+    os = ["darwin"]

--- a/recipes/o/oils-for-unix.toml
+++ b/recipes/o/oils-for-unix.toml
@@ -1,0 +1,35 @@
+[metadata]
+  name = "oils-for-unix"
+  description = "Bash-compatible Unix shell with more consistent syntax and semantics"
+  homepage = "https://oils.pub/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["readline"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "oils-for-unix"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "oils-for-unix"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/oils-for-unix"]
+
+[verify]
+  command = "oils-for-unix --version"
+  pattern = ""

--- a/recipes/p/pdsh.toml
+++ b/recipes/p/pdsh.toml
@@ -1,0 +1,35 @@
+[metadata]
+  name = "pdsh"
+  description = "Efficient rsh-like utility, for using hosts in parallel"
+  homepage = "https://github.com/chaos/pdsh"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["readline"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "pdsh"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "pdsh"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/dshbak", "bin/pdcp", "bin/pdsh", "bin/rpdcp"]
+
+[verify]
+  command = "dshbak --version"
+  pattern = ""

--- a/recipes/p/popt.toml
+++ b/recipes/p/popt.toml
@@ -1,0 +1,50 @@
+[metadata]
+  name = "popt"
+  description = "Library like getopt(3) with a number of enhancements"
+  homepage = "https://github.com/rpm-software-management/popt"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "popt"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "popt"
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libpopt.a", "lib/libpopt.so", "lib/libpopt.so.0", "lib/libpopt.so.0.0.2", "lib/pkgconfig/popt.pc", "include/popt.h"]
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "homebrew"
+  formula = "popt"
+  [steps.when]
+    os = ["darwin"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libpopt.0.dylib", "lib/libpopt.a", "lib/libpopt.dylib", "lib/pkgconfig/popt.pc", "include/popt.h"]
+  [steps.when]
+    os = ["darwin"]

--- a/recipes/p/portaudio.toml
+++ b/recipes/p/portaudio.toml
@@ -1,0 +1,31 @@
+[metadata]
+  name = "portaudio"
+  description = "Cross-platform library for audio I/O"
+  homepage = "https://www.portaudio.com"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "portaudio"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "portaudio"
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libportaudio.a", "lib/libportaudio.so", "lib/libportaudio.so.2", "lib/libportaudio.so.2.0.0", "lib/libportaudiocpp.a", "lib/libportaudiocpp.so", "lib/libportaudiocpp.so.0", "lib/libportaudiocpp.so.0.0.12", "lib/pkgconfig/portaudio-2.0.pc", "lib/pkgconfig/portaudiocpp.pc", "include/pa_mac_core.h", "include/portaudio.h", "include/portaudiocpp/AutoSystem.hxx", "include/portaudiocpp/BlockingStream.hxx", "include/portaudiocpp/CFunCallbackStream.hxx", "include/portaudiocpp/CallbackInterface.hxx", "include/portaudiocpp/CallbackStream.hxx", "include/portaudiocpp/CppFunCallbackStream.hxx", "include/portaudiocpp/Device.hxx", "include/portaudiocpp/DirectionSpecificStreamParameters.hxx", "include/portaudiocpp/Exception.hxx", "include/portaudiocpp/HostApi.hxx", "include/portaudiocpp/InterfaceCallbackStream.hxx", "include/portaudiocpp/MemFunCallbackStream.hxx", "include/portaudiocpp/PortAudioCpp.hxx", "include/portaudiocpp/SampleDataFormat.hxx", "include/portaudiocpp/Stream.hxx", "include/portaudiocpp/StreamParameters.hxx", "include/portaudiocpp/System.hxx", "include/portaudiocpp/SystemDeviceIterator.hxx", "include/portaudiocpp/SystemHostApiIterator.hxx"]

--- a/recipes/r/readline.toml
+++ b/recipes/r/readline.toml
@@ -3,7 +3,6 @@ name = "readline"
 description = "GNU Readline library"
 homepage = "https://tiswww.case.edu/php/chet/readline/rltop.html"
 type = "library"
-supported_os = ["darwin"]
 dependencies = ["ncurses"]
 
 [metadata.satisfies]

--- a/recipes/r/riscv64-elf-gdb.toml
+++ b/recipes/r/riscv64-elf-gdb.toml
@@ -1,0 +1,42 @@
+[metadata]
+  name = "riscv64-elf-gdb"
+  description = "GNU debugger for riscv64-elf cross development"
+  homepage = "https://www.gnu.org/software/gdb/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = [
+    "gmp",
+    "mpfr",
+    "ncurses",
+    "readline",
+    "xz",
+    "zstd",
+  ]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "riscv64-elf-gdb"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "riscv64-elf-gdb"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/riscv64-elf-gdb", "bin/riscv64-elf-gdb-add-index", "bin/riscv64-elf-gstack"]
+
+[verify]
+  command = "riscv64-elf-gdb --version"
+  pattern = ""

--- a/recipes/s/speexdsp.toml
+++ b/recipes/s/speexdsp.toml
@@ -1,0 +1,50 @@
+[metadata]
+  name = "speexdsp"
+  description = "Speex audio processing library"
+  homepage = "https://speex.org/"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "speexdsp"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "speexdsp"
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libspeexdsp.a", "lib/libspeexdsp.so", "lib/libspeexdsp.so.1", "lib/libspeexdsp.so.1.5.2", "lib/pkgconfig/speexdsp.pc", "include/speex/speex_echo.h", "include/speex/speex_jitter.h", "include/speex/speex_preprocess.h", "include/speex/speex_resampler.h", "include/speex/speexdsp_config_types.h", "include/speex/speexdsp_types.h"]
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "homebrew"
+  formula = "speexdsp"
+  [steps.when]
+    os = ["darwin"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libspeexdsp.1.dylib", "lib/libspeexdsp.a", "lib/libspeexdsp.dylib", "lib/pkgconfig/speexdsp.pc", "include/speex/speex_echo.h", "include/speex/speex_jitter.h", "include/speex/speex_preprocess.h", "include/speex/speex_resampler.h", "include/speex/speexdsp_config_types.h", "include/speex/speexdsp_types.h"]
+  [steps.when]
+    os = ["darwin"]

--- a/recipes/y/yaml-cpp.toml
+++ b/recipes/y/yaml-cpp.toml
@@ -1,0 +1,50 @@
+[metadata]
+  name = "yaml-cpp"
+  description = "C++ YAML parser and emitter for YAML 1.2 spec"
+  homepage = "https://github.com/jbeder/yaml-cpp"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "yaml-cpp"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "yaml-cpp"
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libyaml-cpp.so", "lib/libyaml-cpp.so.0.9", "lib/libyaml-cpp.so.0.9.0", "lib/pkgconfig/yaml-cpp.pc", "include/yaml-cpp/anchor.h", "include/yaml-cpp/binary.h", "include/yaml-cpp/contrib/anchordict.h", "include/yaml-cpp/contrib/graphbuilder.h", "include/yaml-cpp/depthguard.h", "include/yaml-cpp/dll.h", "include/yaml-cpp/emitfromevents.h", "include/yaml-cpp/emitter.h", "include/yaml-cpp/emitterdef.h", "include/yaml-cpp/emittermanip.h", "include/yaml-cpp/emitterstyle.h", "include/yaml-cpp/eventhandler.h", "include/yaml-cpp/exceptions.h", "include/yaml-cpp/fptostring.h", "include/yaml-cpp/mark.h", "include/yaml-cpp/node/convert.h", "include/yaml-cpp/node/detail/impl.h", "include/yaml-cpp/node/detail/iterator.h", "include/yaml-cpp/node/detail/iterator_fwd.h", "include/yaml-cpp/node/detail/memory.h", "include/yaml-cpp/node/detail/node.h", "include/yaml-cpp/node/detail/node_data.h", "include/yaml-cpp/node/detail/node_iterator.h", "include/yaml-cpp/node/detail/node_ref.h", "include/yaml-cpp/node/emit.h", "include/yaml-cpp/node/impl.h", "include/yaml-cpp/node/iterator.h", "include/yaml-cpp/node/node.h", "include/yaml-cpp/node/parse.h", "include/yaml-cpp/node/ptr.h", "include/yaml-cpp/node/type.h", "include/yaml-cpp/noexcept.h", "include/yaml-cpp/null.h", "include/yaml-cpp/ostream_wrapper.h", "include/yaml-cpp/parser.h", "include/yaml-cpp/stlemitter.h", "include/yaml-cpp/traits.h", "include/yaml-cpp/yaml.h"]
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "homebrew"
+  formula = "yaml-cpp"
+  [steps.when]
+    os = ["darwin"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libyaml-cpp.0.9.0.dylib", "lib/libyaml-cpp.0.9.dylib", "lib/libyaml-cpp.dylib", "lib/pkgconfig/yaml-cpp.pc", "include/yaml-cpp/anchor.h", "include/yaml-cpp/binary.h", "include/yaml-cpp/contrib/anchordict.h", "include/yaml-cpp/contrib/graphbuilder.h", "include/yaml-cpp/depthguard.h", "include/yaml-cpp/dll.h", "include/yaml-cpp/emitfromevents.h", "include/yaml-cpp/emitter.h", "include/yaml-cpp/emitterdef.h", "include/yaml-cpp/emittermanip.h", "include/yaml-cpp/emitterstyle.h", "include/yaml-cpp/eventhandler.h", "include/yaml-cpp/exceptions.h", "include/yaml-cpp/fptostring.h", "include/yaml-cpp/mark.h", "include/yaml-cpp/node/convert.h", "include/yaml-cpp/node/detail/impl.h", "include/yaml-cpp/node/detail/iterator.h", "include/yaml-cpp/node/detail/iterator_fwd.h", "include/yaml-cpp/node/detail/memory.h", "include/yaml-cpp/node/detail/node.h", "include/yaml-cpp/node/detail/node_data.h", "include/yaml-cpp/node/detail/node_iterator.h", "include/yaml-cpp/node/detail/node_ref.h", "include/yaml-cpp/node/emit.h", "include/yaml-cpp/node/impl.h", "include/yaml-cpp/node/iterator.h", "include/yaml-cpp/node/node.h", "include/yaml-cpp/node/parse.h", "include/yaml-cpp/node/ptr.h", "include/yaml-cpp/node/type.h", "include/yaml-cpp/noexcept.h", "include/yaml-cpp/null.h", "include/yaml-cpp/ostream_wrapper.h", "include/yaml-cpp/parser.h", "include/yaml-cpp/stlemitter.h", "include/yaml-cpp/traits.h", "include/yaml-cpp/yaml.h"]
+  [steps.when]
+    os = ["darwin"]

--- a/recipes/z/zlib-ng-compat.toml
+++ b/recipes/z/zlib-ng-compat.toml
@@ -1,0 +1,50 @@
+[metadata]
+  name = "zlib-ng-compat"
+  description = "Zlib replacement with optimizations for next generation systems"
+  homepage = "https://github.com/zlib-ng/zlib-ng"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "zlib-ng-compat"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "zlib-ng-compat"
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libz.a", "lib/libz.so", "lib/libz.so.1", "lib/libz.so.1.3.1.zlib-ng", "lib/pkgconfig/zlib.pc", "include/zconf.h", "include/zlib.h", "include/zlib_name_mangling.h"]
+  [steps.when]
+    libc = ["glibc"]
+    os = ["linux"]
+
+[[steps]]
+  action = "homebrew"
+  formula = "zlib-ng-compat"
+  [steps.when]
+    os = ["darwin"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libz.1.3.1.zlib-ng.dylib", "lib/libz.1.dylib", "lib/libz.a", "lib/libz.dylib", "lib/pkgconfig/zlib.pc", "include/zconf.h", "include/zlib.h", "include/zlib_name_mangling.h"]
+  [steps.when]
+    os = ["darwin"]


### PR DESCRIPTION
## Summary

Batch 5 of the system library backfill. Adds 15 homebrew
libraries and 15 homebrew tools.

**Libraries (15):** readline, imath, portaudio, libexif, libtommath, popt, yaml-cpp, zlib-ng-compat, glfw, libmagic, librttopo, libsodium, libvpx, lzo, speexdsp

**Tools (15):** abook, clang-uml, clifm, file-formula, freeciv, gnu-apl, gnu-units, gptfdisk, i386-elf-gdb, jp2a, libqalculate, librealsense, oils-for-unix, pdsh, riscv64-elf-gdb

## Test plan

- [x] Local sandbox: debian (30/30 pass)
- [x] Local sandbox: rhel (30/30 pass)
- [x] Local sandbox: alpine (30/30 pass)
- [x] Local sandbox: suse (30/30 pass)
- [ ] CI: all platforms pass

---

Part of the system library backfill effort.