### PR TITLE
fix(test): update functional test for tsuku install no-args

### DIFF
--- a/test/functional/features/error-handling.feature
+++ b/test/functional/features/error-handling.feature
@@ -22,11 +22,12 @@ Feature: Error handling
     When I run "tsuku create sometool --from invalidsource"
     Then the exit code is 2
 
-  Scenario: Install with no arguments
-    # See #2121
+  Scenario: Install with no arguments and no project config
+    # tsuku install (no args) reads .tsuku.toml for project tools (#2175).
+    # Without a config file, it errors with a helpful message.
     When I run "tsuku install"
     Then the exit code is not 0
-    And the error output contains "requires at least 1 arg"
+    And the error output contains "no .tsuku.toml found"
 
   Scenario: Nonexistent plan file
     When I run "tsuku install --plan /nonexistent/path.json"


### PR DESCRIPTION
Update the error-handling functional test for the new `tsuku install`
no-args behavior introduced in #2175. The command now reads `.tsuku.toml`
for project tools instead of requiring a tool name argument, so the
expected error changes from "requires at least 1 arg" to "no .tsuku.toml
found".

---

Fixes the failing Functional Tests check on main since #2175 merged.