### PR TITLE
fix(blog): preserve link color for visited links in post body

### DIFF
--- a/website/assets/blog.css
+++ b/website/assets/blog.css
@@ -7,6 +7,7 @@
 .post-meta .author:hover { text-decoration: underline; }
 .post-content { margin-top: 2rem; line-height: 1.8; }
 .post-content a { color: var(--accent); text-decoration: none; }
+.post-content a:visited { color: var(--accent); }
 .post-content a:hover { text-decoration: underline; }
 .post-content h2 { margin-top: 2rem; margin-bottom: 1rem; }
 .post-content code { font-family: "SF Mono", Consolas, monospace; background: var(--code-bg); padding: 0.15rem 0.4rem; border-radius: 4px; }


### PR DESCRIPTION
Blog post links turn purple after being visited because `.post-content a`
lacks a `:visited` rule. The browser default overrides the accent color.
Add `.post-content a:visited { color: var(--accent); }` to keep links
consistent with the author link style.