### PR TITLE
fix: allow underscores in recipe filenames

### DIFF
--- a/scripts/generate-registry.py
+++ b/scripts/generate-registry.py
@@ -29,7 +29,7 @@ OUTPUT_DIR = Path("_site")
 OUTPUT_FILE = OUTPUT_DIR / "recipes.json"
 
 # Validation patterns
-NAME_PATTERN = re.compile(r"^[a-z0-9@.-]+$")
+NAME_PATTERN = re.compile(r"^[a-z0-9@._-]+$")
 ECOSYSTEM_PATTERN = re.compile(r"^[a-z][a-z0-9-]*$")
 # Accept paths from registry (recipes/<letter>/<name>.toml) or embedded (internal/recipe/recipes/<name>.toml)
 PATH_PATTERN = re.compile(r"^(recipes/[a-z]/[a-z0-9@._-]+\.toml|internal/recipe/recipes/[a-z0-9@._-]+\.toml)$")


### PR DESCRIPTION
Add underscore to the PATH_PATTERN regex in generate-registry.py.
The batch pipeline recently added `hdrhistogram_c.toml` which has an
underscore in its name. The validation pattern only allowed `[a-z0-9@.-]`,
rejecting the file and blocking Deploy Website.

---

## What This Fixes

Deploy Website has been failing since `hdrhistogram_c.toml` landed on
main. The generate-registry.py path validator rejects underscores in
recipe filenames, but Homebrew formula names can contain them.