### PR TITLE
feat(recipe): add 14 homebrew recipes

### DIFF
--- a/recipes/a/azqr.toml
+++ b/recipes/a/azqr.toml
@@ -1,0 +1,34 @@
+[metadata]
+  name = "azqr"
+  description = "Azure Quick Review"
+  homepage = "https://azure.github.io/azqr/"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "azqr"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "azqr"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/azqr"]
+
+[verify]
+  command = "azqr --version"
+  pattern = ""

--- a/recipes/a/aztfexport.toml
+++ b/recipes/a/aztfexport.toml
@@ -1,0 +1,34 @@
+[metadata]
+  name = "aztfexport"
+  description = "Bring your existing Azure resources under the management of Terraform"
+  homepage = "https://azure.github.io/aztfexport/"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "aztfexport"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "aztfexport"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/aztfexport"]
+
+[verify]
+  command = "aztfexport --version"
+  pattern = ""

--- a/recipes/a/azure-dev.toml
+++ b/recipes/a/azure-dev.toml
@@ -1,0 +1,34 @@
+[metadata]
+  name = "azure-dev"
+  description = "Developer CLI that provides commands for working with Azure resources"
+  homepage = "https://aka.ms/azd"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "azure-dev"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "azure-dev"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/azd"]
+
+[verify]
+  command = "azd version"
+  pattern = ""

--- a/recipes/a/azurehound.toml
+++ b/recipes/a/azurehound.toml
@@ -1,0 +1,34 @@
+[metadata]
+  name = "azurehound"
+  description = "Azure Data Exporter for BloodHound"
+  homepage = "https://github.com/SpecterOps/AzureHound"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "azurehound"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "azurehound"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/azurehound"]
+
+[verify]
+  command = "azurehound --version"
+  pattern = ""

--- a/recipes/b/baidupcs-go.toml
+++ b/recipes/b/baidupcs-go.toml
@@ -1,0 +1,34 @@
+[metadata]
+  name = "baidupcs-go"
+  description = "Terminal utility for Baidu Network Disk"
+  homepage = "https://github.com/qjfoidnh/BaiduPCS-Go"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "baidupcs-go"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "baidupcs-go"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/baidupcs-go"]
+
+[verify]
+  command = "baidupcs-go --version"
+  pattern = ""

