### PR TITLE
fix(ci): trigger test workflow on recipe file changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
Add `recipes/**/*.toml` and `internal/recipe/recipes/**/*.toml` to the
top-level `on.push.paths` and `on.pull_request.paths` filters in the
test workflow. Previously only Go source files, test fixtures, and the
workflow file itself were listed, so recipe-only commits to main never
triggered the workflow. The badge stayed red until the nightly cron ran,
even when the underlying recipe issues were already fixed.

The job-level `dorny/paths-filter` already detects recipe changes and
routes them to `validate-recipes`. This change just ensures the workflow
starts in the first place.

---

Fixes #2114