### PR TITLE
fix(install): reject path traversal in parseDistributedName

### DIFF
--- a/cmd/tsuku/install_distributed.go
+++ b/cmd/tsuku/install_distributed.go
@@ -32,8 +32,15 @@ type distributedInstallArgs struct {
 //   - owner/repo:recipe@version   -> source=owner/repo, recipe=recipe, version=version
 //
 // Returns nil if the name doesn't contain "/" (not a distributed name).
+// Also returns nil for path traversal patterns (e.g. ../etc/passwd) so they
+// fall through to the regular recipe lookup path and produce a not-found error.
 func parseDistributedName(name string) *distributedInstallArgs {
 	if !strings.Contains(name, "/") {
+		return nil
+	}
+
+	// Reject path traversal attempts before treating the name as owner/repo.
+	if strings.Contains(name, "..") {
 		return nil
 	}
 

--- a/cmd/tsuku/install_distributed_test.go
+++ b/cmd/tsuku/install_distributed_test.go
@@ -71,6 +71,16 @@ func TestParseDistributedName(t *testing.T) {
 			wantRecipe: "toolbox",
 			wantVer:    "3.14.159",
 		},
+		{
+			name:    "path traversal",
+			input:   "../etc/passwd",
+			wantNil: true,
+		},
+		{
+			name:    "path traversal with extra segments",
+			input:   "../../etc/shadow",
+			wantNil: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Add an early guard in `parseDistributedName` that returns `nil` for any name
containing `..`. Previously, names like `../etc/passwd` were parsed as
distributed install targets because they contain `/`, sending them down the
distributed source validation path rather than the regular recipe lookup path.

---

## What This Fixes

`parseDistributedName` checked only for the presence of `/` to decide whether
a tool name was a distributed reference. This caused path traversal patterns
like `../etc/passwd` to be parsed as `owner=".."`, `repo="etc/passwd"`. The
subsequent call to `validateRegistrySource` rejected the name with "invalid
owner name in URL" (exit 1) instead of falling through to recipe lookup, which
produces "could not find" (exit 3).

The fix returns `nil` early for names containing `..`, treating them as plain
tool names. The existing `validateRegistrySource` check remains as a
defence-in-depth layer for names that do reach the distributed path.

## Changes

- `cmd/tsuku/install_distributed.go`: add `..` guard in `parseDistributedName`
- `cmd/tsuku/install_distributed_test.go`: add path traversal cases to `TestParseDistributedName`