### PR TITLE
docs: split curated backfill into 17 category-scoped issues

### DIFF
--- a/docs/designs/DESIGN-curated-recipes.md
+++ b/docs/designs/DESIGN-curated-recipes.md
@@ -643,8 +643,25 @@ Plan: [docs/plans/PLAN-curated-recipes.md](../plans/PLAN-curated-recipes.md)
 | ~~_Ships `recipes/a/awscli.toml` using download+PGP-verify from awscli.amazonaws.com and `recipes/c/cmake.toml` using download+extract with SHA-256.txt checksum from Kitware's GitHub releases._~~ | | |
 | ~~[#2267: feat(recipes): backfill curated recipes — modern CLI tools and AI assistants](https://github.com/tsukumogami/tsuku/issues/2267)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
 | ~~_Replaces batch-generated recipes for ripgrep, fd, eza, zoxide, and delta with handcrafted versions, and adds missing AI tool recipes (aider, ollama)._~~ | | |
-| [#2268: feat(recipes): backfill curated recipes — remaining top-100 gaps](https://github.com/tsukumogami/tsuku/issues/2268) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260), [#2266](https://github.com/tsukumogami/tsuku/issues/2266), [#2267](https://github.com/tsukumogami/tsuku/issues/2267) | testable |
-| _Authors handcrafted recipes for all remaining top-100 tools not covered by earlier issues, reaching full curated coverage of the priority list._ | | |
+| ~~[#2268: feat(recipes): backfill curated recipes — remaining top-100 gaps](https://github.com/tsukumogami/tsuku/issues/2268)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260), [#2266](https://github.com/tsukumogami/tsuku/issues/2266), [#2267](https://github.com/tsukumogami/tsuku/issues/2267)~~ | ~~superseded~~ |
+| _Superseded by #2281–#2297 (decomposition into 17 category-sized batches); see `docs/plans/PLAN-curated-recipes.md` for the full list._ | | |
+| [#2281: security scanners](https://github.com/tsukumogami/tsuku/issues/2281) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| [#2282: Kubernetes core CLIs](https://github.com/tsukumogami/tsuku/issues/2282) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| [#2283: Kubernetes ecosystem tools](https://github.com/tsukumogami/tsuku/issues/2283) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| [#2284: HashiCorp and infra tools](https://github.com/tsukumogami/tsuku/issues/2284) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| [#2285: terminal UI and TUI tools](https://github.com/tsukumogami/tsuku/issues/2285) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| [#2286: shell utilities](https://github.com/tsukumogami/tsuku/issues/2286) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| [#2287: environment and version managers](https://github.com/tsukumogami/tsuku/issues/2287) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| [#2288: JS and Node.js ecosystem](https://github.com/tsukumogami/tsuku/issues/2288) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| [#2289: Go and shell linters](https://github.com/tsukumogami/tsuku/issues/2289) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| [#2290: Python and JS linters and formatters](https://github.com/tsukumogami/tsuku/issues/2290) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| [#2291: crypto, secrets, and certificate tools](https://github.com/tsukumogami/tsuku/issues/2291) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| [#2292: CI/CD automation tools](https://github.com/tsukumogami/tsuku/issues/2292) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| [#2293: container and image tools](https://github.com/tsukumogami/tsuku/issues/2293) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| [#2294: language runtimes](https://github.com/tsukumogami/tsuku/issues/2294) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| [#2295: C++ and JVM build tools](https://github.com/tsukumogami/tsuku/issues/2295) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| [#2296: cloud CLIs and orchestration](https://github.com/tsukumogami/tsuku/issues/2296) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| [#2297: IaC quality and policy tools](https://github.com/tsukumogami/tsuku/issues/2297) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
 
 ```mermaid
 graph TD
@@ -657,7 +674,24 @@ graph TD
     I2265["#2265: node.js recipe"]
     I2266["#2266: backfill — cloud CLIs + build tools"]
     I2267["#2267: backfill — modern CLIs + AI tools"]
-    I2268["#2268: backfill — remaining top-100"]
+    I2268["#2268: superseded by #2281–#2297"]
+    I2281["#2281: security scanners"]
+    I2282["#2282: K8s core CLIs"]
+    I2283["#2283: K8s ecosystem"]
+    I2284["#2284: HashiCorp + infra"]
+    I2285["#2285: terminal UI"]
+    I2286["#2286: shell utilities"]
+    I2287["#2287: env/version managers"]
+    I2288["#2288: JS/Node ecosystem"]
+    I2289["#2289: Go/shell linters"]
+    I2290["#2290: Python/JS formatters"]
+    I2291["#2291: crypto + certs"]
+    I2292["#2292: CI/CD automation"]
+    I2293["#2293: container tools"]
+    I2294["#2294: language runtimes"]
+    I2295["#2295: C++/JVM build tools"]
+    I2296["#2296: cloud CLIs"]
+    I2297["#2297: IaC quality"]
 
     I2259 --> I2261
     I2259 --> I2262
@@ -666,19 +700,51 @@ graph TD
     I2259 --> I2265
     I2259 --> I2266
     I2259 --> I2267
-    I2259 --> I2268
     I2260 --> I2266
     I2260 --> I2267
-    I2260 --> I2268
-    I2266 --> I2268
-    I2267 --> I2268
+    I2259 --> I2281
+    I2259 --> I2282
+    I2259 --> I2283
+    I2259 --> I2284
+    I2259 --> I2285
+    I2259 --> I2286
+    I2259 --> I2287
+    I2259 --> I2288
+    I2259 --> I2289
+    I2259 --> I2290
+    I2259 --> I2291
+    I2259 --> I2292
+    I2259 --> I2293
+    I2259 --> I2294
+    I2259 --> I2295
+    I2259 --> I2296
+    I2259 --> I2297
+    I2260 --> I2281
+    I2260 --> I2282
+    I2260 --> I2283
+    I2260 --> I2284
+    I2260 --> I2285
+    I2260 --> I2286
+    I2260 --> I2287
+    I2260 --> I2288
+    I2260 --> I2289
+    I2260 --> I2290
+    I2260 --> I2291
+    I2260 --> I2292
+    I2260 --> I2293
+    I2260 --> I2294
+    I2260 --> I2295
+    I2260 --> I2296
+    I2260 --> I2297
 
     classDef done fill:#c8e6c9
     classDef ready fill:#bbdefb
+    classDef superseded fill:#e0e0e0,stroke:#9e9e9e,color:#616161
     classDef blocked fill:#fff9c4
 
     class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267 done
-    class I2268 ready
+    class I2268 superseded
+    class I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297 ready
 ```
 
-**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design.
+**Legend**: Green = done, Blue = ready, Grey = superseded, Yellow = blocked, Purple = needs-design.

--- a/docs/designs/DESIGN-curated-recipes.md
+++ b/docs/designs/DESIGN-curated-recipes.md
@@ -643,25 +643,42 @@ Plan: [docs/plans/PLAN-curated-recipes.md](../plans/PLAN-curated-recipes.md)
 | ~~_Ships `recipes/a/awscli.toml` using download+PGP-verify from awscli.amazonaws.com and `recipes/c/cmake.toml` using download+extract with SHA-256.txt checksum from Kitware's GitHub releases._~~ | | |
 | ~~[#2267: feat(recipes): backfill curated recipes — modern CLI tools and AI assistants](https://github.com/tsukumogami/tsuku/issues/2267)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
 | ~~_Replaces batch-generated recipes for ripgrep, fd, eza, zoxide, and delta with handcrafted versions, and adds missing AI tool recipes (aider, ollama)._~~ | | |
-| ~~[#2268: feat(recipes): backfill curated recipes — remaining top-100 gaps](https://github.com/tsukumogami/tsuku/issues/2268)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260), [#2266](https://github.com/tsukumogami/tsuku/issues/2266), [#2267](https://github.com/tsukumogami/tsuku/issues/2267)~~ | ~~superseded~~ |
-| _Superseded by #2281–#2297 (decomposition into 17 category-sized batches); see `docs/plans/PLAN-curated-recipes.md` for the full list._ | | |
-| [#2281: security scanners](https://github.com/tsukumogami/tsuku/issues/2281) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| [#2282: Kubernetes core CLIs](https://github.com/tsukumogami/tsuku/issues/2282) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| [#2283: Kubernetes ecosystem tools](https://github.com/tsukumogami/tsuku/issues/2283) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| [#2284: HashiCorp and infra tools](https://github.com/tsukumogami/tsuku/issues/2284) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| [#2285: terminal UI and TUI tools](https://github.com/tsukumogami/tsuku/issues/2285) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| [#2286: shell utilities](https://github.com/tsukumogami/tsuku/issues/2286) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| [#2287: environment and version managers](https://github.com/tsukumogami/tsuku/issues/2287) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| [#2288: JS and Node.js ecosystem](https://github.com/tsukumogami/tsuku/issues/2288) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| [#2289: Go and shell linters](https://github.com/tsukumogami/tsuku/issues/2289) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| [#2290: Python and JS linters and formatters](https://github.com/tsukumogami/tsuku/issues/2290) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| [#2291: crypto, secrets, and certificate tools](https://github.com/tsukumogami/tsuku/issues/2291) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| [#2292: CI/CD automation tools](https://github.com/tsukumogami/tsuku/issues/2292) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| [#2293: container and image tools](https://github.com/tsukumogami/tsuku/issues/2293) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| [#2294: language runtimes](https://github.com/tsukumogami/tsuku/issues/2294) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| [#2295: C++ and JVM build tools](https://github.com/tsukumogami/tsuku/issues/2295) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| [#2296: cloud CLIs and orchestration](https://github.com/tsukumogami/tsuku/issues/2296) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| [#2297: IaC quality and policy tools](https://github.com/tsukumogami/tsuku/issues/2297) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| ~~[#2268: feat(recipes): backfill curated recipes — remaining top-100 gaps](https://github.com/tsukumogami/tsuku/issues/2268)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260), [#2266](https://github.com/tsukumogami/tsuku/issues/2266), [#2267](https://github.com/tsukumogami/tsuku/issues/2267)~~ | ~~testable~~ |
+| ~~_Superseded by #2281–#2297; see `docs/plans/PLAN-curated-recipes.md` for the full decomposition into 17 category-sized batches._~~ | | |
+| [#2281: feat(recipes): backfill curated recipes — security scanners](https://github.com/tsukumogami/tsuku/issues/2281) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates trivy, grype, cosign, syft, and tflint — 5 handcrafted recipes needing upstream asset re-verification and the `curated = true` flag._ | | |
+| [#2282: feat(recipes): backfill curated recipes — Kubernetes core CLIs](https://github.com/tsukumogami/tsuku/issues/2282) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates k9s, flux, stern, kubectx, and kustomize — 5 handcrafted recipes needing re-verification and the `curated = true` flag._ | | |
+| [#2283: feat(recipes): backfill curated recipes — Kubernetes ecosystem tools](https://github.com/tsukumogami/tsuku/issues/2283) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates eksctl, skaffold, and velero, and replaces the batch-generated recipes for cilium-cli and istioctl with handcrafted `github_archive` versions._ | | |
+| [#2284: feat(recipes): backfill curated recipes — HashiCorp and infra tools](https://github.com/tsukumogami/tsuku/issues/2284) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates terraform, vault, packer, and pulumi, and adds new handcrafted recipes for consul and vagrant using the HashiCorp releases pattern._ | | |
+| [#2285: feat(recipes): backfill curated recipes — terminal UI and TUI tools](https://github.com/tsukumogami/tsuku/issues/2285) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates fzf, lazygit, and btop, and replaces the batch-generated recipes for lazydocker and htop with handcrafted cross-platform versions._ | | |
+| [#2286: feat(recipes): backfill curated recipes — shell utilities](https://github.com/tsukumogami/tsuku/issues/2286) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates git, curl, and httpie; rewrites the batch recipes for wget and jq; and authors a new recipe for tmux._ | | |
+| [#2287: feat(recipes): backfill curated recipes — environment and version managers](https://github.com/tsukumogami/tsuku/issues/2287) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates direnv and mise, rewrites the batch recipe for asdf, and authors new recipes for pyenv and rbenv._ | | |
+| [#2288: feat(recipes): backfill curated recipes — JS and Node.js ecosystem](https://github.com/tsukumogami/tsuku/issues/2288) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates bun, rewrites the batch recipe for yarn, and authors new recipes for deno, pnpm, and nvm._ | | |
+| [#2289: feat(recipes): backfill curated recipes — Go and shell linters](https://github.com/tsukumogami/tsuku/issues/2289) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates actionlint and golangci-lint, and replaces the batch-generated recipes for shellcheck and shfmt._ | | |
+| [#2290: feat(recipes): backfill curated recipes — Python and JS linters and formatters](https://github.com/tsukumogami/tsuku/issues/2290) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates ruff and black, rewrites the batch recipe for prettier, and authors a new `npm_install` recipe for eslint._ | | |
+| [#2291: feat(recipes): backfill curated recipes — crypto, secrets, and certificate tools](https://github.com/tsukumogami/tsuku/issues/2291) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates caddy and age, rewrites the batch recipe for mkcert, and authors new recipes for sops and step._ | | |
+| [#2292: feat(recipes): backfill curated recipes — CI/CD automation tools](https://github.com/tsukumogami/tsuku/issues/2292) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Rewrites the batch recipes for act, earthly, and goreleaser, and authors a new recipe for the GitHub copilot CLI._ | | |
+| [#2293: feat(recipes): backfill curated recipes — container and image tools](https://github.com/tsukumogami/tsuku/issues/2293) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates the docker CLI recipe and authors new recipes for ko, dive, and hadolint._ | | |
+| [#2294: feat(recipes): backfill curated recipes — language runtimes](https://github.com/tsukumogami/tsuku/issues/2294) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates the golang toolchain recipe and authors new recipes for python, rust, and ruby._ | | |
+| [#2295: feat(recipes): backfill curated recipes — C++ and JVM build tools](https://github.com/tsukumogami/tsuku/issues/2295) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Authors new recipes for make, ninja-build, meson, gradle, maven, and sbt._ | | |
+| [#2296: feat(recipes): backfill curated recipes — cloud CLIs and orchestration](https://github.com/tsukumogami/tsuku/issues/2296) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Authors new recipes for gcloud, azure-cli, ansible, and argocd, and replaces the batch-generated recipe for bazel._ | | |
+| [#2297: feat(recipes): backfill curated recipes — IaC quality and policy tools](https://github.com/tsukumogami/tsuku/issues/2297) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Rewrites the batch recipes for terragrunt and infracost, and authors new recipes for pre-commit, lefthook, and checkov._ | | |
 
 ```mermaid
 graph TD
@@ -739,12 +756,10 @@ graph TD
 
     classDef done fill:#c8e6c9
     classDef ready fill:#bbdefb
-    classDef superseded fill:#e0e0e0,stroke:#9e9e9e,color:#616161
     classDef blocked fill:#fff9c4
 
-    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267 done
-    class I2268 superseded
+    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268 done
     class I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297 ready
 ```
 
-**Legend**: Green = done, Blue = ready, Grey = superseded, Yellow = blocked, Purple = needs-design.
+**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design.

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -43,8 +43,8 @@ Introduce a `curated = true` flag for handcrafted recipes, nightly cross-platfor
 | ~~_Ships `recipes/a/awscli.toml` (PGP-verified zip download with PyInstaller bundle install) and `recipes/c/cmake.toml` (download+extract with SHA-256.txt from GitHub)._~~ | | |
 | ~~[#2267: feat(recipes): backfill curated recipes — modern CLI tools and AI assistants](https://github.com/tsukumogami/tsuku/issues/2267)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
 | ~~_Replaces batch-generated recipes for ripgrep, fd, eza, zoxide, and delta with handcrafted `github_archive` versions, and adds missing AI tool recipes (aider, ollama) identified in the priority list._~~ | | |
-| ~~[#2268: feat(recipes): backfill curated recipes — remaining top-100 gaps](https://github.com/tsukumogami/tsuku/issues/2268)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260), [#2266](https://github.com/tsukumogami/tsuku/issues/2266), [#2267](https://github.com/tsukumogami/tsuku/issues/2267)~~ | ~~superseded~~ |
-| _Superseded by #2281–#2297, which decompose the remaining top-100 gap into 17 category-sized batches so each PR has a reviewable surface._ | | |
+| ~~[#2268: feat(recipes): backfill curated recipes — remaining top-100 gaps](https://github.com/tsukumogami/tsuku/issues/2268)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260), [#2266](https://github.com/tsukumogami/tsuku/issues/2266), [#2267](https://github.com/tsukumogami/tsuku/issues/2267)~~ | ~~testable~~ |
+| ~~_Superseded by #2281–#2297, which decompose the remaining top-100 gap into 17 category-sized batches so each PR has a reviewable surface._~~ | | |
 | [#2281: feat(recipes): backfill curated recipes — security scanners](https://github.com/tsukumogami/tsuku/issues/2281) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
 | _Adds `curated = true` to the existing handcrafted recipes for trivy, grype, cosign, syft, and tflint after verifying each against its latest upstream release._ | | |
 | [#2282: feat(recipes): backfill curated recipes — Kubernetes core CLIs](https://github.com/tsukumogami/tsuku/issues/2282) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
@@ -158,7 +158,6 @@ graph TD
 
     classDef done fill:#c8e6c9
     classDef ready fill:#bbdefb
-    classDef superseded fill:#e0e0e0,stroke:#9e9e9e,color:#616161
     classDef blocked fill:#fff9c4
     classDef needsDesign fill:#e1bee7
     classDef needsPrd fill:#b3e5fc
@@ -167,12 +166,11 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267 done
-    class I2268 superseded
+    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268 done
     class I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297 ready
 ```
 
-**Legend**: Green = done, Blue = ready, Grey = superseded, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan
+**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan
 
 ## Implementation Sequence
 

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -4,7 +4,7 @@ status: Active
 execution_mode: multi-pr
 upstream: docs/designs/DESIGN-curated-recipes.md
 milestone: "Curated Recipe System"
-issue_count: 10
+issue_count: 27
 ---
 
 ## Status
@@ -43,8 +43,42 @@ Introduce a `curated = true` flag for handcrafted recipes, nightly cross-platfor
 | ~~_Ships `recipes/a/awscli.toml` (PGP-verified zip download with PyInstaller bundle install) and `recipes/c/cmake.toml` (download+extract with SHA-256.txt from GitHub)._~~ | | |
 | ~~[#2267: feat(recipes): backfill curated recipes — modern CLI tools and AI assistants](https://github.com/tsukumogami/tsuku/issues/2267)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
 | ~~_Replaces batch-generated recipes for ripgrep, fd, eza, zoxide, and delta with handcrafted `github_archive` versions, and adds missing AI tool recipes (aider, ollama) identified in the priority list._~~ | | |
-| [#2268: feat(recipes): backfill curated recipes — remaining top-100 gaps](https://github.com/tsukumogami/tsuku/issues/2268) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260), [#2266](https://github.com/tsukumogami/tsuku/issues/2266), [#2267](https://github.com/tsukumogami/tsuku/issues/2267) | testable |
-| _Authors handcrafted recipes for all remaining tools in the top-100 priority list not covered by earlier issues, reaching the target of 100 tools with handcrafted curated coverage._ | | |
+| ~~[#2268: feat(recipes): backfill curated recipes — remaining top-100 gaps](https://github.com/tsukumogami/tsuku/issues/2268)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260), [#2266](https://github.com/tsukumogami/tsuku/issues/2266), [#2267](https://github.com/tsukumogami/tsuku/issues/2267)~~ | ~~superseded~~ |
+| _Superseded by #2281–#2297, which decompose the remaining top-100 gap into 17 category-sized batches so each PR has a reviewable surface._ | | |
+| [#2281: feat(recipes): backfill curated recipes — security scanners](https://github.com/tsukumogami/tsuku/issues/2281) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Adds `curated = true` to the existing handcrafted recipes for trivy, grype, cosign, syft, and tflint after verifying each against its latest upstream release._ | | |
+| [#2282: feat(recipes): backfill curated recipes — Kubernetes core CLIs](https://github.com/tsukumogami/tsuku/issues/2282) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Adds `curated = true` to the existing handcrafted recipes for k9s, flux, stern, kubectx, and kustomize after upstream asset re-verification._ | | |
+| [#2283: feat(recipes): backfill curated recipes — Kubernetes ecosystem tools](https://github.com/tsukumogami/tsuku/issues/2283) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates eksctl, skaffold, and velero, and replaces the batch-generated recipes for cilium-cli and istioctl with handcrafted `github_archive` versions._ | | |
+| [#2284: feat(recipes): backfill curated recipes — HashiCorp and infra tools](https://github.com/tsukumogami/tsuku/issues/2284) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates terraform, vault, packer, and pulumi, and adds new handcrafted recipes for consul and vagrant using the HashiCorp releases pattern._ | | |
+| [#2285: feat(recipes): backfill curated recipes — terminal UI and TUI tools](https://github.com/tsukumogami/tsuku/issues/2285) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates fzf, lazygit, and btop, and replaces the batch-generated recipes for lazydocker and htop with handcrafted cross-platform versions._ | | |
+| [#2286: feat(recipes): backfill curated recipes — shell utilities](https://github.com/tsukumogami/tsuku/issues/2286) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates git, curl, and httpie; rewrites the batch recipes for wget and jq; and authors a new recipe for tmux. Several tools here may require source build fallbacks on some platforms._ | | |
+| [#2287: feat(recipes): backfill curated recipes — environment and version managers](https://github.com/tsukumogami/tsuku/issues/2287) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates direnv and mise, rewrites the batch recipe for asdf, and authors new recipes for pyenv and rbenv following the shell-based clone-and-install pattern._ | | |
+| [#2288: feat(recipes): backfill curated recipes — JS and Node.js ecosystem](https://github.com/tsukumogami/tsuku/issues/2288) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates bun, rewrites the batch recipe for yarn, and authors new recipes for deno, pnpm, and nvm._ | | |
+| [#2289: feat(recipes): backfill curated recipes — Go and shell linters](https://github.com/tsukumogami/tsuku/issues/2289) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates actionlint and golangci-lint, and replaces the batch-generated recipes for shellcheck and shfmt._ | | |
+| [#2290: feat(recipes): backfill curated recipes — Python and JS linters and formatters](https://github.com/tsukumogami/tsuku/issues/2290) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates ruff and black, rewrites the batch recipe for prettier, and authors a new `npm_install` recipe for eslint._ | | |
+| [#2291: feat(recipes): backfill curated recipes — crypto, secrets, and certificate tools](https://github.com/tsukumogami/tsuku/issues/2291) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates caddy and age, rewrites the batch recipe for mkcert, and authors new recipes for sops and step._ | | |
+| [#2292: feat(recipes): backfill curated recipes — CI/CD automation tools](https://github.com/tsukumogami/tsuku/issues/2292) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Rewrites the batch recipes for act, earthly, and goreleaser, and authors a new recipe for the GitHub copilot CLI._ | | |
+| [#2293: feat(recipes): backfill curated recipes — container and image tools](https://github.com/tsukumogami/tsuku/issues/2293) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates the docker CLI recipe and authors new recipes for ko, dive, and hadolint._ | | |
+| [#2294: feat(recipes): backfill curated recipes — language runtimes](https://github.com/tsukumogami/tsuku/issues/2294) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Curates the golang toolchain recipe and authors new recipes for python, rust, and ruby._ | | |
+| [#2295: feat(recipes): backfill curated recipes — C++ and JVM build tools](https://github.com/tsukumogami/tsuku/issues/2295) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Authors new recipes for make, ninja-build, meson, gradle, maven, and sbt._ | | |
+| [#2296: feat(recipes): backfill curated recipes — cloud CLIs and orchestration](https://github.com/tsukumogami/tsuku/issues/2296) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Authors new recipes for gcloud, azure-cli, ansible, and argocd, and replaces the batch-generated recipe for bazel._ | | |
+| [#2297: feat(recipes): backfill curated recipes — IaC quality and policy tools](https://github.com/tsukumogami/tsuku/issues/2297) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
+| _Rewrites the batch recipes for terragrunt and infracost, and authors new recipes for pre-commit, lefthook, and checkov._ | | |
 
 ## Dependency Graph
 
@@ -59,7 +93,24 @@ graph TD
     I2265["#2265: node.js recipe"]
     I2266["#2266: backfill — cloud CLIs + build tools"]
     I2267["#2267: backfill — modern CLIs + AI tools"]
-    I2268["#2268: backfill — remaining top-100"]
+    I2268["#2268: superseded by #2281–#2297"]
+    I2281["#2281: security scanners"]
+    I2282["#2282: K8s core CLIs"]
+    I2283["#2283: K8s ecosystem"]
+    I2284["#2284: HashiCorp + infra"]
+    I2285["#2285: terminal UI / TUI"]
+    I2286["#2286: shell utilities"]
+    I2287["#2287: env/version managers"]
+    I2288["#2288: JS/Node ecosystem"]
+    I2289["#2289: Go/shell linters"]
+    I2290["#2290: Python/JS formatters"]
+    I2291["#2291: crypto + certs"]
+    I2292["#2292: CI/CD automation"]
+    I2293["#2293: container + image tools"]
+    I2294["#2294: language runtimes"]
+    I2295["#2295: C++/JVM build tools"]
+    I2296["#2296: cloud CLIs + orchestration"]
+    I2297["#2297: IaC quality + policy"]
 
     I2259 --> I2261
     I2259 --> I2262
@@ -68,15 +119,46 @@ graph TD
     I2259 --> I2265
     I2259 --> I2266
     I2259 --> I2267
-    I2259 --> I2268
     I2260 --> I2266
     I2260 --> I2267
-    I2260 --> I2268
-    I2266 --> I2268
-    I2267 --> I2268
+    I2259 --> I2281
+    I2259 --> I2282
+    I2259 --> I2283
+    I2259 --> I2284
+    I2259 --> I2285
+    I2259 --> I2286
+    I2259 --> I2287
+    I2259 --> I2288
+    I2259 --> I2289
+    I2259 --> I2290
+    I2259 --> I2291
+    I2259 --> I2292
+    I2259 --> I2293
+    I2259 --> I2294
+    I2259 --> I2295
+    I2259 --> I2296
+    I2259 --> I2297
+    I2260 --> I2281
+    I2260 --> I2282
+    I2260 --> I2283
+    I2260 --> I2284
+    I2260 --> I2285
+    I2260 --> I2286
+    I2260 --> I2287
+    I2260 --> I2288
+    I2260 --> I2289
+    I2260 --> I2290
+    I2260 --> I2291
+    I2260 --> I2292
+    I2260 --> I2293
+    I2260 --> I2294
+    I2260 --> I2295
+    I2260 --> I2296
+    I2260 --> I2297
 
     classDef done fill:#c8e6c9
     classDef ready fill:#bbdefb
+    classDef superseded fill:#e0e0e0,stroke:#9e9e9e,color:#616161
     classDef blocked fill:#fff9c4
     classDef needsDesign fill:#e1bee7
     classDef needsPrd fill:#b3e5fc
@@ -86,22 +168,23 @@ graph TD
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
     class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267 done
-    class I2268 ready
+    class I2268 superseded
+    class I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297 ready
 ```
 
-**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan
+**Legend**: Green = done, Blue = ready, Grey = superseded, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan
 
 ## Implementation Sequence
 
-**Critical path**: #2259 → #2260 → #2266/#2267 → #2268
+**Critical path**: #2259 → #2260 → Wave 3 backfill batches (#2281–#2297)
 
 | Wave | Issues | Start condition |
 |------|--------|----------------|
 | Wave 0 | #2259, #2260 | Immediately — no prerequisites |
 | Wave 1 | #2261, #2262, #2263, #2264, #2265 | After #2259 merges |
 | Wave 2 | #2266, #2267 | After both #2259 and #2260 merge |
-| Wave 3 | #2268 | After #2259, #2260, #2266, #2267 all merge |
+| Wave 3 | #2281–#2297 (17 backfill batches) | After #2259 and #2260 merge |
 
-Start with #2259 and #2260 in parallel. Wave 1 contains five independent leaf issues that can be worked concurrently — assign to different contributors or work sequentially by priority. Wave 2 issues are independent of each other. Wave 3 is the final backfill gate.
+Wave 3 issues are fully independent of each other; any can be picked up in any order and worked in parallel. Each batch is scoped to a coherent tool category and ships as a single PR.
 
-**Priority within Wave 1**: #2261 (claude + gemini) addresses the primary motivation for this design; #2262 and #2263 (kubectl, helm) are highest-traffic tools; #2264 and #2265 (bat/starship/neovim, node.js) can follow.
+**Priority within Wave 3**: lead with the "handcrafted-only" batches (#2281 security scanners, #2282 K8s CLIs) since those are low-risk validation plus flag additions. The "new recipe" heavy batches (#2294 language runtimes, #2295 build tools, #2296 cloud CLIs) require more research time per tool.


### PR DESCRIPTION
Decompose `docs/plans/PLAN-curated-recipes.md` into 17 category-sized batch issues covering the remaining tools in the top-100 priority list. Each entry in the Implementation Issues table gains a new row with its dependency list and tier; the Mermaid dependency graph gains 17 new nodes, all blocked only on the already-merged foundation issues (#2259 and #2260); and the Implementation Sequence is rewritten with a parallelizable Wave 3 covering #2281-#2297. `docs/designs/DESIGN-curated-recipes.md` is updated in lockstep with the same decomposition.

---

## What This Accomplishes

The original \"backfill all remaining top-100 gaps\" issue bundled ~82 tools across three work tiers — adding the curated flag to already-handcrafted recipes, rewriting batch-generated recipes, and authoring brand-new recipes — into a single issue too large for one PR. The decomposition scopes each of 17 child issues to a coherent tool category (security scanners, Kubernetes CLIs, language runtimes, etc.), so each can ship as an independent, reviewable PR.

All 17 children depend only on the foundation issues that already merged, making Wave 3 fully parallelizable.

Fixes #2268