### PR TITLE
feat(batch): propagate failure/blocked statuses to queue on main

### DIFF
--- a/.github/workflows/batch-generate.yml
+++ b/.github/workflows/batch-generate.yml
@@ -1069,7 +1069,7 @@ jobs:
       - name: Persist circuit breaker and metrics state
         if: steps.check-open-prs.outputs.should_skip != 'true' && steps.check.outputs.changes == 'false'
         run: |
-          git add batch-control.json data/metrics/ 2>/dev/null || true
+          git add batch-control.json data/metrics/ data/failures/ 2>/dev/null || true
           if git diff --cached --quiet; then
             echo "No state changes to persist"
             exit 0

--- a/.github/workflows/update-queue-status.yml
+++ b/.github/workflows/update-queue-status.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'recipes/**'
+      - 'data/failures/**'
 
 permissions:
   contents: write

--- a/cmd/queue-maintain/main.go
+++ b/cmd/queue-maintain/main.go
@@ -1,12 +1,19 @@
-// Command queue-maintain performs queue maintenance: requeuing blocked entries
-// whose dependencies have been resolved, then reordering entries within each
-// tier by transitive blocking impact. Both steps run by default; use
-// --skip-requeue or --skip-reorder to skip individual steps.
+// Command queue-maintain performs queue maintenance in three steps:
+//
+//  1. Mark failures: read failure JSONL data and set queue entry statuses
+//     to failed/blocked; expire backoffs on failed entries past next_retry_at.
+//  2. Requeue: flip blocked entries to pending when their blocking
+//     dependencies have been resolved (status "success" in queue).
+//  3. Reorder: sort entries within each priority level by transitive
+//     blocking impact.
+//
+// All steps run by default; use --skip-mark-failures, --skip-requeue, or
+// --skip-reorder to skip individual steps.
 //
 // Usage:
 //
 //	queue-maintain [-queue path] [-failures-dir path] [-output path] [-dry-run] [-json]
