### PR TITLE
fix(blog): reduce padding on mobile devices

### DIFF
--- a/website/assets/blog.css
+++ b/website/assets/blog.css
@@ -30,7 +30,7 @@
 
 /* Mobile */
 @media (max-width: 600px) {
-    .blog-post { padding: 1rem; }
+    .blog-post { padding: 0.5rem; }
     .blog-post h1 { font-size: 1.5rem; }
-    .blog-index { padding: 1rem; }
+    .blog-index { padding: 0.5rem; }
 }


### PR DESCRIPTION
Add a mobile breakpoint to blog.css at 600px (matching style.css) that
reduces `.blog-post` and `.blog-index` padding from 2rem to 1rem. The
2rem padding was stacking with the parent `<main>` element's own 2rem
padding, totaling 64px per side on narrow screens. Also scales down
the post title from 2rem to 1.5rem on mobile.

Desktop layout is unchanged.

---

Fixes #2112