### PR TITLE
fix(cli): remove debug print statements from fixLibraryDylibRpaths

### DIFF
--- a/internal/actions/homebrew_relocate.go
+++ b/internal/actions/homebrew_relocate.go
@@ -602,18 +602,6 @@ func (a *HomebrewRelocateAction) fixLibraryDylibRpaths(ctx *ExecutionContext, in
 		for depName, depVersion := range ctx.Dependencies.InstallTime {
 			// Dependency libraries are in $TSUKU_HOME/libs/depname-version/lib
 			depLibPath := filepath.Join(ctx.LibsDir, fmt.Sprintf("%s-%s", depName, depVersion), "lib")
-
-			// Debug: Check if this dependency lib dir exists and list its contents
-			if entries, err := os.ReadDir(depLibPath); err == nil {
-				var fileNames []string
-				for _, e := range entries {
-					fileNames = append(fileNames, e.Name())
-				}
-				fmt.Printf("   Debug: %s lib dir contains: %v\n", depName, fileNames)
-			} else {
-				fmt.Printf("   Debug: %s lib dir doesn't exist: %v\n", depName, err)
-			}
-
 			depLibPaths = append(depLibPaths, depLibPath)
 		}
 	}
@@ -624,7 +612,6 @@ func (a *HomebrewRelocateAction) fixLibraryDylibRpaths(ctx *ExecutionContext, in
 	}
 
 	fmt.Printf("   Fixing dylib RPATHs for %d .dylib file(s) with %d dependencies\n", len(dylibFiles), len(depLibPaths))
-	fmt.Printf("   Debug: Dependency lib paths: %v\n", depLibPaths)
 
 	installNameTool, err := exec.LookPath("install_name_tool")
 	if err != nil {
@@ -634,8 +621,6 @@ func (a *HomebrewRelocateAction) fixLibraryDylibRpaths(ctx *ExecutionContext, in
 
 	// For each .dylib file, add RPATHs to all dependency lib directories
 	for _, dylibPath := range dylibFiles {
-		fmt.Printf("   Debug: Processing dylib: %s\n", filepath.Base(dylibPath))
-
 		// Make file writable
 		info, err := os.Stat(dylibPath)
 		if err != nil {
@@ -653,19 +638,11 @@ func (a *HomebrewRelocateAction) fixLibraryDylibRpaths(ctx *ExecutionContext, in
 
 		// Add RPATH for each dependency
 		for _, depPath := range depLibPaths {
-			fmt.Printf("   Debug: Adding RPATH %s to %s\n", depPath, filepath.Base(dylibPath))
-			addCmd := exec.Command(installNameTool, "-add_rpath", depPath, dylibPath)
-			output, err := addCmd.CombinedOutput()
-			if err != nil {
-				// Ignore "would duplicate" errors
-				if !strings.Contains(string(output), "would duplicate") {
-					fmt.Printf("   Warning: failed to add RPATH %s to %s: %s\n",
-						depPath, filepath.Base(dylibPath), strings.TrimSpace(string(output)))
-				} else {
-					fmt.Printf("   Debug: RPATH already exists (duplicate)\n")
-				}
-			} else {
-				fmt.Printf("   Debug: Successfully added RPATH\n")
+			rpathCmd := exec.Command(installNameTool, "-add_rpath", depPath, dylibPath)
+			output, err := rpathCmd.CombinedOutput()
+			if err != nil && !strings.Contains(string(output), "would duplicate") {
+				fmt.Printf("   Warning: failed to add RPATH %s to %s: %s\n",
+					depPath, filepath.Base(dylibPath), strings.TrimSpace(string(output)))
 			}
 		}
 


### PR DESCRIPTION
Remove leftover `Debug:` printf calls from `fixLibraryDylibRpaths` in
`homebrew_relocate.go`. Simplify the RPATH error handling to use a single
conditional instead of an if/else with a debug branch, matching the pattern
used elsewhere in the file.

---

## What This Fixes

Seven debug print statements were left in `fixLibraryDylibRpaths` during
development of the dylib RPATH dependency fix. These print directory listings,
individual RPATH operations, and success/duplicate status on every dylib
processed -- noise that shouldn't appear in production output.

No behavioral change: Warning-level output and the status summary line are
preserved.