### PR TITLE
fix(executor): skip post-install phase steps in ExecutePlan main loop

### DIFF
--- a/cmd/tsuku/plan_install.go
+++ b/cmd/tsuku/plan_install.go
@@ -9,6 +9,7 @@ import (
 	"github.com/tsukumogami/tsuku/internal/executor"
 	"github.com/tsukumogami/tsuku/internal/install"
 	"github.com/tsukumogami/tsuku/internal/recipe"
+	"github.com/tsukumogami/tsuku/internal/shellenv"
 )
 
 // runPlanBasedInstall installs a tool from an external plan file or stdin.
@@ -100,6 +101,31 @@ func runPlanBasedInstall(planPath, toolName string) error {
 		// Install to permanent location
 		if err := mgr.InstallWithOptions(effectiveToolName, plan.Version, exec.WorkDir(), installOpts); err != nil {
 			return fmt.Errorf("failed to install to permanent location: %w", err)
+		}
+
+		// Execute post-install phase (e.g., install_shell_init).
+		// The ToolInstallDir must point to the final installed location so
+		// source_command can find the tool's binary.
+		exec.SetToolInstallDir(cfg.ToolDir(effectiveToolName, plan.Version))
+		if err := exec.ExecutePhase(globalCtx, plan, "post-install"); err != nil {
+			printInfof("Warning: post-install phase failed: %v\n", err)
+		}
+
+		// Collect cleanup actions recorded by post-install actions and
+		// rebuild shell caches for any shells that were written to.
+		postInstallCleanup := exec.GetCleanupActions()
+		if len(postInstallCleanup) > 0 {
+			affectedShells := make(map[string]bool)
+			for _, ca := range postInstallCleanup {
+				if shell := install.ShellFromCleanupPath(ca.Path); shell != "" {
+					affectedShells[shell] = true
+				}
+			}
+			for shell := range affectedShells {
+				if err := shellenv.RebuildShellCache(cfg.HomeDir, shell); err != nil {
+					printInfof("Warning: failed to rebuild shell cache for %s: %v\n", shell, err)
+				}
+			}
 		}
 
 		// Update state to mark as explicit installation

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -448,11 +448,18 @@ func (e *Executor) ExecutePlan(ctx context.Context, plan *InstallationPlan) erro
 		}
 	}
 