--- a/recipes/b/bashdb.toml
+++ b/recipes/b/bashdb.toml
@@ -1,0 +1,36 @@
+[metadata]
+  name = "bashdb"
+  description = "Bash shell debugger"
+  homepage = "https://bashdb.sourceforge.net/"
+  version_format = ""
+  requires_sudo = false
+  runtime_dependencies = ["bash"]
+  unsupported_platforms = ["darwin/arm64", "darwin/amd64"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "bashdb"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "bashdb"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/bashdb"]
+
+[verify]
+  command = "bashdb --version"
+  pattern = ""

--- a/recipes/b/bat-extras.toml
+++ b/recipes/b/bat-extras.toml
@@ -1,0 +1,34 @@
+[metadata]
+  name = "bat-extras"
+  description = "Bash scripts that integrate bat with various command-line tools"
+  homepage = "https://github.com/eth-p/bat-extras"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "bat-extras"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "bat-extras"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/bat-modules", "bin/batdiff", "bin/batgrep", "bin/batman", "bin/batpipe", "bin/batwatch", "bin/prettybat"]
+
+[verify]
+  command = "bat-modules --version"
+  pattern = ""

--- a/recipes/b/bazel.toml
+++ b/recipes/b/bazel.toml
@@ -1,0 +1,35 @@
+[metadata]
+  name = "bazel"
+  description = "Google's own build tool"
+  homepage = "https://bazel.build/"
+  version_format = ""
+  requires_sudo = false
+  unsupported_platforms = ["darwin/arm64", "darwin/amd64"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "bazel"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "bazel"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/bazel", "bin/bazel-9.0.0"]
+
+[verify]
+  command = "bazel --version"
+  pattern = ""

--- a/recipes/b/bbtools.toml
+++ b/recipes/b/bbtools.toml
@@ -1,0 +1,35 @@
+[metadata]
+  name = "bbtools"
+  description = "Brian Bushnell's tools for manipulating reads"
+  homepage = "https://bbmap.org/"
+  version_format = ""
+  requires_sudo = false
+  unsupported_platforms = ["darwin/arm64", "darwin/amd64"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "bbtools"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "bbtools"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/a_sample_mt.sh", "bin/addadapters.sh", "bin/addssu.sh", "bin/adjusthomopolymers.sh", "bin/alignrandom.sh", "bin/alltoall.sh", "bin/analyzeaccession.sh", "bin/analyzegenes.sh", "bin/analyzesketchresults.sh", "bin/applyvariants.sh", "bin/bamlinestreamer.sh", "bin/bandedaligner.sh", "bin/bandedplusaligner.sh", "bin/bbcms.sh", "bin/bbcountunique.sh", "bin/bbcrisprfinder.sh", "bin/bbduk.sh", "bin/bbdukOld.sh", "bin/bbdukS.sh", "bin/bbest.sh", "bin/bbfakereads.sh", "bin/bbmap.sh", "bin/bbmapskimmer.sh", "bin/bbmask.sh", "bin/bbmerge-auto.sh", "bin/bbmerge.sh", "bin/bbnorm.sh", "bin/bbrealign.sh", "bin/bbrename.sh", "bin/bbsketch.sh", "bin/bbsort.sh", "bin/bbsplit.sh", "bin/bbsplitpairs.sh", "bin/bbstats.sh", "bin/bbversion.sh", "bin/bbwrap.sh", "bin/bloomfilter.sh", "bin/bloomfilterparser.sh", "bin/calcmem.sh", "bin/calctruequality.sh", "bin/callgenes.sh", "bin/callpeaks.sh", "bin/callvariants.sh", "bin/callvariants2.sh", "bin/cat.sh", "bin/cbcl2text.sh", "bin/cg2illumina.sh", "bin/checkstrand.sh", "bin/cladeloader.sh", "bin/cladeserver.sh", "bin/cloudplot.sh", "bin/clumpify.sh", "bin/commonkmers.sh", "bin/comparegff.sh", "bin/comparelabels.sh", "bin/comparesketch.sh", "bin/comparessu.sh", "bin/comparevcf.sh", "bin/consect.sh", "bin/consensus.sh", "bin/copyfile.sh", "bin/countbarcodes.sh", "bin/countbarcodes2.sh", "bin/countduplicates.sh", "bin/countgc.sh", "bin/countsharedlines.sh", "bin/covmaker.sh", "bin/crossblock.sh", "bin/crosscontaminate.sh", "bin/crosscutaligner.sh", "bin/cutgff.sh", "bin/cutprimers.sh", "bin/decontaminate.sh", "bin/dedupe.sh", "bin/dedupe2.sh", "bin/dedupebymapping.sh", "bin/demuxbyname.sh", "bin/demuxserver.sh", "bin/diskbench.sh", "bin/driftingaligner.sh", "bin/driftingplusaligner.sh", "bin/estherfilter.sh", "bin/explodetree.sh", "bin/fastqscan.sh", "bin/fetchproks.sh", "bin/filescan.sh", "bin/filterassemblysummary.sh", "bin/filterbarcodes.sh", "bin/filterbycoverage.sh", "bin/filterbyname.sh", "bin/filterbysequence.sh", "bin/filterbytaxa.sh", "bin/filterbytile.sh", "bin/filterlines.sh", "bin/filtersam.sh", "bin/filtersilva.sh", "bin/filtersubs.sh", "bin/filtervcf.sh", "bin/findrepeats.sh", "bin/fix_script_paths.sh", "bin/fixgaps.sh", "bin/fungalrelease.sh", "bin/fuse.sh", "bin/gbff2gff.sh", "bin/getreads.sh", "bin/gi2ancestors.sh", "bin/gi2taxid.sh", "bin/gitable.sh", "bin/glocalaligner.sh", "bin/gradebins.sh", "bin/grademerge.sh", "bin/gradesam.sh", "bin/icecreamfinder.sh", "bin/icecreamgrader.sh", "bin/icecreammaker.sh", "bin/idmatrix.sh", "bin/idtree.sh", "bin/indelfree.sh", "bin/invertkey.sh", "bin/javasetup.sh", "bin/kapastats.sh", "bin/kcompress.sh", "bin/keepbestcopy.sh", "bin/khist.sh", "bin/kmercountexact.sh", "bin/kmercountmulti.sh", "bin/kmercountshort.sh", "bin/kmercoverage.sh", "bin/kmerfilterset.sh", "bin/kmerlimit.sh", "bin/kmerlimit2.sh", "bin/kmerposition.sh", "bin/kmutate.sh", "bin/lilypad.sh", "bin/loadreads.sh", "bin/loglog.sh", "bin/makechimeras.sh", "bin/makecontaminatedgenomes.sh", "bin/makepolymers.sh", "bin/makequickbinvector.sh", "bin/mapPacBio.sh", "bin/matrixtocolumns.sh", "bin/memdetect.sh", "bin/mergeOTUs.sh", "bin/mergebarcodes.sh", "bin/mergepgm.sh", "bin/mergeribo.sh", "bin/mergesam.sh", "bin/mergesketch.sh", "bin/mergesorted.sh", "bin/microalign.sh", "bin/msa.sh", "bin/mutate.sh", "bin/muxbyname.sh", "bin/netfilter.sh", "bin/novademux.sh", "bin/parallelogram.sh", "bin/partition.sh", "bin/phylip2fasta.sh", "bin/picksubset.sh", "bin/pileup.sh", "bin/pileup2.sh", "bin/plotflowcell.sh", "bin/plotgc.sh", "bin/plothist.sh", "bin/plotreadposition.sh", "bin/polyfilter.sh", "bin/postfilter.sh", "bin/printtime.sh", "bin/processfrag.sh", "bin/processhi-c.sh", "bin/processspeed.sh", "bin/profile.sh", "bin/quabblealigner.sh", "bin/quantumaligner.sh", "bin/quickbin.sh", "bin/quickclade.sh", "bin/randomgenome.sh", "bin/randomreads.sh", "bin/randomreadsmg.sh", "bin/readlength.sh", "bin/reassemble.sh", "bin/reducecolumns.sh", "bin/reducesilva.sh", "bin/reformat.sh", "bin/reformat2.sh", "bin/reformat3.sh", "bin/reformatpb.sh", "bin/removebadbarcodes.sh", "bin/removecatdogmousehuman.sh", "bin/removehuman.sh", "bin/removehuman2.sh", "bin/removemicrobes.sh", "bin/removesmartbell.sh", "bin/rename.sh", "bin/renamebymapping.sh", "bin/renamebysketch.sh", "bin/renameimg.sh", "bin/renameref.sh", "bin/repair.sh", "bin/replaceheaders.sh", "bin/representative.sh", "bin/rqcfilter.sh", "bin/rqcfilter2.sh", "bin/rqcfilter3.sh", "bin/runhmm.sh", "bin/samstreamer.sh", "bin/samtoroc.sh", "bin/scalarintervals.sh", "bin/scalars.sh", "bin/scoresequence.sh", "bin/scrabblealigner.sh", "bin/seal.sh", "bin/sendclade.sh", "bin/sendsketch.sh", "bin/seqtovec.sh", "bin/shred.sh", "bin/shrinkaccession.sh", "bin/shuffle.sh", "bin/shuffle2.sh", "bin/sketch.sh", "bin/sketchblacklist.sh", "bin/sketchblacklist2.sh", "bin/smithwaterman.sh", "bin/sortbyname.sh", "bin/splitbytaxa.sh", "bin/splitnextera.sh", "bin/splitribo.sh", "bin/splitsam.sh", "bin/splitsam4way.sh", "bin/splitsam6way.sh", "bin/stats.sh", "bin/stats3.sh", "bin/statswrapper.sh", "bin/stream.sh", "bin/streamsam.sh", "bin/subsketch.sh", "bin/summarizecontam.sh", "bin/summarizecoverage.sh", "bin/summarizecrossblock.sh", "bin/summarizemerge.sh", "bin/summarizequast.sh", "bin/summarizescafstats.sh", "bin/summarizeseal.sh", "bin/summarizesketch.sh", "bin/synthmda.sh", "bin/tadpipe.sh", "bin/tadpole.sh", "bin/tadwrapper.sh", "bin/tagandmerge.sh", "bin/taxonomy.sh", "bin/taxserver.sh", "bin/taxsize.sh", "bin/taxtree.sh", "bin/testaligners.sh", "bin/testaligners2.sh", "bin/testfilesystem.sh", "bin/testformat.sh", "bin/testformat2.sh", "bin/tetramerfreq.sh", "bin/textfile.sh", "bin/tiledump.sh", "bin/train.sh", "bin/translate6frames.sh", "bin/trimcontigs.sh", "bin/unicode2ascii.sh", "bin/unzip.sh", "bin/vcf2gff.sh", "bin/visualizealignment.sh", "bin/wavefrontaligner.sh", "bin/wavefrontalignerviz.sh", "bin/webcheck.sh", "bin/wobblealigner.sh", "bin/wobbleplusaligner.sh", "bin/xdrophaligner.sh", "bin/zz_rename_package.sh"]
+
+[verify]
+  command = "a_sample_mt.sh --version"
+  pattern = ""

--- a/recipes/b/bchunk.toml
+++ b/recipes/b/bchunk.toml
@@ -1,0 +1,34 @@
+[metadata]
+  name = "bchunk"
+  description = "Convert CD images from .bin/.cue to .iso/.cdr"
+  homepage = "https://he.fi/bchunk/"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "bchunk"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "bchunk"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/bchunk"]
+
+[verify]
+  command = "bchunk --version"
+  pattern = ""

--- a/recipes/b/beads-viewer.toml
+++ b/recipes/b/beads-viewer.toml
@@ -1,0 +1,34 @@
+[metadata]
+  name = "beads-viewer"
+  description = "Terminal-based UI for the Beads issue tracker"
+  homepage = "https://github.com/Dicklesworthstone/beads_viewer"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "beads_viewer"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "beads_viewer"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/bv"]
+
+[verify]
+  command = "bv --version"
+  pattern = ""

--- a/recipes/b/benthos.toml
+++ b/recipes/b/benthos.toml
@@ -1,0 +1,34 @@
+[metadata]
+  name = "benthos"
+  description = "Stream processor for mundane tasks written in Go"
+  homepage = "https://github.com/redpanda-data/benthos"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "benthos"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "benthos"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/benthos"]
+
+[verify]
+  command = "benthos --version"
+  pattern = ""

--- a/recipes/b/bento4.toml
+++ b/recipes/b/bento4.toml
@@ -1,0 +1,38 @@
+[metadata]
+  name = "bento4"
+  description = "Full-featured MP4 format and MPEG DASH library and tools"
+  homepage = "https://www.bento4.com/"
+  version_format = ""
+  requires_sudo = false
+  unsupported_platforms = ["darwin/arm64", "darwin/amd64", "linux/arm64"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "bento4"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "bento4"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/aac2mp4", "bin/avcinfo", "bin/fixaacsampledescription", "bin/hevcinfo", "bin/mp42aac", "bin/mp42avc", "bin/mp42hevc", "bin/mp42hls", "bin/mp42ts", "bin/mp4audioclip", "bin/mp4compact", "bin/mp4dcfpackager", "bin/mp4decrypt", "bin/mp4diff", "bin/mp4dump", "bin/mp4edit", "bin/mp4encrypt", "bin/mp4extract", "bin/mp4fragment", "bin/mp4iframeindex", "bin/mp4info", "bin/mp4mux", "bin/mp4pssh", "bin/mp4rtphintinfo", "bin/mp4split", "bin/mp4tag"]
+
+[verify]
+  command = "aac2mp4"
+  pattern = ""
+  mode = "output"
+  reason = "bento4 tools print usage and exit non-zero when called without arguments"
+  exit_code = 1

--- a/recipes/b/berkeley-db.toml
+++ b/recipes/b/berkeley-db.toml
@@ -1,0 +1,36 @@
+[metadata]
+  name = "berkeley-db"
+  description = "High performance key/value database"
+  homepage = "https://www.oracle.com/database/technologies/related/berkeleydb.html"
+  version_format = ""
+  requires_sudo = false
+  unsupported_platforms = ["darwin/arm64", "darwin/amd64", "linux/arm64"]
+  tier = 0
+  type = ""
+  llm_validation = "skipped"
+  runtime_dependencies = ["openssl"]
+
+[version]
+  source = "homebrew"
+  github_repo = ""
+  tag_prefix = ""
+  module = ""
+  formula = "berkeley-db"
+  cask = ""
+  tap = ""
+  fossil_repo = ""
+  project_name = ""
+  version_separator = ""
+  timeline_tag = ""
+
+[[steps]]
+  action = "homebrew"
+  formula = "berkeley-db"
+
+[[steps]]
+  action = "install_binaries"
+  binaries = ["bin/db_archive", "bin/db_checkpoint", "bin/db_convert", "bin/db_deadlock", "bin/db_dump", "bin/db_hotbackup", "bin/db_load", "bin/db_log_verify", "bin/db_printlog", "bin/db_recover", "bin/db_replicate", "bin/db_stat", "bin/db_tuner", "bin/db_upgrade", "bin/db_verify"]
+
+[verify]
+  command = "db_archive --version"
+  pattern = ""


### PR DESCRIPTION
Add 14 homebrew recipe files for: azqr, aztfexport, azure-dev, azurehound, baidupcs-go, bashdb, bat-extras, bazel, bbtools, bchunk, beads-viewer, benthos, bento4, berkeley-db.

Each recipe defines installation via homebrew bottles, with platform
exclusions applied where bottles aren't available (macOS, Linux arm64).

---

## Test plan

- [x] Local sandbox: all recipes pass on debian, rhel, alpine, suse
- [x] CI: all platforms pass