### PR TITLE
feat(recipes): add cross-platform kubectl recipe

### DIFF
--- a/docs/designs/DESIGN-curated-recipes.md
+++ b/docs/designs/DESIGN-curated-recipes.md
@@ -631,8 +631,8 @@ Plan: [docs/plans/PLAN-curated-recipes.md](../plans/PLAN-curated-recipes.md)
 | ~~_Researches and ranks the top 100 most-used developer tools, categorizing each by coverage status (handcrafted, batch-generated, discovery-only, or missing)._~~ | | |
 | ~~[#2261: feat(recipes): add handcrafted recipes for claude and gemini-cli](https://github.com/tsukumogami/tsuku/issues/2261)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259)~~ | ~~testable~~ |
 | ~~_Adds `recipes/c/claude.toml` and `recipes/g/gemini.toml` using npm_install with glibc-only constraint, plus discovery entries for both tools._~~ | | |
-| [#2262: feat(recipes): add cross-platform kubectl recipe](https://github.com/tsukumogami/tsuku/issues/2262) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259) | testable |
-| _Replaces or supplements the existing kubectl recipe with a cross-platform version supporting Linux and macOS via direct download from the Kubernetes release server._ | | |
+| ~~[#2262: feat(recipes): add cross-platform kubectl recipe](https://github.com/tsukumogami/tsuku/issues/2262)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259)~~ | ~~testable~~ |
+| ~~_Replaces or supplements the existing kubectl recipe with a cross-platform version supporting Linux and macOS via direct download from the Kubernetes release server._~~ | | |
 | [#2263: feat(recipes): replace Linux-only helm recipe with cross-platform version](https://github.com/tsukumogami/tsuku/issues/2263) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259) | testable |
 | _Rewrites the helm recipe to download from official Helm GitHub releases for both Linux and macOS, replacing the Linux-only version._ | | |
 | [#2264: feat(recipes): add handcrafted recipes for bat, starship, and neovim](https://github.com/tsukumogami/tsuku/issues/2264) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259) | testable |
@@ -677,8 +677,8 @@ graph TD
     classDef ready fill:#bbdefb
     classDef blocked fill:#fff9c4
 
-    class I2259,I2260,I2261 done
-    class I2262,I2263,I2264,I2265,I2266,I2267 ready
+    class I2259,I2260,I2261,I2262 done
+    class I2263,I2264,I2265,I2266,I2267 ready
     class I2268 blocked
 ```
 

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -31,8 +31,8 @@ Introduce a `curated = true` flag for handcrafted recipes, nightly cross-platfor
 | ~~_Research and publish a prioritized list of the 100 most-used developer tools with current tsuku coverage status, to guide the recipe authoring order in backfill batches._~~ | | |
 | ~~[#2261: feat(recipes): add handcrafted recipes for claude and gemini-cli](https://github.com/tsukumogami/tsuku/issues/2261)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259)~~ | ~~testable~~ |
 | ~~_Ships `recipes/c/claude.toml` using `npm_install` with `@anthropic-ai/claude-code` and `recipes/g/gemini.toml` with `@google/gemini-cli`, each with a companion discovery entry that prevents the batch pipeline from resolving the wrong scoped package._~~ | | |
-| [#2262: feat(recipes): add cross-platform kubectl recipe](https://github.com/tsukumogami/tsuku/issues/2262) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259) | testable |
-| _Adds `recipes/k/kubectl.toml` using direct binary download from `dl.k8s.io` for linux/amd64, linux/arm64, darwin/amd64, and darwin/arm64 — additive alongside the existing Linux-only `kubernetes-cli.toml`._ | | |
+| ~~[#2262: feat(recipes): add cross-platform kubectl recipe](https://github.com/tsukumogami/tsuku/issues/2262)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259)~~ | ~~testable~~ |
+| ~~_Adds `recipes/k/kubectl.toml` using direct binary download from `dl.k8s.io` for linux/amd64, linux/arm64, darwin/amd64, and darwin/arm64 — additive alongside the existing Linux-only `kubernetes-cli.toml`._~~ | | |
 | [#2263: feat(recipes): replace Linux-only helm recipe with cross-platform version](https://github.com/tsukumogami/tsuku/issues/2263) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259) | testable |
 | _Replaces the batch-generated `recipes/h/helm.toml` (Homebrew-only, Linux-only) with a handcrafted recipe using `get.helm.sh` tarballs for all four supported platform-arch combinations._ | | |
 | [#2264: feat(recipes): add handcrafted recipes for bat, starship, and neovim](https://github.com/tsukumogami/tsuku/issues/2264) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259) | testable |
@@ -85,8 +85,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2259,I2260,I2261 done
-    class I2262,I2263,I2264,I2265,I2266,I2267 ready
+    class I2259,I2260,I2261,I2262 done
+    class I2263,I2264,I2265,I2266,I2267 ready
     class I2268 blocked
 ```
 

--- a/recipes/k/kubectl.toml
+++ b/recipes/k/kubectl.toml
@@ -1,0 +1,27 @@
+[metadata]
+name = "kubectl"
+description = "Kubernetes command-line tool"
+homepage = "https://kubernetes.io/docs/reference/kubectl/"
+version_format = "semver"
+curated = true
+
+[version]
+github_repo = "kubernetes/kubernetes"
+tag_prefix = "v"
+
+[[steps]]
+action = "download"
+url = "https://dl.k8s.io/release/v{version}/bin/{os}/{arch}/kubectl"
+checksum_url = "https://dl.k8s.io/release/v{version}/bin/{os}/{arch}/kubectl.sha256"
+
+[[steps]]
+action = "chmod"
+files = ["kubectl"]
+
+[[steps]]
+action = "install_binaries"
+binaries = ["kubectl"]
+
+[verify]
+command = "kubectl version --client"
+pattern = "{version}"


### PR DESCRIPTION
Adds `recipes/k/kubectl.toml` — a handcrafted kubectl recipe that downloads the official binary directly from `dl.k8s.io` for linux/amd64, linux/arm64, darwin/amd64, and darwin/arm64. SHA256 checksum verification uses the `.sha256` sidecar file published alongside each release binary. Version resolution uses `kubernetes/kubernetes` GitHub releases with `tag_prefix = "v"`.

Setting `curated = true` enrolls the recipe in nightly cross-platform validation via the dynamic grep-based discovery introduced in the previous PR. The existing `kubernetes-cli.toml` (Homebrew-only, Linux-only, batch-generated) is unchanged.

---

Fixes #2262