-//	               [-skip-requeue] [-skip-reorder]
+//	               [-skip-mark-failures] [-skip-requeue] [-skip-reorder]
 package main
 
 import (
@@ -16,14 +23,16 @@ import (
 	"os"
 
 	"github.com/tsukumogami/tsuku/internal/batch"
+	"github.com/tsukumogami/tsuku/internal/markfailures"
 	"github.com/tsukumogami/tsuku/internal/reorder"
 	"github.com/tsukumogami/tsuku/internal/requeue"
 )
 
-// maintainResult holds the combined results from both steps for JSON output.
+// maintainResult holds the combined results from all steps for JSON output.
 type maintainResult struct {
-	Requeue *requeue.Result `json:"requeue,omitempty"`
-	Reorder *reorder.Result `json:"reorder,omitempty"`
+	MarkFailures *markfailures.Result `json:"mark_failures,omitempty"`
+	Requeue      *requeue.Result      `json:"requeue,omitempty"`
+	Reorder      *reorder.Result      `json:"reorder,omitempty"`
 }
 
 func main() {
@@ -32,6 +41,7 @@ func main() {
 	output := flag.String("output", "", "output file path (default: overwrite queue file)")
 	dryRun := flag.Bool("dry-run", false, "compute and report changes without writing")
 	jsonOutput := flag.Bool("json", false, "output result as JSON")
+	skipMarkFailures := flag.Bool("skip-mark-failures", false, "skip the mark-failures step")
 	skipRequeue := flag.Bool("skip-requeue", false, "skip the requeue step")
 	skipReorder := flag.Bool("skip-reorder", false, "skip the reorder step")
 	flag.Parse()
@@ -45,7 +55,17 @@ func main() {
 
 	var combined maintainResult
 
-	// Step 1: Requeue
+	// Step 1: Mark failures
+	if !*skipMarkFailures {
+		markResult, err := markfailures.Run(queue, *failuresDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error: mark-failures: %v\n", err)
+			os.Exit(1)
+		}
+		combined.MarkFailures = markResult
+	}
+
+	// Step 2: Requeue
 	if !*skipRequeue {
 		requeueResult, err := requeue.Run(queue, *failuresDir)
 		if err != nil {
@@ -96,6 +116,16 @@ func main() {
 }
 
 func printHumanOutput(combined maintainResult, dryRun bool) {
+	if combined.MarkFailures != nil {
+		fmt.Fprintf(os.Stderr, "Mark failures complete\n")
+		fmt.Fprintf(os.Stderr, "  Entries marked failed: %d\n", combined.MarkFailures.MarkedFailed)
+		fmt.Fprintf(os.Stderr, "  Entries marked blocked: %d\n", combined.MarkFailures.MarkedBlocked)
+		fmt.Fprintf(os.Stderr, "  Entries retried (backoff expired): %d\n", combined.MarkFailures.Retried)
+		for _, c := range combined.MarkFailures.Details {
+			fmt.Fprintf(os.Stderr, "  - %s: %s -> %s\n", c.Name, c.FromState, c.ToState)
+		}
+	}
+
 	if combined.Requeue != nil {
 		fmt.Fprintf(os.Stderr, "Requeue complete\n")
 		fmt.Fprintf(os.Stderr, "  Entries requeued: %d\n", combined.Requeue.Requeued)

--- a/data/queues/priority-queue.json
+++ b/data/queues/priority-queue.json
@@ -1,15 +1,15 @@
 {
   "schema_version": 1,
-  "updated_at": "2026-03-03T03:21:03Z",
+  "updated_at": "2026-03-03T04:08:12Z",
   "entries": [
     {
       "name": "node",
       "source": "homebrew:node",
       "priority": 1,
-      "status": "pending",
+      "status": "blocked",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 0,
+      "failure_count": 4,
       "next_retry_at": null
     },
     {
@@ -96,10 +96,10 @@
       "name": "neovim",
       "source": "homebrew:neovim",
       "priority": 1,
-      "status": "pending",
+      "status": "blocked",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 0,
+      "failure_count": 4,
       "next_retry_at": null
     },
     {
@@ -159,17 +159,17 @@
       "status": "pending",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 0,
+      "failure_count": 4,
       "next_retry_at": null
     },
     {
       "name": "vim",
       "source": "homebrew:vim",
       "priority": 1,
-      "status": "pending",
+      "status": "blocked",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 0,
+      "failure_count": 4,
       "next_retry_at": null
     },
     {
@@ -186,11 +186,11 @@
       "name": "openssl@3",
       "source": "homebrew:openssl@3",
       "priority": 2,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 3,
-      "next_retry_at": "2026-02-24T06:13:54.942523874Z"
+      "failure_count": 6,
+      "next_retry_at": "2026-03-04T12:08:12.881937985Z"
     },
     {
       "name": "python@3.13",
@@ -206,30 +206,30 @@
       "name": "python@3.14",
       "source": "homebrew:python@3.14",
       "priority": 2,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 3,
-      "next_retry_at": "2026-02-24T06:14:03.397894201Z"
+      "failure_count": 5,
+      "next_retry_at": "2026-03-03T20:08:12.881937985Z"
     },
     {
       "name": "anomalyco/tap/opencode",
       "source": "homebrew:anomalyco/tap/opencode",
       "priority": 2,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 3,
-      "next_retry_at": "2026-02-24T06:13:52.416870032Z"
+      "failure_count": 5,
+      "next_retry_at": "2026-03-03T20:08:12.881937985Z"
     },
     {
       "name": "awscli",
       "source": "homebrew:awscli",
       "priority": 2,
-      "status": "pending",
+      "status": "blocked",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 0,
+      "failure_count": 2,
       "next_retry_at": null
     },
     {
@@ -256,11 +256,11 @@
       "name": "exa",
       "source": "homebrew:exa",
       "priority": 2,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 0,
-      "next_retry_at": null
+      "failure_count": 2,
+      "next_retry_at": "2026-03-03T06:08:12.881937985Z"
     },
     {
       "name": "ffmpeg",
@@ -269,37 +269,37 @@
       "status": "pending",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 0,
+      "failure_count": 2,
       "next_retry_at": null
     },
     {
       "name": "gcc",
       "source": "homebrew:gcc",
       "priority": 2,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 0,
-      "next_retry_at": null
+      "failure_count": 1,
+      "next_retry_at": "2026-03-03T05:08:12.881937985Z"
     },
     {
       "name": "gemini-cli",
       "source": "homebrew:gemini-cli",
       "priority": 2,
-      "status": "pending",
+      "status": "blocked",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 0,
+      "failure_count": 2,
       "next_retry_at": null
     },
     {
       "name": "gnupg",
       "source": "homebrew:gnupg",
       "priority": 2,
-      "status": "pending",
+      "status": "blocked",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 0,
+      "failure_count": 1,
       "next_retry_at": null
     },
     {
@@ -326,61 +326,61 @@
       "name": "imagemagick",
       "source": "homebrew:imagemagick",
       "priority": 2,
-      "status": "pending",
+      "status": "blocked",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 0,
+      "failure_count": 2,
       "next_retry_at": null
     },
     {
       "name": "jless",
       "source": "homebrew:jless",
       "priority": 2,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 0,
-      "next_retry_at": null
+      "failure_count": 1,
+      "next_retry_at": "2026-03-03T05:08:12.881937985Z"
     },
     {
       "name": "node@22",
       "source": "homebrew:node@22",
       "priority": 2,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 3,
-      "next_retry_at": "2026-02-24T06:13:53.677861623Z"
+      "failure_count": 4,
+      "next_retry_at": "2026-03-03T12:08:12.881937985Z"
     },
     {
       "name": "nvm",
       "source": "homebrew:nvm",
       "priority": 2,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 0,
-      "next_retry_at": null
+      "failure_count": 1,
+      "next_retry_at": "2026-03-03T05:08:12.881937985Z"
     },
     {
       "name": "ollama",
       "source": "homebrew:ollama",
       "priority": 2,
-      "status": "pending",
+      "status": "blocked",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 0,
+      "failure_count": 1,
       "next_retry_at": null
     },
     {
       "name": "pnpm",
       "source": "homebrew:pnpm",
       "priority": 2,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 3,
-      "next_retry_at": "2026-02-24T06:13:56.654327224Z"
+      "failure_count": 4,
+      "next_retry_at": "2026-03-03T12:08:12.881937985Z"
     },
     {
       "name": "protobuf",
@@ -396,31 +396,31 @@
       "name": "pyenv",
       "source": "homebrew:pyenv",
       "priority": 2,
-      "status": "pending",
+      "status": "blocked",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 3,
+      "failure_count": 5,
       "next_retry_at": "2026-02-24T06:13:58.306913285Z"
     },
     {
       "name": "python@3.11",
       "source": "homebrew:python@3.11",
       "priority": 2,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 3,
-      "next_retry_at": "2026-02-24T06:13:59.5569802Z"
+      "failure_count": 4,
+      "next_retry_at": "2026-03-03T12:08:12.881937985Z"
     },
     {
       "name": "python@3.12",
       "source": "homebrew:python@3.12",
       "priority": 2,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 3,
-      "next_retry_at": "2026-02-24T06:14:00.808190795Z"
+      "failure_count": 4,
+      "next_retry_at": "2026-03-03T12:08:12.881937985Z"
     },
     {
       "name": "ripgrep",
@@ -429,7 +429,7 @@
       "status": "pending",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 0,
+      "failure_count": 1,
       "next_retry_at": null
     },
     {
@@ -806,11 +806,11 @@
       "name": "tree-sitter@0.25",
       "source": "homebrew:tree-sitter@0.25",
       "priority": 3,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 1,
-      "next_retry_at": null
+      "failure_count": 2,
+      "next_retry_at": "2026-03-03T06:08:12.881937985Z"
     },
     {
       "name": "webp",
@@ -889,7 +889,7 @@
       "status": "pending",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 2,
+      "failure_count": 4,
       "next_retry_at": "2026-02-19T15:38:27.082365439Z"
     },
     {
@@ -919,7 +919,7 @@
       "status": "pending",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 2,
+      "failure_count": 4,
       "next_retry_at": "2026-02-19T15:38:37.6217734Z"
     },
     {
@@ -966,21 +966,21 @@
       "name": "abcmidi",
       "source": "homebrew:abcmidi",
       "priority": 3,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 2,
-      "next_retry_at": "2026-02-22T06:14:18.341810854Z"
+      "failure_count": 4,
+      "next_retry_at": "2026-03-03T12:08:12.881937985Z"
     },
     {
       "name": "abduco",
       "source": "homebrew:abduco",
       "priority": 3,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 2,
-      "next_retry_at": "2026-02-22T06:14:20.797891678Z"
+      "failure_count": 4,
+      "next_retry_at": "2026-03-03T12:08:12.881937985Z"
     },
     {
       "name": "abi3audit",
@@ -1006,11 +1006,11 @@
       "name": "achannarasappa/tap/ticker",
       "source": "homebrew:achannarasappa/tap/ticker",
       "priority": 3,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 2,
-      "next_retry_at": "2026-02-22T06:14:23.679804391Z"
+      "failure_count": 4,
+      "next_retry_at": "2026-03-03T12:08:12.881937985Z"
     },
     {
       "name": "ack",
@@ -1036,11 +1036,11 @@
       "name": "acme.sh",
       "source": "homebrew:acme.sh",
       "priority": 3,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 2,
-      "next_retry_at": "2026-02-22T06:14:25.067893975Z"
+      "failure_count": 3,
+      "next_retry_at": "2026-03-03T08:08:12.881937985Z"
     },
     {
       "name": "acpica",
@@ -1736,11 +1736,11 @@
       "name": "amp",
       "source": "rubygems:amp",
       "priority": 3,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 2,
-      "next_retry_at": "2026-02-22T07:21:30.499339095Z"
+      "failure_count": 3,
+      "next_retry_at": "2026-03-03T08:08:12.881937985Z"
     },
     {
       "name": "amplify",
@@ -2306,11 +2306,11 @@
       "name": "apt",
       "source": "homebrew:apt",
       "priority": 3,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 0,
-      "next_retry_at": null
+      "failure_count": 1,
+      "next_retry_at": "2026-03-03T05:08:12.881937985Z"
     },
     {
       "name": "apt-dater",
@@ -2726,11 +2726,11 @@
       "name": "ascii",
       "source": "crates.io:ascii",
       "priority": 3,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 1,
-      "next_retry_at": null
+      "failure_count": 2,
+      "next_retry_at": "2026-03-03T06:08:12.881937985Z"
     },
     {
       "name": "asciidoc",
@@ -3806,11 +3806,11 @@
       "name": "azion",
       "source": "npm:azion",
       "priority": 3,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 2,
-      "next_retry_at": "2026-02-20T14:14:52.863503027Z"
+      "failure_count": 3,
+      "next_retry_at": "2026-03-03T08:08:12.881937985Z"
     },
     {
       "name": "azqr",
@@ -25086,11 +25086,11 @@
       "name": "lib3mf",
       "source": "pypi:lib3mf",
       "priority": 3,
-      "status": "pending",
+      "status": "failed",
       "confidence": "auto",
       "disambiguated_at": "2026-02-17T00:10:01.867521792Z",
-      "failure_count": 2,
-      "next_retry_at": "2026-02-20T22:30:41.219402634Z"
+      "failure_count": 3,
+      "next_retry_at": "2026-03-03T08:08:12.881937985Z"
     },
     {
       "name": "libaacs",

--- a/docs/designs/current/DESIGN-requeue-on-recipe-merge.md
+++ b/docs/designs/current/DESIGN-requeue-on-recipe-merge.md
@@ -180,13 +180,41 @@ This eliminates the concurrent-writer problem entirely: one workflow owns the fi
 
 **Extract queue commit job**: Split queue-writing into a shared job called by both workflows. More correct than today but adds significant workflow complexity. The single-owner pattern achieves the same safety with less machinery.
 
+### Decision 5: Failure Status Propagation
+
+The single-writer design (Decision 4) keeps `batch-generate.yml` from committing queue status changes. The batch orchestrator updates entries to `failed`/`blocked` locally during its run, but those changes stay in the working tree. On main, the queue shows 0 failed and 0 blocked entries, making the pipeline dashboard inaccurate.
+
+Meanwhile, failure JSONL data (`data/failures/*.jsonl`) does reach main -- either through batch PRs (which include `data/failures/` in their commits) or through the persist step (when zero recipes pass). This data contains the ground truth about which packages are failing and why.
+
+#### Chosen: Extend queue-maintain with Mark Failures Step
+
+Add a mark-failures step to `queue-maintain` that reads failure JSONL data and updates queue entry statuses. This preserves single-writer: all queue writes still flow through `update-queue-status.yml`, which runs `queue-maintain` after marking merged recipes as "success".
+
+The new step order in `queue-maintain` is:
+
+1. **Mark failures**: for each `pending` entry with more failures in JSONL than its current `failure_count`, set status to `blocked` (if `missing_dep` with `blocked_by`) or `failed` (otherwise). For `failed` entries past their `next_retry_at`, flip back to `pending`.
+2. **Requeue**: blocked -> pending when all blocking deps resolved (existing).
+3. **Reorder**: sort by priority and transitive blocking impact (existing).
+
+**Idempotency**: The comparison `total_failures_in_jsonl > entry.failure_count` prevents re-marking entries from stale data. Once an entry is marked `failed` with count=N and later retried (flipped to `pending`), it won't be re-marked unless new failure records appear (count > N).
+
+**Backoff expiry**: Failed entries get `next_retry_at` set via exponential backoff (1h base, 2x per failure, capped at 7 days). When `next_retry_at` passes, the mark-failures step flips the entry back to `pending`, making it eligible for the next batch run.
+
+**Workflow trigger expansion**: `update-queue-status.yml` path triggers are expanded to include `data/failures/**` so the workflow fires when `batch-generate.yml` commits failure data directly to main (via its persist step, which now includes `data/failures/`).
+
+#### Alternatives Considered
+
+**Dashboard-side computation**: Have the dashboard compute failed/blocked counts from JSONL data instead of queue statuses. Avoids any queue changes but creates two sources of truth (queue says "pending", dashboard says "failed"). The batch orchestrator also reads queue statuses for scheduling decisions, so the queue itself needs to be accurate.
+
+**Commit queue changes from batch-generate.yml**: Have the batch PR include queue status updates. Rejected -- this was the pre-Decision 4 approach and reintroduces the concurrent-writer problem.
+
 ## Decision Outcome
 
-**Chosen: 1 (Go) + 2 (single command) + 3 (queue status) + 4 (single owner)**
+**Chosen: 1 (Go) + 2 (single command) + 3 (queue status) + 4 (single owner) + 5 (mark failures via queue-maintain)**
 
 ### Summary
 
-We're replacing `scripts/requeue-unblocked.sh` and `cmd/reorder-queue/` with a single `cmd/queue-maintain/` Go CLI that performs both requeue and reorder in one pass. The tool loads the unified queue and failure JSONL data once, scans for blocked entries whose dependencies now have status "success" in the queue, flips them to "pending", then reorders all entries within each priority level by transitive blocking impact. It writes the result back to the unified queue file.
+We're replacing `scripts/requeue-unblocked.sh` and `cmd/reorder-queue/` with a single `cmd/queue-maintain/` Go CLI that performs mark-failures, requeue, and reorder in one pass. The tool loads the unified queue and failure JSONL data once, marks entries as failed or blocked based on failure records, scans for blocked entries whose dependencies now have status "success" in the queue and flips them to "pending", then reorders all entries within each priority level by transitive blocking impact. It writes the result back to the unified queue file.
 
 The workflow integration makes `update-queue-status.yml` the single owner of `priority-queue.json` on main. After marking merged recipes as "success" (its existing behavior), it builds and runs `queue-maintain`, which requeues any newly-unblockable packages and reorders the queue. The queue modifications from `batch-generate.yml`'s PR creation step are removed -- when batch PRs merge, `update-queue-status.yml` handles the queue state. `batch-generate.yml` still runs `queue-maintain` locally during its generate and merge jobs (replacing the current `requeue-unblocked.sh` calls), but those queue changes stay in the batch working tree and only the recipe files go into the batch PR.
 
@@ -382,6 +410,7 @@ No user data is accessed or transmitted. The queue and failure data contain pack
 - Single Go tool for queue maintenance reduces operational complexity
 - Eliminating the concurrent-writer pattern prevents git conflicts between workflows
 - Shared blocker map loading means one implementation to maintain
+- Pipeline dashboard shows accurate failed/blocked counts (Decision 5) -- failure JSONL ground truth is translated into queue statuses on every queue-maintain run
 
 ### Negative
 

--- a/internal/markfailures/markfailures.go
+++ b/internal/markfailures/markfailures.go
@@ -1,0 +1,268 @@
+// Package markfailures reads failure JSONL data and updates queue entry
+// statuses to reflect actual failure and blocked states. This bridges the
+// gap between the batch orchestrator (which tracks failures locally) and
+// the queue on main (which only gets success transitions from
+// update-queue-status.yml).
+//
+// The package is designed for idempotent execution: running it multiple
+// times on the same failure data produces the same result. It uses
+// total failure count comparison (JSONL records vs queue entry's
+// failure_count) to avoid re-marking entries from stale data.
+package markfailures
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/tsukumogami/tsuku/internal/batch"
+)
+
+// PackageFailureSummary aggregates failure information for a single package
+// across all JSONL files.
+type PackageFailureSummary struct {
+	TotalFailures   int      // count of failure records across all JSONL files
+	HasMissingDep   bool     // any missing_dep category failure
+	BlockedBy       []string // union of blocked_by deps (deduplicated)
+	HasOtherFailure bool     // any non-missing_dep failure
+}
+
+// Result summarizes the outcome of a mark-failures operation.
+type Result struct {
+	MarkedFailed  int      // entries set from pending to failed
+	MarkedBlocked int      // entries set from pending to blocked
+	Retried       int      // entries flipped from failed to pending (backoff expired)
+	Details       []Change // per-entry changes
+}
+
+// Change records a single status transition.
+type Change struct {
+	Name      string // entry name
+	FromState string // previous status
+	ToState   string // new status
+}
+
+// backoffBase is the base duration for exponential backoff.
+// Each failure doubles: 1h, 2h, 4h, 8h, ... capped at maxBackoff.
+const backoffBase = 1 * time.Hour
+
+// maxBackoff caps the retry delay at 7 days.
+const maxBackoff = 7 * 24 * time.Hour
+
+// failureRecord mirrors blocker.FailureRecord but is local to avoid
+// coupling the two packages. Supports both legacy batch format and
+// per-recipe format.
+type failureRecord struct {
+	SchemaVersion int              `json:"schema_version"`
+	Ecosystem     string           `json:"ecosystem,omitempty"`
+	Failures      []packageFailure `json:"failures,omitempty"`
+	// Per-recipe format fields
+	Recipe    string   `json:"recipe,omitempty"`
+	Category  string   `json:"category,omitempty"`
+	BlockedBy []string `json:"blocked_by,omitempty"`
+}
+
+type packageFailure struct {
+	PackageID string   `json:"package_id"`
+	Category  string   `json:"category"`
+	BlockedBy []string `json:"blocked_by,omitempty"`
+}
+
+// LoadFailureMap reads all JSONL files in dir and builds a per-package
+// failure summary. Keys are bare package names (ecosystem prefix stripped).
+func LoadFailureMap(dir string) (map[string]*PackageFailureSummary, error) {
+	pattern := filepath.Join(dir, "*.jsonl")
+	files, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("glob failures: %w", err)
+	}
+
+	result := make(map[string]*PackageFailureSummary)
+	for _, path := range files {
+		if err := loadFailuresFromFile(path, result); err != nil {
+			continue // skip files that can't be read
+		}
+	}
+	return result, nil
+}
+
+// loadFailuresFromFile reads a single JSONL file and populates the summary map.
+func loadFailuresFromFile(path string, summaries map[string]*PackageFailureSummary) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1<<20) // 1MB max line
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var record failureRecord
+		if err := json.Unmarshal(line, &record); err != nil {
+			continue // skip malformed lines
+		}
+
+		// Legacy batch format: failures array
+		for _, f := range record.Failures {
+			name := bareName(f.PackageID)
+			addFailure(summaries, name, f.Category, f.BlockedBy)
+		}
+
+		// Per-recipe format
+		if record.Recipe != "" && record.Category != "" {
+			addFailure(summaries, record.Recipe, record.Category, record.BlockedBy)
+		}
+	}
+
+	return scanner.Err()
+}
+
+// addFailure records a single failure for a package in the summary map.
+func addFailure(summaries map[string]*PackageFailureSummary, name, category string, blockedBy []string) {
+	s, ok := summaries[name]
+	if !ok {
+		s = &PackageFailureSummary{}
+		summaries[name] = s
+	}
+
+	s.TotalFailures++
+
+	if category == "missing_dep" {
+		s.HasMissingDep = true
+		for _, dep := range blockedBy {
+			if !containsString(s.BlockedBy, dep) {
+				s.BlockedBy = append(s.BlockedBy, dep)
+			}
+		}
+	} else {
+		s.HasOtherFailure = true
+	}
+}
+
+// Run reads failure data and updates queue entry statuses. It performs two
+// operations:
+//
+//  1. Mark new failures: pending entries with more failures in JSONL than
+//     their failure_count get set to failed or blocked.
+//  2. Expire backoffs: failed entries whose next_retry_at has passed get
+//     flipped back to pending.
+//
+// It modifies the queue in place. The caller handles I/O.
+func Run(queue *batch.UnifiedQueue, failuresDir string) (*Result, error) {
+	failureMap, err := LoadFailureMap(failuresDir)
+	if err != nil {
+		return &Result{}, nil // no failure data is not an error
+	}
+
+	now := time.Now().UTC()
+	result := &Result{}
+
+	for i := range queue.Entries {
+		entry := &queue.Entries[i]
+
+		switch entry.Status {
+		case batch.StatusPending:
+			markPendingEntry(entry, failureMap, now, result)
+		case batch.StatusFailed:
+			expireBackoff(entry, now, result)
+		}
+	}
+
+	return result, nil
+}
+
+// markPendingEntry checks a pending entry against failure data and marks
+// it as failed or blocked if new failures exist.
+func markPendingEntry(entry *batch.QueueEntry, failureMap map[string]*PackageFailureSummary, now time.Time, result *Result) {
+	summary, ok := failureMap[entry.Name]
+	if !ok {
+		return // no failure data for this entry
+	}
+
+	// Only mark if there are new failures beyond what's already counted.
+	// This prevents the idempotency cycle: once marked and retried,
+	// the same failure data won't trigger re-marking.
+	if summary.TotalFailures <= entry.FailureCount {
+		return
+	}
+
+	entry.FailureCount = summary.TotalFailures
+
+	if summary.HasMissingDep && len(summary.BlockedBy) > 0 {
+		entry.Status = batch.StatusBlocked
+		result.MarkedBlocked++
+		result.Details = append(result.Details, Change{
+			Name:      entry.Name,
+			FromState: batch.StatusPending,
+			ToState:   batch.StatusBlocked,
+		})
+	} else {
+		entry.Status = batch.StatusFailed
+		retryAt := computeRetryAt(now, entry.FailureCount)
+		entry.NextRetryAt = &retryAt
+		result.MarkedFailed++
+		result.Details = append(result.Details, Change{
+			Name:      entry.Name,
+			FromState: batch.StatusPending,
+			ToState:   batch.StatusFailed,
+		})
+	}
+}
+
+// expireBackoff flips a failed entry back to pending if its backoff has expired.
+func expireBackoff(entry *batch.QueueEntry, now time.Time, result *Result) {
+	if entry.NextRetryAt != nil && entry.NextRetryAt.After(now) {
+		return // backoff still active
+	}
+
+	entry.Status = batch.StatusPending
+	result.Retried++
+	result.Details = append(result.Details, Change{
+		Name:      entry.Name,
+		FromState: batch.StatusFailed,
+		ToState:   batch.StatusPending,
+	})
+}
+
+// computeRetryAt returns the next retry time using exponential backoff.
+// Formula: now + min(base * 2^(failures-1), maxBackoff)
+func computeRetryAt(now time.Time, failureCount int) time.Time {
+	exp := failureCount - 1
+	if exp < 0 {
+		exp = 0
+	}
+	delay := time.Duration(float64(backoffBase) * math.Pow(2, float64(exp)))
+	if delay > maxBackoff {
+		delay = maxBackoff
+	}
+	return now.Add(delay)
+}
+
+// bareName extracts the bare name from a fully-qualified package ID.
+// For "homebrew:ffmpeg" it returns "ffmpeg". For "ffmpeg" it returns "ffmpeg".
+func bareName(pkgID string) string {
+	if idx := strings.Index(pkgID, ":"); idx >= 0 {
+		return pkgID[idx+1:]
+	}
+	return pkgID
+}
+
+// containsString reports whether s is in the slice.
+func containsString(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/markfailures/markfailures_test.go
+++ b/internal/markfailures/markfailures_test.go
@@ -1,0 +1,340 @@
+package markfailures
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tsukumogami/tsuku/internal/batch"
+)
+
+func TestLoadFailureMap_LegacyBatchFormat(t *testing.T) {
+	dir := t.TempDir()
+	content := `{"schema_version":1,"ecosystem":"homebrew","failures":[{"package_id":"homebrew:neovim","category":"missing_dep","blocked_by":["tree-sitter","luv"]},{"package_id":"homebrew:tmux","category":"install_failed"}]}`
+	writeJSONL(t, dir, "homebrew-2026-01-01T00-00-00Z.jsonl", content)
+
+	fm, err := LoadFailureMap(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// neovim: missing_dep with blocked_by
+	neo, ok := fm["neovim"]
+	if !ok {
+		t.Fatal("expected neovim in failure map")
+	}
+	if neo.TotalFailures != 1 {
+		t.Errorf("neovim.TotalFailures = %d, want 1", neo.TotalFailures)
+	}
+	if !neo.HasMissingDep {
+		t.Error("neovim.HasMissingDep should be true")
+	}
+	if len(neo.BlockedBy) != 2 {
+		t.Errorf("neovim.BlockedBy = %v, want [tree-sitter luv]", neo.BlockedBy)
+	}
+
+	// tmux: install_failed
+	tmux, ok := fm["tmux"]
+	if !ok {
+		t.Fatal("expected tmux in failure map")
+	}
+	if tmux.TotalFailures != 1 {
+		t.Errorf("tmux.TotalFailures = %d, want 1", tmux.TotalFailures)
+	}
+	if !tmux.HasOtherFailure {
+		t.Error("tmux.HasOtherFailure should be true")
+	}
+	if tmux.HasMissingDep {
+		t.Error("tmux.HasMissingDep should be false")
+	}
+}
+
+func TestLoadFailureMap_PerRecipeFormat(t *testing.T) {
+	dir := t.TempDir()
+	lines := `{"schema_version":1,"recipe":"gitui","platform":"darwin-arm64","category":"generation_failed"}
+{"schema_version":1,"recipe":"gitui","platform":"darwin-x86_64","category":"generation_failed"}`
+	writeJSONL(t, dir, "batch-2026-01-01T00-00-00Z.jsonl", lines)
+
+	fm, err := LoadFailureMap(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gitui, ok := fm["gitui"]
+	if !ok {
+		t.Fatal("expected gitui in failure map")
+	}
+	if gitui.TotalFailures != 2 {
+		t.Errorf("gitui.TotalFailures = %d, want 2", gitui.TotalFailures)
+	}
+	if !gitui.HasOtherFailure {
+		t.Error("gitui.HasOtherFailure should be true")
+	}
+}
+
+func TestLoadFailureMap_MultipleFiles(t *testing.T) {
+	dir := t.TempDir()
+	// Two separate batch runs, same package
+	writeJSONL(t, dir, "homebrew-run1.jsonl",
+		`{"schema_version":1,"ecosystem":"homebrew","failures":[{"package_id":"homebrew:ffmpeg","category":"install_failed"}]}`)
+	writeJSONL(t, dir, "homebrew-run2.jsonl",
+		`{"schema_version":1,"ecosystem":"homebrew","failures":[{"package_id":"homebrew:ffmpeg","category":"install_failed"}]}`)
+
+	fm, err := LoadFailureMap(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ff := fm["ffmpeg"]
+	if ff == nil {
+		t.Fatal("expected ffmpeg in failure map")
+	}
+	if ff.TotalFailures != 2 {
+		t.Errorf("ffmpeg.TotalFailures = %d, want 2", ff.TotalFailures)
+	}
+}
+
+func TestLoadFailureMap_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	fm, err := LoadFailureMap(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(fm) != 0 {
+		t.Errorf("expected empty map, got %d entries", len(fm))
+	}
+}
+
+func TestLoadFailureMap_DeduplicatesBlockedBy(t *testing.T) {
+	dir := t.TempDir()
+	// Same blocked_by dep appears in two records
+	writeJSONL(t, dir, "f1.jsonl",
+		`{"schema_version":1,"ecosystem":"homebrew","failures":[{"package_id":"homebrew:vim","category":"missing_dep","blocked_by":["python@3.14"]}]}`)
+	writeJSONL(t, dir, "f2.jsonl",
+		`{"schema_version":1,"ecosystem":"homebrew","failures":[{"package_id":"homebrew:vim","category":"missing_dep","blocked_by":["python@3.14"]}]}`)
+
+	fm, err := LoadFailureMap(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	vim := fm["vim"]
+	if vim == nil {
+		t.Fatal("expected vim in failure map")
+	}
+	if len(vim.BlockedBy) != 1 {
+		t.Errorf("vim.BlockedBy = %v, want [python@3.14]", vim.BlockedBy)
+	}
+}
+
+func TestRun_MarkPendingAsFailed(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONL(t, dir, "f.jsonl",
+		`{"schema_version":1,"ecosystem":"homebrew","failures":[{"package_id":"homebrew:tmux","category":"install_failed"}]}`)
+
+	queue := &batch.UnifiedQueue{
+		Entries: []batch.QueueEntry{
+			{Name: "tmux", Source: "homebrew:tmux", Priority: 2, Status: batch.StatusPending, Confidence: "auto", FailureCount: 0},
+		},
+	}
+
+	result, err := Run(queue, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.MarkedFailed != 1 {
+		t.Errorf("MarkedFailed = %d, want 1", result.MarkedFailed)
+	}
+	if queue.Entries[0].Status != batch.StatusFailed {
+		t.Errorf("status = %s, want failed", queue.Entries[0].Status)
+	}
+	if queue.Entries[0].FailureCount != 1 {
+		t.Errorf("failure_count = %d, want 1", queue.Entries[0].FailureCount)
+	}
+	if queue.Entries[0].NextRetryAt == nil {
+		t.Error("next_retry_at should be set")
+	}
+}
+
+func TestRun_MarkPendingAsBlocked(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONL(t, dir, "f.jsonl",
+		`{"schema_version":1,"ecosystem":"homebrew","failures":[{"package_id":"homebrew:neovim","category":"missing_dep","blocked_by":["tree-sitter"]}]}`)
+
+	queue := &batch.UnifiedQueue{
+		Entries: []batch.QueueEntry{
+			{Name: "neovim", Source: "homebrew:neovim", Priority: 1, Status: batch.StatusPending, Confidence: "auto", FailureCount: 0},
+		},
+	}
+
+	result, err := Run(queue, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.MarkedBlocked != 1 {
+		t.Errorf("MarkedBlocked = %d, want 1", result.MarkedBlocked)
+	}
+	if queue.Entries[0].Status != batch.StatusBlocked {
+		t.Errorf("status = %s, want blocked", queue.Entries[0].Status)
+	}
+}
+
+func TestRun_ExpireBackoff(t *testing.T) {
+	dir := t.TempDir()
+	// No failure data needed for expiry test, but we need at least an
+	// empty dir (LoadFailureMap returns empty map on no files)
+
+	pastTime := time.Now().Add(-2 * time.Hour)
+	queue := &batch.UnifiedQueue{
+		Entries: []batch.QueueEntry{
+			{Name: "tmux", Source: "homebrew:tmux", Priority: 2, Status: batch.StatusFailed, Confidence: "auto", FailureCount: 1, NextRetryAt: &pastTime},
+		},
+	}
+
+	result, err := Run(queue, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Retried != 1 {
+		t.Errorf("Retried = %d, want 1", result.Retried)
+	}
+	if queue.Entries[0].Status != batch.StatusPending {
+		t.Errorf("status = %s, want pending", queue.Entries[0].Status)
+	}
+}
+
+func TestRun_DoNotExpireActiveBackoff(t *testing.T) {
+	dir := t.TempDir()
+
+	futureTime := time.Now().Add(24 * time.Hour)
+	queue := &batch.UnifiedQueue{
+		Entries: []batch.QueueEntry{
+			{Name: "tmux", Source: "homebrew:tmux", Priority: 2, Status: batch.StatusFailed, Confidence: "auto", FailureCount: 1, NextRetryAt: &futureTime},
+		},
+	}
+
+	result, err := Run(queue, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Retried != 0 {
+		t.Errorf("Retried = %d, want 0", result.Retried)
+	}
+	if queue.Entries[0].Status != batch.StatusFailed {
+		t.Errorf("status = %s, want failed", queue.Entries[0].Status)
+	}
+}
+
+func TestRun_Idempotency(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONL(t, dir, "f.jsonl",
+		`{"schema_version":1,"ecosystem":"homebrew","failures":[{"package_id":"homebrew:tmux","category":"install_failed"}]}`)
+
+	// Entry already has failure_count matching JSONL data
+	queue := &batch.UnifiedQueue{
+		Entries: []batch.QueueEntry{
+			{Name: "tmux", Source: "homebrew:tmux", Priority: 2, Status: batch.StatusPending, Confidence: "auto", FailureCount: 1},
+		},
+	}
+
+	result, err := Run(queue, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should NOT be re-marked because failure_count already matches
+	if result.MarkedFailed != 0 {
+		t.Errorf("MarkedFailed = %d, want 0 (idempotency)", result.MarkedFailed)
+	}
+	if queue.Entries[0].Status != batch.StatusPending {
+		t.Errorf("status = %s, want pending (unchanged)", queue.Entries[0].Status)
+	}
+}
+
+func TestRun_SkipsSuccessEntries(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONL(t, dir, "f.jsonl",
+		`{"schema_version":1,"ecosystem":"homebrew","failures":[{"package_id":"homebrew:wget","category":"install_failed"}]}`)
+
+	queue := &batch.UnifiedQueue{
+		Entries: []batch.QueueEntry{
+			{Name: "wget", Source: "homebrew:wget", Priority: 2, Status: batch.StatusSuccess, Confidence: "auto", FailureCount: 0},
+		},
+	}
+
+	result, err := Run(queue, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.MarkedFailed != 0 {
+		t.Errorf("MarkedFailed = %d, want 0", result.MarkedFailed)
+	}
+	if queue.Entries[0].Status != batch.StatusSuccess {
+		t.Errorf("status = %s, want success (unchanged)", queue.Entries[0].Status)
+	}
+}
+
+func TestRun_MixedFailuresPreferBlocked(t *testing.T) {
+	dir := t.TempDir()
+	// Package has both missing_dep and install_failed. Missing_dep with
+	// blocked_by takes precedence.
+	writeJSONL(t, dir, "f.jsonl",
+		`{"schema_version":1,"ecosystem":"homebrew","failures":[{"package_id":"homebrew:vim","category":"missing_dep","blocked_by":["python@3.14"]},{"package_id":"homebrew:vim","category":"install_failed"}]}`)
+
+	queue := &batch.UnifiedQueue{
+		Entries: []batch.QueueEntry{
+			{Name: "vim", Source: "homebrew:vim", Priority: 1, Status: batch.StatusPending, Confidence: "auto", FailureCount: 0},
+		},
+	}
+
+	result, err := Run(queue, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should be blocked, not failed, because missing_dep takes precedence
+	if result.MarkedBlocked != 1 {
+		t.Errorf("MarkedBlocked = %d, want 1", result.MarkedBlocked)
+	}
+	if queue.Entries[0].Status != batch.StatusBlocked {
+		t.Errorf("status = %s, want blocked", queue.Entries[0].Status)
+	}
+}
+
+func TestComputeRetryAt(t *testing.T) {
+	now := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		failures int
+		wantDur  time.Duration
+	}{
+		{1, 1 * time.Hour},       // 2^0 = 1h
+		{2, 2 * time.Hour},       // 2^1 = 2h
+		{3, 4 * time.Hour},       // 2^2 = 4h
+		{5, 16 * time.Hour},      // 2^4 = 16h
+		{20, 7 * 24 * time.Hour}, // capped at 7 days
+	}
+
+	for _, tt := range tests {
+		got := computeRetryAt(now, tt.failures)
+		want := now.Add(tt.wantDur)
+		if !got.Equal(want) {
+			t.Errorf("computeRetryAt(now, %d) = %v, want %v (delta %v)",
+				tt.failures, got, want, got.Sub(want))
+		}
+	}
+}
+
+func writeJSONL(t *testing.T, dir, name, content string) {
+	t.Helper()
+	err := os.WriteFile(filepath.Join(dir, name), []byte(content+"\n"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Add `internal/markfailures/` package that reads failure JSONL data and
updates queue entry statuses: pending to failed for install/generation
failures, pending to blocked for missing_dep failures, and failed back
to pending when exponential backoff expires. Integrate as step 1 in
`queue-maintain` (before requeue and reorder), with `--skip-mark-failures`
flag. Include `data/failures/` in batch-generate persist step so failure
data reaches main when zero recipes pass, and expand update-queue-status
path triggers to fire on failure data changes. Add Decision 5 (Failure
Status Propagation) to DESIGN-requeue-on-recipe-merge.md.

---

## What This Accomplishes

The pipeline dashboard shows 0 failed and 0 blocked entries despite
hundreds of packages failing every batch run. The single-writer design
(Decision 4) correctly keeps batch-generate from committing queue
changes, but nothing translates failure JSONL ground truth into queue
statuses on main. The mark-failures step fills this gap while preserving
single-writer: all queue writes still flow through update-queue-status.yml.

After this change, running queue-maintain on the current data marks
21 entries as failed, 14 as blocked (9 net after requeue resolves
dependencies).

## Implementation Notes

Idempotency uses `total_failures_in_jsonl > entry.failure_count`: once
an entry is marked failed with count=N and later retried (flipped to
pending), it won't be re-marked unless new failure JSONL records appear.
Running queue-maintain twice on the same data produces zero changes on
the second run.

## Test Plan

- [x] 13 unit tests covering both JSONL formats, all status transitions, idempotency, backoff
- [x] Dry-run on real queue data: 21 failed, 14 blocked, 5 requeued
- [x] Second dry-run confirms idempotency (0 changes)
- [ ] CI passes
- [ ] After merge: dashboard shows non-zero failed/blocked counts