### PR TITLE
fix(distributed): pass version constraint to plan generator

### DIFF
--- a/cmd/tsuku/install.go
+++ b/cmd/tsuku/install.go
@@ -242,8 +242,7 @@ Test installation in a sandbox container:
 				// in installWithDependencies can find it during the install flow.
 				loader.CacheRecipe(dArgs.RecipeName, r)
 
-				// Use opaque "distributed" tag for telemetry (never send owner/repo)
-				if err := runInstallWithTelemetry(dArgs.RecipeName, resolveVersion, "distributed", true, "", telemetryClient); err != nil {
+				if err := runInstallWithTelemetry(dArgs.RecipeName, resolveVersion, versionConstraint, true, "", telemetryClient); err != nil {
 					handleInstallError(err)
 				}
 


### PR DESCRIPTION
The distributed install path passed the literal string `"distributed"` as the `versionConstraint` argument to `runInstallWithTelemetry`. This string propagated into the plan generator's `VersionConstraint` field, causing version resolution to attempt to find a GitHub release tag named `"distributed"`, which never exists.

The fix passes the actual `versionConstraint` (`dArgs.Version`, which is `""` for latest or a semver string for pinned installs), so version resolution resolves the latest available release correctly.

Root cause: the comment read "Use opaque 'distributed' tag for telemetry (never send owner/repo)." The intent was reasonable (avoid sending owner/repo in telemetry), but `versionConstraint` is already safe — it's the user's version string (`""` or `"v0.1.0"`), not the `owner/repo` identifier. The `owner/repo` is never passed to the telemetry event regardless.

---

Fixes #2165

Closes the `PLAN-distributed-recipes` milestone's E2E validation gap: `tsuku install tsukumogami/koto -y` now resolves and installs successfully.