### PR TITLE
chore(docs): archive completed plan documents

### DIFF
--- a/docs/plans/completed/PLAN-test-quality-cleanup.md
+++ b/docs/plans/completed/PLAN-test-quality-cleanup.md
@@ -1,6 +1,6 @@
 ---
 schema: plan/v1
-status: Active
+status: Completed
 execution_mode: single-pr
 issue_count: 10
 ---
@@ -9,7 +9,7 @@ issue_count: 10
 
 ## Status
 
-Active
+Completed
 
 ## Scope Summary
 

--- a/docs/plans/completed/PLAN-unified-release-versioning.md
+++ b/docs/plans/completed/PLAN-unified-release-versioning.md
@@ -1,6 +1,6 @@
 ---
 schema: plan/v1
-status: Active
+status: Completed
 execution_mode: multi-pr
 upstream: docs/designs/DESIGN-unified-release-versioning.md
 milestone: "Unified Release Versioning"
@@ -11,7 +11,7 @@ issue_count: 7
 
 ## Status
 
-Active
+Completed
 
 ## Scope Summary
 


### PR DESCRIPTION
Move three completed plan documents to docs/plans/completed/ and update
their frontmatter status from Active to Completed:

- PLAN-test-quality-cleanup (10/10 issues done)
- PLAN-unified-release-versioning (7/7 issues done)
- PLAN-code-coverage-75 (5/5 issues closed: #2131-#2135)

Also update the dependency graph in PLAN-code-coverage-75 to mark all
nodes as done.

---

## What This Accomplishes

Archives three fully completed plan documents to keep docs/plans/ focused
on active work. Introduces docs/plans/completed/ as the destination for
finished plans.