### PR TITLE
chore(docs): archive PLAN-code-coverage-75 as completed

### DIFF
--- a/docs/plans/completed/PLAN-code-coverage-75.md
+++ b/docs/plans/completed/PLAN-code-coverage-75.md
@@ -1,6 +1,6 @@
 ---
 schema: plan/v1
-status: Active
+status: Completed
 execution_mode: multi-pr
 milestone: "Code Coverage 75%"
 issue_count: 5
@@ -10,7 +10,7 @@ issue_count: 5
 
 ## Status
 
-Active
+Completed
 
 ## Scope Summary
 
@@ -60,8 +60,7 @@ graph TD
     classDef ready fill:#bbdefb
     classDef blocked fill:#fff9c4
 
-    class I2131,I2132,I2133,I2134 ready
-    class I2135 blocked
+    class I2131,I2132,I2133,I2134,I2135 done
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked


### PR DESCRIPTION
Mark PLAN-code-coverage-75 as Completed and move it to
docs/plans/completed/. All 5 issues (#2131-#2135) are closed. Update
the dependency graph to mark all nodes as done.

---

## What This Accomplishes

Archives the last completed plan document, keeping docs/plans/ focused
on active work. Only PLAN-registry-versioning (Draft) remains.