### PR TITLE
feat(recipes): add handcrafted recipes for bat, starship, and neovim

### DIFF
--- a/docs/designs/DESIGN-curated-recipes.md
+++ b/docs/designs/DESIGN-curated-recipes.md
@@ -635,8 +635,8 @@ Plan: [docs/plans/PLAN-curated-recipes.md](../plans/PLAN-curated-recipes.md)
 | ~~_Replaces or supplements the existing kubectl recipe with a cross-platform version supporting Linux and macOS via direct download from the Kubernetes release server._~~ | | |
 | ~~[#2263: feat(recipes): replace Linux-only helm recipe with cross-platform version](https://github.com/tsukumogami/tsuku/issues/2263)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259)~~ | ~~testable~~ |
 | ~~_Rewrites the helm recipe to download from official Helm GitHub releases for both Linux and macOS, replacing the Linux-only version._~~ | | |
-| [#2264: feat(recipes): add handcrafted recipes for bat, starship, and neovim](https://github.com/tsukumogami/tsuku/issues/2264) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259) | testable |
-| _Adds curated handcrafted recipes for bat, starship, and neovim using github_archive with proper platform-specific asset patterns._ | | |
+| ~~[#2264: feat(recipes): add handcrafted recipes for bat, starship, and neovim](https://github.com/tsukumogami/tsuku/issues/2264)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259)~~ | ~~testable~~ |
+| ~~_Adds curated handcrafted recipes for bat, starship, and neovim using github_archive with proper platform-specific asset patterns._~~ | | |
 | [#2265: feat(recipes): add handcrafted node.js recipe](https://github.com/tsukumogami/tsuku/issues/2265) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259) | testable |
 | _Adds `recipes/n/node.toml` using direct download from nodejs.org with platform-specific tarballs for Linux (glibc and musl) and macOS._ | | |
 | [#2266: feat(recipes): backfill curated recipes — cloud CLIs and build tools](https://github.com/tsukumogami/tsuku/issues/2266) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
@@ -677,8 +677,8 @@ graph TD
     classDef ready fill:#bbdefb
     classDef blocked fill:#fff9c4
 
-    class I2259,I2260,I2261,I2262,I2263 done
-    class I2264,I2265,I2266,I2267 ready
+    class I2259,I2260,I2261,I2262,I2263,I2264 done
+    class I2265,I2266,I2267 ready
     class I2268 blocked
 ```
 

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -35,8 +35,8 @@ Introduce a `curated = true` flag for handcrafted recipes, nightly cross-platfor
 | ~~_Adds `recipes/k/kubectl.toml` using direct binary download from `dl.k8s.io` for linux/amd64, linux/arm64, darwin/amd64, and darwin/arm64 — additive alongside the existing Linux-only `kubernetes-cli.toml`._~~ | | |
 | ~~[#2263: feat(recipes): replace Linux-only helm recipe with cross-platform version](https://github.com/tsukumogami/tsuku/issues/2263)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259)~~ | ~~testable~~ |
 | ~~_Replaces the batch-generated `recipes/h/helm.toml` (Homebrew-only, Linux-only) with a handcrafted recipe using `get.helm.sh` tarballs for all four supported platform-arch combinations._~~ | | |
-| [#2264: feat(recipes): add handcrafted recipes for bat, starship, and neovim](https://github.com/tsukumogami/tsuku/issues/2264) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259) | testable |
-| _Ships `recipes/b/bat.toml`, `recipes/s/starship.toml`, and `recipes/n/neovim.toml` using `github_archive` action, converting three discovery-only tools into fully installable curated recipes._ | | |
+| ~~[#2264: feat(recipes): add handcrafted recipes for bat, starship, and neovim](https://github.com/tsukumogami/tsuku/issues/2264)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259)~~ | ~~testable~~ |
+| ~~_Ships `recipes/b/bat.toml`, `recipes/s/starship.toml`, and `recipes/n/neovim.toml` using `github_archive` action, converting three discovery-only tools into fully installable curated recipes._~~ | | |
 | [#2265: feat(recipes): add handcrafted node.js recipe](https://github.com/tsukumogami/tsuku/issues/2265) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259) | testable |
 | _Adds `recipes/n/node.toml` using direct download from `nodejs.org` with platform-specific tarballs, making the Node.js runtime (a prerequisite for npm-based tools) installable via tsuku._ | | |
 | [#2266: feat(recipes): backfill curated recipes — cloud CLIs and build tools](https://github.com/tsukumogami/tsuku/issues/2266) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
@@ -85,8 +85,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2259,I2260,I2261,I2262,I2263 done
-    class I2264,I2265,I2266,I2267 ready
+    class I2259,I2260,I2261,I2262,I2263,I2264 done
+    class I2265,I2266,I2267 ready
     class I2268 blocked
 ```
 

--- a/recipes/b/bat.toml
+++ b/recipes/b/bat.toml
@@ -1,0 +1,32 @@
+[metadata]
+name = "bat"
+description = "A cat(1) clone with syntax highlighting and Git integration"
+homepage = "https://github.com/sharkdp/bat"
+version_format = "semver"
+curated = true
+
+[version]
+github_repo = "sharkdp/bat"
+tag_prefix = "v"
+
+[[steps]]
+action = "github_archive"
+when = { os = ["linux"] }
+repo = "sharkdp/bat"
+asset_pattern = "bat-v{version}-{arch}.tar.gz"
+strip_dirs = 1
+binaries = ["bat"]
+arch_mapping = { amd64 = "x86_64-unknown-linux-gnu", arm64 = "aarch64-unknown-linux-gnu" }
+
+[[steps]]
+action = "github_archive"
+when = { os = ["darwin"] }
+repo = "sharkdp/bat"
+asset_pattern = "bat-v{version}-{arch}.tar.gz"
+strip_dirs = 1
+binaries = ["bat"]
+arch_mapping = { amd64 = "x86_64-apple-darwin", arm64 = "aarch64-apple-darwin" }
+
+[verify]
+command = "bat --version"
+pattern = "{version}"

--- a/recipes/n/neovim.toml
+++ b/recipes/n/neovim.toml
@@ -1,0 +1,32 @@
+[metadata]
+name = "neovim"
+description = "Hyperextensible Vim-based text editor"
+homepage = "https://neovim.io"
+version_format = "semver"
+curated = true
+
+[version]
+github_repo = "neovim/neovim"
+tag_prefix = "v"
+
+[[steps]]
+action = "github_archive"
+when = { os = ["linux"] }
+repo = "neovim/neovim"
+asset_pattern = "nvim-linux-{arch}.tar.gz"
+strip_dirs = 1
+binaries = ["bin/nvim"]
+arch_mapping = { amd64 = "x86_64", arm64 = "arm64" }
+
+[[steps]]
+action = "github_archive"
+when = { os = ["darwin"] }
+repo = "neovim/neovim"
+asset_pattern = "nvim-macos-{arch}.tar.gz"
+strip_dirs = 1
+binaries = ["bin/nvim"]
+arch_mapping = { amd64 = "x86_64", arm64 = "arm64" }
+
+[verify]
+command = "nvim --version"
+pattern = "{version}"

--- a/recipes/s/starship.toml
+++ b/recipes/s/starship.toml
@@ -1,0 +1,32 @@
+[metadata]
+name = "starship"
+description = "The minimal, blazing-fast, and infinitely customizable prompt for any shell"
+homepage = "https://starship.rs"
+version_format = "semver"
+curated = true
+
+[version]
+github_repo = "starship/starship"
+tag_prefix = "v"
+
+[[steps]]
+action = "github_archive"
+when = { os = ["linux"] }
+repo = "starship/starship"
+asset_pattern = "starship-{arch}.tar.gz"
+strip_dirs = 0
+binaries = ["starship"]
+arch_mapping = { amd64 = "x86_64-unknown-linux-gnu", arm64 = "aarch64-unknown-linux-musl" }
+
+[[steps]]
+action = "github_archive"
+when = { os = ["darwin"] }
+repo = "starship/starship"
+asset_pattern = "starship-{arch}-apple-darwin.tar.gz"
+strip_dirs = 0
+binaries = ["starship"]
+arch_mapping = { amd64 = "x86_64", arm64 = "aarch64" }
+
+[verify]
+command = "starship --version"
+pattern = "{version}"


### PR DESCRIPTION
Adds curated recipes for bat, starship, and neovim using the `github_archive` action. All three were previously discovery-only — they appeared in search results but `tsuku install` failed. This converts them to fully installable, cross-platform curated recipes with `curated = true` enrolled in nightly CI.

Each recipe handles the quirks of that project's release asset naming:

- **bat** (`sharkdp/bat`): versioned filenames (`bat-v{version}-{arch}.tar.gz`); full Rust target triples differ by OS, so two platform-specific steps handle linux/darwin separately
- **starship** (`starship/starship`): no version in asset names; linux/arm64 only provides a musl build (no GNU available), linux/amd64 uses GNU
- **neovim** (`neovim/neovim`): fixed OS identifiers (`nvim-linux-*`, `nvim-macos-*`) with no version; `strip_dirs = 1` exposes the `bin/nvim` binary from the extracted directory

---

Fixes #2264