### PR TITLE
fix(hook): use TSUKU_HOME fallback in rc file source line

### DIFF
--- a/docs/GUIDE-command-not-found.md
+++ b/docs/GUIDE-command-not-found.md
@@ -118,7 +118,7 @@ If you uninstall tsuku entirely, run `tsuku hook uninstall` first to clean up th
 
 ```
 # tsuku hook
-. "$TSUKU_HOME/share/hooks/tsuku.bash"
+. "${TSUKU_HOME:-$HOME/.tsuku}/share/hooks/tsuku.bash"
 ```
 
 The comment line and the source line immediately after it are the only lines tsuku adds. Delete both.

--- a/internal/hook/install.go
+++ b/internal/hook/install.go
@@ -30,10 +30,10 @@ func rcFileForShell(shell, homeDir string) (string, error) {
 }
 
 // markerBlock returns the two-line block to insert into bash/zsh rc files.
-// The TSUKU_HOME variable reference is used in the source path so the line
-// works even if the user changes $TSUKU_HOME later.
+// Uses ${TSUKU_HOME:-$HOME/.tsuku} so the line works whether or not
+// TSUKU_HOME is exported. Matches the fallback pattern in $TSUKU_HOME/env.
 func markerBlock(shell string) string {
-	return markerComment + "\n" + `. "$TSUKU_HOME/share/hooks/tsuku.` + shell + `"`
+	return markerComment + "\n" + `. "${TSUKU_HOME:-$HOME/.tsuku}/share/hooks/tsuku.` + shell + `"`
 }
 
 // Install writes the hook files to shareHooksDir and registers the hook for

--- a/internal/hook/install_test.go
+++ b/internal/hook/install_test.go
@@ -37,7 +37,7 @@ func TestInstallBashMarkerInsertion(t *testing.T) {
 	if !strings.Contains(content, "# tsuku hook") {
 		t.Errorf(".bashrc missing marker comment; got:\n%s", content)
 	}
-	if !strings.Contains(content, `. "$TSUKU_HOME/share/hooks/tsuku.bash"`) {
+	if !strings.Contains(content, `. "${TSUKU_HOME:-$HOME/.tsuku}/share/hooks/tsuku.bash"`) {
 		t.Errorf(".bashrc missing source line; got:\n%s", content)
 	}
 }
@@ -62,7 +62,7 @@ func TestInstallZshMarkerInsertion(t *testing.T) {
 	if !strings.Contains(content, "# tsuku hook") {
 		t.Errorf(".zshrc missing marker comment; got:\n%s", content)
 	}
-	if !strings.Contains(content, `. "$TSUKU_HOME/share/hooks/tsuku.zsh"`) {
+	if !strings.Contains(content, `. "${TSUKU_HOME:-$HOME/.tsuku}/share/hooks/tsuku.zsh"`) {
 		t.Errorf(".zshrc missing source line; got:\n%s", content)
 	}
 }


### PR DESCRIPTION
The marker block written by `tsuku hook install` used `$TSUKU_HOME` in the
source line, but that variable isn't guaranteed to be exported. On systems
where it's unset, the source line resolves to an empty path and the hook
silently fails to load. Use `${TSUKU_HOME:-$HOME/.tsuku}` instead, matching
the fallback pattern already used in `$TSUKU_HOME/env`.

---

## What This Fixes

`tsuku hook install` appends a source line to `~/.bashrc` (or `~/.zshrc`):

```bash
. "$TSUKU_HOME/share/hooks/tsuku.bash"
```

Nothing in the default setup exports `TSUKU_HOME`. The env file at
`~/.tsuku/env` uses `${TSUKU_HOME:-$HOME/.tsuku}` as a fallback, but the
hook source line didn't. On a standard install, `$TSUKU_HOME` expands to
empty and the hook never loads — the shell's built-in command-not-found
handler runs instead.

After this fix, the source line becomes:

```bash
. "${TSUKU_HOME:-$HOME/.tsuku}/share/hooks/tsuku.bash"
```

## Changes

- `internal/hook/install.go`: Use fallback pattern in `markerBlock()`
- `internal/hook/install_test.go`: Update marker expectations
- `docs/GUIDE-command-not-found.md`: Update manual cleanup example