### PR TITLE
fix(ci): install glslc for ARM64 Vulkan builds in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,7 +290,7 @@ jobs:
             sudo apt-get install -y vulkan-sdk
           else
             sudo apt-get update
-            sudo apt-get install -y libvulkan-dev spirv-tools glslang-tools
+            sudo apt-get install -y libvulkan-dev spirv-tools glslang-tools glslc
           fi
           echo "VULKAN_SDK=/usr" >> $GITHUB_ENV
 


### PR DESCRIPTION
Add the `glslc` package to the ARM64 Vulkan SDK install step in `release.yml`. The Lunarg PPA (x86_64-only) bundles `glslc` via `vulkan-sdk`, but the ARM64 fallback uses distro packages that don't include it. CMake's `FindVulkan` requires `glslc` when `GGML_VULKAN=ON`, so every `linux-arm64-vulkan` build has failed since the pipeline merge in v0.5.0.

---

## What This Fixes

The `linux-arm64-vulkan` build step fails during CMake configuration:

```
CMake Error: Could NOT find Vulkan (missing: glslc) (found version "1.3.275")
```

The x86_64 path installs `vulkan-sdk` from the Lunarg PPA which includes `glslc`. The ARM64 path installs `libvulkan-dev spirv-tools glslang-tools` -- but `glslang-tools` provides `glslangValidator`, not `glslc`. Adding the `glslc` package resolves this.

Fixes #2149