### PR TITLE
fix(release): adopt draft-aware upload pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,29 +48,44 @@ jobs:
             exit 1
           fi
 
-      - name: Run GoReleaser
+      - name: Run GoReleaser (build only)
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29  # v7.0.0
         with:
           distribution: goreleaser
           version: "~> v2"
-          args: release --clean
+          args: release --clean --skip=publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Update release with notes from tag
+      - name: Upload assets to draft release or create one
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${GITHUB_REF_NAME}"
-          # Fetch tag annotations (not included in checkout)
-          git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
-          # Extract full tag annotation message
-          git tag -l --format='%(contents)' "${TAG}" > /tmp/release-notes.md
-          echo "Release notes extracted:"
-          cat /tmp/release-notes.md
-          # Update the release body with our curated notes
-          gh release edit "$TAG" --notes-file /tmp/release-notes.md
-          echo "Updated release $TAG with release notes"
+          ASSETS=(
+            dist/tsuku-linux-amd64
+            dist/tsuku-linux-arm64
+            dist/tsuku-darwin-amd64
+            dist/tsuku-darwin-arm64
+            dist/checksums.txt
+          )
+
+          # Check if a draft release already exists (created by /release skill)
+          DRAFT=$(gh release view "$TAG" --json isDraft --jq '.isDraft' 2>/dev/null || echo "not_found")
+
+          if [ "$DRAFT" = "true" ]; then
+            echo "Draft release found for $TAG, uploading assets..."
+            gh release upload "$TAG" "${ASSETS[@]}" --clobber
+          else
+            echo "No draft release found, creating one..."
+            git fetch origin "refs/tags/${TAG}:refs/tags/${TAG}" --force
+            git tag -l --format='%(contents)' "${TAG}" > /tmp/release-notes.md
+            gh release create "$TAG" \
+              --draft \
+              --title "$TAG" \
+              --notes-file /tmp/release-notes.md \
+              "${ASSETS[@]}"
+          fi
 
   # Build Rust binary (tsuku-dltest) on native runners
   build-rust:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,12 +37,7 @@ changelog:
   disable: true
 
 release:
-  github:
-    owner: tsukumogami
-    name: tsuku
-  draft: true
-  make_latest: true
-  prerelease: auto
+  disable: true
 
 snapshot:
   version_template: "{{ incpatch .Version }}-next"

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -98,10 +98,13 @@ Calls shirabe's reusable release workflow, which:
 
 ### release.yml (step 2)
 
-Triggered by the tag push. Builds everything:
+Triggered by the tag push. Builds everything and uploads to the draft
+release. If a draft already exists (created by `/release` in step 1),
+assets are uploaded to it. Otherwise, a new draft is created from the
+tag annotation.
 
-- **Go binary** -- goreleaser creates the draft release and uploads 4
-  platform binaries with partial checksums
+- **Go binary** -- goreleaser builds 4 platform binaries (publish
+  disabled; a separate step uploads assets to the draft)
 - **tsuku-dltest** -- Rust binary built on native runners (4 glibc + 2 musl)
 - **tsuku-llm** -- Rust binary with GPU backends (2 macOS + 4 Linux)
 - **Integration tests** -- validates binaries on each platform


### PR DESCRIPTION
Disable goreleaser's release creation and replace it with a draft-aware
upload step that checks for an existing draft before creating one. When
the `/release` skill pre-creates a draft with release notes, goreleaser
now uploads to it instead of creating a duplicate.

Changes:
- `.goreleaser.yaml`: set `release.disable: true`
- `release.yml`: add `--skip=publish` to goreleaser, replace release
  creation + notes step with draft-aware upload (matches niwa/koto pattern)
- `docs/guides/releasing.md`: updated step 2 description

---

Root cause: v0.7.0 release had duplicate drafts because both `/release`
(Phase 4) and goreleaser created separate drafts for the same tag.
Integration tests downloaded from the wrong one (no assets), causing
exit 127 on all platforms.