### PR TITLE
fix(ci): use GitHub App token for batch-operations push

### DIFF
--- a/.github/workflows/batch-operations.yml
+++ b/.github/workflows/batch-operations.yml
@@ -7,6 +7,9 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 concurrency:
   group: batch-control
   cancel-in-progress: false
@@ -45,9 +48,16 @@ jobs:
     if: needs.pre-flight.outputs.can_proceed == 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2.2.1
+        with:
+          app-id: ${{ secrets.TSUKU_BATCH_GENERATOR_APP_ID }}
+          private-key: ${{ secrets.TSUKU_BATCH_GENERATOR_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Check circuit breaker
         id: breaker


### PR DESCRIPTION
The batch-operations workflow uses `secrets.GITHUB_TOKEN` for checkout,
which lacks push permission to main under branch protection. The "Persist
control file" step has failed with a 403 on every run for 10+ days,
preventing circuit breaker state updates from being committed. All six
ecosystem circuit breakers are stuck open as a result.

Other workflows that push to main (update-dashboard, update-queue-status)
use a GitHub App token via `actions/create-github-app-token`. This change
matches that pattern: add the app-token generation step, pass it to
checkout, and declare `contents: write` permissions.

---

## What This Fixes

The workflow computes breaker state updates correctly but the push always
fails:

```
remote: Permission to tsukumogami/tsuku.git denied to github-actions[bot].
fatal: unable to access '...': The requested URL returned error: 403
```

After this change, the checkout token has push access via the same GitHub
App used by update-dashboard and update-queue-status.

## Test Plan

- [ ] Merge and trigger a manual workflow_dispatch run of Batch Operations
- [ ] Verify "Persist control file" step succeeds (no 403)
- [ ] Confirm batch-control.json circuit breaker state updates on main