### PR TITLE
fix(llm): fix ARM64 link order for CUDA and Vulkan backends

### DIFF
--- a/tsuku-llm/build.rs
+++ b/tsuku-llm/build.rs
@@ -125,18 +125,23 @@ fn compile_llama_cpp() -> Result<(), Box<dyn std::error::Error>> {
             println!("cargo:rustc-link-search=native={}/lib64", cuda_path);
             println!("cargo:rustc-link-search=native={}/lib64/stubs", cuda_path);
         }
+        // ggml-cuda (static) must come before its dynamic dependencies so the
+        // single-pass linker sees the undefined CUDA symbols before processing
+        // the shared libraries that provide them.
+        println!("cargo:rustc-link-lib=static=ggml-cuda");
         println!("cargo:rustc-link-lib=cuda");
         println!("cargo:rustc-link-lib=cublas");
         println!("cargo:rustc-link-lib=culibos");
         println!("cargo:rustc-link-lib=cudart");
         println!("cargo:rustc-link-lib=cublasLt");
-        println!("cargo:rustc-link-lib=static=ggml-cuda");
     }
 
     #[cfg(feature = "vulkan")]
     {
-        println!("cargo:rustc-link-lib=vulkan");
+        // ggml-vulkan (static) must come before -lvulkan (dynamic) for the
+        // same single-pass linker ordering reason as CUDA above.
         println!("cargo:rustc-link-lib=static=ggml-vulkan");
+        println!("cargo:rustc-link-lib=vulkan");
     }
 
     // Rerun if llama.cpp sources change


### PR DESCRIPTION
Move static `ggml-cuda` and `ggml-vulkan` link directives before their dynamic dependencies (`-lcuda`, `-lvulkan`) in `build.rs`. The single-pass linker on Linux ARM64 processes libraries left-to-right: when `ggml-cuda` appears after `-lcuda`, the linker has already discarded the CUDA symbols by the time it encounters the references in the static library.

This caused `undefined reference to cudaGetLastError` and `undefined reference to vkGetInstanceProcAddr` on every ARM64 release build since the pipeline merge.

---

## What This Fixes

Both `linux-arm64-cuda` and `linux-arm64-vulkan` llm builds fail at link time with undefined CUDA/Vulkan symbol errors. The static backend libraries (`ggml-cuda`, `ggml-vulkan`) reference symbols from the dynamic CUDA/Vulkan libraries, but were listed after them in the linker command. x86_64 builds happened to work because the linker there is more lenient about ordering (or the library layout differs), but ARM64's `ld` strictly follows single-pass semantics.

Fixes #2149