### PR TITLE
feat(recipes): add mlx-c recipe

### DIFF
--- a/recipes/m/mlx-c.toml
+++ b/recipes/m/mlx-c.toml
@@ -1,0 +1,33 @@
+[metadata]
+  name = "mlx-c"
+  description = "C API for MLX"
+  homepage = "https://ml-explore.github.io/mlx-c"
+  version_format = ""
+  requires_sudo = false
+  tier = 0
+  type = "library"
+  llm_validation = "skipped"
+  unsupported_platforms = ["darwin/amd64", "linux/arm64", "linux/amd64"]
+
+[version]
+  source = "homebrew"
+  formula = "mlx-c"
+
+[[steps]]
+  action = "homebrew"
+  formula = "mlx-c"
+  [steps.when]
+    os = ["darwin"]
+    arch = ["arm64"]
+
+[[steps]]
+  action = "install_binaries"
+  install_mode = "directory"
+  outputs = ["lib/libmlxc.dylib", "include/mlx/c/mlx.h", "include/mlx/c/array.h", "include/mlx/c/closure.h", "include/mlx/c/compile.h", "include/mlx/c/cuda.h", "include/mlx/c/device.h", "include/mlx/c/distributed.h", "include/mlx/c/distributed_group.h", "include/mlx/c/error.h", "include/mlx/c/export.h", "include/mlx/c/fast.h", "include/mlx/c/fft.h", "include/mlx/c/half.h", "include/mlx/c/io.h", "include/mlx/c/io_types.h", "include/mlx/c/linalg.h", "include/mlx/c/map.h", "include/mlx/c/memory.h", "include/mlx/c/metal.h", "include/mlx/c/ops.h", "include/mlx/c/optional.h", "include/mlx/c/random.h", "include/mlx/c/stream.h", "include/mlx/c/string.h", "include/mlx/c/transforms.h", "include/mlx/c/transforms_impl.h", "include/mlx/c/vector.h", "include/mlx/c/version.h"]
+  [steps.when]
+    os = ["darwin"]
+    arch = ["arm64"]
+
+[verify]
+  command = "test -f lib/libmlxc.dylib"
+  pattern = ""


### PR DESCRIPTION
Add recipe for mlx-c (C API for Apple's MLX framework). macOS ARM64
only -- the formula has no Linux or x86_64 bottles. Library type with
headers and a single shared library.

---

## What This Accomplishes

Unblocks ollama in the batch pipeline queue. Ollama is currently
`blocked` because its Homebrew formula depends on mlx-c, which had no
recipe. Once this merges and update-queue-status marks mlx-c as
`success`, the requeue step in queue-maintain will flip ollama from
`blocked` to `pending`.