### PR TITLE
fix: remove redundant github_repo from tsuku-dltest recipe

### DIFF
--- a/recipes/t/tsuku-dltest.toml
+++ b/recipes/t/tsuku-dltest.toml
@@ -7,7 +7,6 @@ homepage = "https://github.com/tsukumogami/tsuku"
 supported_libc = ["glibc"]
 
 [version]
-github_repo = "tsukumogami/tsuku"
 tag_prefix = "v"
 
 [[steps]]


### PR DESCRIPTION
Remove the redundant `github_repo = "tsukumogami/tsuku"` field from the
tsuku-dltest recipe's `[version]` section. The `github_file` step already
specifies `repo = "tsukumogami/tsuku"`, which the validator infers
automatically for version resolution.

---

## What This Fixes

Nightly `test.yml` runs recipe validation in `--strict` mode, where this
redundancy is treated as an error. The tsuku-dltest recipe was the only
failure (1417/1418 passed). Push-triggered runs skipped validation because
no recipe paths changed, so the Tests badge flipped between green (after
pushes) and red (after nightly runs).

## Test Plan

- [x] `tsuku validate --strict recipes/t/tsuku-dltest.toml` passes locally
- [ ] CI "Validate Recipes" job passes on this PR
- [ ] After merge, next nightly run stays green