-	// Execute each step (including flattened dependency steps)
+	// Execute each step (including flattened dependency steps).
+	// Post-install steps are skipped here — they run after SetToolInstallDir
+	// is called, via a separate ExecutePhase("post-install") call.
 	for i, step := range allSteps {
 		// Check for context cancellation
 		if err := ctx.Err(); err != nil {
 			return err
+		}
+
+		// Skip post-install steps — ToolInstallDir is not set yet.
+		if StepPhase(step) != "install" {
+			continue
 		}
 
 		fmt.Printf("Step %d/%d: %s\n", i+1, len(allSteps), step.Action)

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -1858,6 +1859,109 @@ func TestExecutor_SetToolInstallDir(t *testing.T) {
 	exec.SetToolInstallDir("/tools/mytool-1.0")
 	if exec.ctx.ToolInstallDir != "/tools/mytool-1.0" {
 		t.Errorf("expected ToolInstallDir = /tools/mytool-1.0, got %s", exec.ctx.ToolInstallDir)
+	}
+}
+
+// TestExecutePlan_SkipsPostInstallSteps verifies that ExecutePlan does not execute
+// steps tagged phase="post-install". Without this guard, install_shell_init with
+// source_command would fail because ToolInstallDir is not set during ExecutePlan.
+func TestExecutePlan_SkipsPostInstallSteps(t *testing.T) {
+	r := &recipe.Recipe{
+		Metadata: recipe.MetadataSection{Name: "test-tool"},
+	}
+
+	exec, err := New(r)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer exec.Cleanup()
+
+	exec.SetToolsDir(t.TempDir())
+
+	plan := &InstallationPlan{
+		FormatVersion: PlanFormatVersion,
+		Tool:          "test-tool",
+		Version:       "1.0.0",
+		Platform:      Platform{OS: runtime.GOOS, Arch: runtime.GOARCH},
+		Steps: []ResolvedStep{
+			{
+				Action: "install_shell_init",
+				Phase:  "post-install",
+				Params: map[string]interface{}{
+					"source_command": "test-tool shell-init {shell}",
+					"target":         "test-tool",
+				},
+			},
+		},
+	}
+
+	if err := exec.ExecutePlan(context.Background(), plan); err != nil {
+		t.Errorf("ExecutePlan() should skip post-install steps and succeed, got: %v", err)
+	}
+}
+
+// TestExecutePlan_TwoPhaseSequence verifies the full two-phase lifecycle:
+// ExecutePlan (install phase only) → SetToolInstallDir → ExecutePhase("post-install").
+// The post-install step must run after SetToolInstallDir so that shell init
+// files are written with the correct final install location.
+func TestExecutePlan_TwoPhaseSequence(t *testing.T) {
+	r := &recipe.Recipe{
+		Metadata: recipe.MetadataSection{Name: "test-tool"},
+	}
+
+	exec, err := New(r)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer exec.Cleanup()
+
+	// toolsDir parent becomes TSUKU_HOME for shell.d path derivation
+	tsukuHome := t.TempDir()
+	exec.SetToolsDir(filepath.Join(tsukuHome, "tools"))
+
+	// Place the source file in the executor's install dir (workDir/.install)
+	installDir := filepath.Join(exec.WorkDir(), ".install")
+	srcFile := filepath.Join(installDir, "init.sh")
+	if err := os.WriteFile(srcFile, []byte("# shell init\n"), 0644); err != nil {
+		t.Fatalf("failed to create source file: %v", err)
+	}
+
+	plan := &InstallationPlan{
+		FormatVersion: PlanFormatVersion,
+		Tool:          "test-tool",
+		Version:       "1.0.0",
+		Platform:      Platform{OS: runtime.GOOS, Arch: runtime.GOARCH},
+		Steps: []ResolvedStep{
+			{
+				Action: "install_shell_init",
+				Phase:  "post-install",
+				Params: map[string]interface{}{
+					"source_file": "init.sh",
+					"target":      "test-tool",
+					"shells":      []interface{}{"bash"},
+				},
+			},
+		},
+	}
+
+	// Phase 1: ExecutePlan must succeed even though post-install step is present.
+	if err := exec.ExecutePlan(context.Background(), plan); err != nil {
+		t.Fatalf("ExecutePlan() error = %v", err)
+	}
+
+	// Phase 2: SetToolInstallDir sets the final install location on the context.
+	finalInstallDir := filepath.Join(tsukuHome, "tools", "test-tool-1.0.0")
+	exec.SetToolInstallDir(finalInstallDir)
+
+	// Phase 3: ExecutePhase runs only the post-install steps.
+	if err := exec.ExecutePhase(context.Background(), plan, "post-install"); err != nil {
+		t.Fatalf("ExecutePhase(post-install) error = %v", err)
+	}
+
+	// Verify the shell init file was written to $TSUKU_HOME/share/shell.d/
+	shellDFile := filepath.Join(tsukuHome, "share", "shell.d", "test-tool.bash")
+	if _, err := os.Stat(shellDFile); os.IsNotExist(err) {
+		t.Errorf("expected shell init file at %s, but it does not exist", shellDFile)
 	}
 }
 


### PR DESCRIPTION
\`ExecutePlan\` iterated all plan steps unconditionally, running \`install_shell_init\` and \`install_completions\` steps tagged \`phase = \"post-install\"\` before \`ToolInstallDir\` was set. The security guard in \`shell_init.go\` correctly rejects this, causing every install and update of tools using \`source_command\` (niwa, koto) to fail. The fix adds a phase check in \`ExecutePlan\`'s execution loop to skip post-install steps; the preflight validation loop is intentionally left unfiltered so all steps are validated before execution begins.

Also fixes \`plan_install.go\` (used by \`--recipe\` and \`--plan\`), which was missing the post-install block entirely — after \`InstallWithOptions\` moved files to the permanent location, it never called \`SetToolInstallDir\` or \`ExecutePhase(\"post-install\")\`.

---

## What This Fixes

PR #2201 introduced the \`ExecutePlan → SetToolInstallDir → ExecutePhase(\"post-install\")\` lifecycle. \`ExecutePlan\` was meant to run only install-phase steps, with post-install steps deferred until \`SetToolInstallDir\` supplies the tool's final location. Instead it ran all steps, hitting the guard before \`ToolInstallDir\` was available.

\`plan_install.go\` had a separate gap: it never called \`SetToolInstallDir\` or \`ExecutePhase(\"post-install\")\` after \`InstallWithOptions\`, so tools installed via \`--recipe\` or \`--plan\` silently skipped all post-install steps.

## Changes

- \`internal/executor/executor.go\`: add \`StepPhase(step) != "install"\` guard in \`ExecutePlan\`'s execution loop
- \`cmd/tsuku/plan_install.go\`: add missing \`SetToolInstallDir\` + \`ExecutePhase("post-install")\` + shell cache rebuild after \`InstallWithOptions\`, mirroring \`install_deps.go\`
- \`internal/executor/executor_test.go\`: \`TestExecutePlan_SkipsPostInstallSteps\` and \`TestExecutePlan_TwoPhaseSequence\`

Fixes #2222, fixes #2218