### PR TITLE
feat(recipes): replace Linux-only helm recipe with cross-platform version

### DIFF
--- a/docs/designs/DESIGN-curated-recipes.md
+++ b/docs/designs/DESIGN-curated-recipes.md
@@ -633,8 +633,8 @@ Plan: [docs/plans/PLAN-curated-recipes.md](../plans/PLAN-curated-recipes.md)
 | ~~_Adds `recipes/c/claude.toml` and `recipes/g/gemini.toml` using npm_install with glibc-only constraint, plus discovery entries for both tools._~~ | | |
 | ~~[#2262: feat(recipes): add cross-platform kubectl recipe](https://github.com/tsukumogami/tsuku/issues/2262)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259)~~ | ~~testable~~ |
 | ~~_Replaces or supplements the existing kubectl recipe with a cross-platform version supporting Linux and macOS via direct download from the Kubernetes release server._~~ | | |
-| [#2263: feat(recipes): replace Linux-only helm recipe with cross-platform version](https://github.com/tsukumogami/tsuku/issues/2263) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259) | testable |
-| _Rewrites the helm recipe to download from official Helm GitHub releases for both Linux and macOS, replacing the Linux-only version._ | | |
+| ~~[#2263: feat(recipes): replace Linux-only helm recipe with cross-platform version](https://github.com/tsukumogami/tsuku/issues/2263)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259)~~ | ~~testable~~ |
+| ~~_Rewrites the helm recipe to download from official Helm GitHub releases for both Linux and macOS, replacing the Linux-only version._~~ | | |
 | [#2264: feat(recipes): add handcrafted recipes for bat, starship, and neovim](https://github.com/tsukumogami/tsuku/issues/2264) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259) | testable |
 | _Adds curated handcrafted recipes for bat, starship, and neovim using github_archive with proper platform-specific asset patterns._ | | |
 | [#2265: feat(recipes): add handcrafted node.js recipe](https://github.com/tsukumogami/tsuku/issues/2265) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259) | testable |
@@ -677,8 +677,8 @@ graph TD
     classDef ready fill:#bbdefb
     classDef blocked fill:#fff9c4
 
-    class I2259,I2260,I2261,I2262 done
-    class I2263,I2264,I2265,I2266,I2267 ready
+    class I2259,I2260,I2261,I2262,I2263 done
+    class I2264,I2265,I2266,I2267 ready
     class I2268 blocked
 ```
 

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -33,8 +33,8 @@ Introduce a `curated = true` flag for handcrafted recipes, nightly cross-platfor
 | ~~_Ships `recipes/c/claude.toml` using `npm_install` with `@anthropic-ai/claude-code` and `recipes/g/gemini.toml` with `@google/gemini-cli`, each with a companion discovery entry that prevents the batch pipeline from resolving the wrong scoped package._~~ | | |
 | ~~[#2262: feat(recipes): add cross-platform kubectl recipe](https://github.com/tsukumogami/tsuku/issues/2262)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259)~~ | ~~testable~~ |
 | ~~_Adds `recipes/k/kubectl.toml` using direct binary download from `dl.k8s.io` for linux/amd64, linux/arm64, darwin/amd64, and darwin/arm64 — additive alongside the existing Linux-only `kubernetes-cli.toml`._~~ | | |
-| [#2263: feat(recipes): replace Linux-only helm recipe with cross-platform version](https://github.com/tsukumogami/tsuku/issues/2263) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259) | testable |
-| _Replaces the batch-generated `recipes/h/helm.toml` (Homebrew-only, Linux-only) with a handcrafted recipe using `get.helm.sh` tarballs for all four supported platform-arch combinations._ | | |
+| ~~[#2263: feat(recipes): replace Linux-only helm recipe with cross-platform version](https://github.com/tsukumogami/tsuku/issues/2263)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259)~~ | ~~testable~~ |
+| ~~_Replaces the batch-generated `recipes/h/helm.toml` (Homebrew-only, Linux-only) with a handcrafted recipe using `get.helm.sh` tarballs for all four supported platform-arch combinations._~~ | | |
 | [#2264: feat(recipes): add handcrafted recipes for bat, starship, and neovim](https://github.com/tsukumogami/tsuku/issues/2264) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259) | testable |
 | _Ships `recipes/b/bat.toml`, `recipes/s/starship.toml`, and `recipes/n/neovim.toml` using `github_archive` action, converting three discovery-only tools into fully installable curated recipes._ | | |
 | [#2265: feat(recipes): add handcrafted node.js recipe](https://github.com/tsukumogami/tsuku/issues/2265) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259) | testable |
@@ -85,8 +85,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2259,I2260,I2261,I2262 done
-    class I2263,I2264,I2265,I2266,I2267 ready
+    class I2259,I2260,I2261,I2262,I2263 done
+    class I2264,I2265,I2266,I2267 ready
     class I2268 blocked
 ```
 

--- a/recipes/h/helm.toml
+++ b/recipes/h/helm.toml
@@ -1,22 +1,33 @@
 [metadata]
-  name = "helm"
-  description = "Kubernetes package manager"
-  homepage = "https://helm.sh/"
-  version_format = ""
-  requires_sudo = false
-  tier = 0
-  type = ""
-  llm_validation = "skipped"
-supported_os = ["linux"]
+name = "helm"
+description = "Kubernetes package manager"
+homepage = "https://helm.sh/"
+version_format = "semver"
+curated = true
+
+[version]
+github_repo = "helm/helm"
+tag_prefix = "v"
 
 [[steps]]
-  action = "homebrew"
-  formula = "helm"
+action = "download"
+url = "https://get.helm.sh/helm-v{version}-{os}-{arch}.tar.gz"
+checksum_url = "https://get.helm.sh/helm-v{version}-{os}-{arch}.tar.gz.sha256sum"
 
 [[steps]]
-  action = "install_binaries"
-  binaries = ["bin/helm"]
+action = "extract"
+archive = "helm-v{version}-{os}-{arch}.tar.gz"
+format = "tar.gz"
+strip_dirs = 1
+
+[[steps]]
+action = "chmod"
+files = ["helm"]
+
+[[steps]]
+action = "install_binaries"
+binaries = ["helm"]
 
 [verify]
-  command = "helm --version"
-  pattern = ""
+command = "helm version"
+pattern = "{version}"


### PR DESCRIPTION
Replaces the batch-generated `recipes/h/helm.toml` (Homebrew-only, `supported_os = ["linux"]`) with a handcrafted recipe that downloads official Helm release tarballs from `get.helm.sh` for linux/amd64, linux/arm64, darwin/amd64, and darwin/arm64.

Uses `download` + `extract` + `install_binaries` rather than `download_archive` to enable checksum verification against Helm's published `.sha256sum` files. The tarball layout is `{os}-{arch}/helm`; `strip_dirs = 1` extracts the binary directly. Setting `curated = true` enrolls the recipe in nightly cross-platform validation via dynamic grep-based discovery.

---

Fixes #2263