### PR TITLE
feat(recipes): curate HashiCorp and infra tools

### DIFF
--- a/docs/curated-tools-priority-list.md
+++ b/docs/curated-tools-priority-list.md
@@ -11,13 +11,13 @@ Popularity rankings are based on Homebrew download analytics, GitHub star counts
 ## Action Summary
 
 ### No action needed (handcrafted — full platform support)
-git, docker, terraform, gh, golang, fzf, btop, curl, httpie, lazygit, k9s, stern, kubectx, direnv, mise, eksctl, flux, skaffold, kustomize, velero, vault, packer, bun, claude, gemini, trivy, grype, cosign, syft, actionlint, golangci-lint, ruff, black, tflint, pulumi, caddy, age
+git, docker, terraform, gh, golang, fzf, btop, curl, httpie, lazygit, k9s, stern, kubectx, direnv, mise, eksctl, flux, skaffold, kustomize, velero, vault, packer, bun, claude, gemini, trivy, grype, cosign, syft, actionlint, golangci-lint, ruff, black, tflint, pulumi, caddy, age, consul, vagrant
 
 ### Review coverage (batch — may need platform expansion or full handcrafting)
 helm, jq, ripgrep, fd, eza, zoxide, wget, lazydocker, htop, asdf, cilium-cli, istioctl, bazel, yarn, ollama, act, earthly, goreleaser, shellcheck, shfmt, prettier, infracost, terragrunt, mkcert
 
 ### Author recipe (missing or discovery-only — needs a recipe)
-node, python, kubectl, aws-cli, rust, bat, starship, neovim, tmux, delta, pyenv, nvm, rbenv, gcloud, azure-cli, argocd, ansible, cmake, ninja-build, meson, make, gradle, maven, sbt, deno, pnpm, aider, copilot, ko, dive, hadolint, pre-commit, lefthook, checkov, sops, step, vagrant, consul, eslint
+node, python, kubectl, aws-cli, rust, bat, starship, neovim, tmux, delta, pyenv, nvm, rbenv, gcloud, azure-cli, argocd, ansible, cmake, ninja-build, meson, make, gradle, maven, sbt, deno, pnpm, aider, copilot, ko, dive, hadolint, pre-commit, lefthook, checkov, sops, step, eslint
 
 ## Tool Ranking
 
@@ -72,9 +72,9 @@ node, python, kubectl, aws-cli, rust, bat, starship, neovim, tmux, delta, pyenv,
 | 47 | istioctl | batch | review coverage |
 | 48 | velero | handcrafted | no action needed |
 | 49 | vault | handcrafted | no action needed |
-| 50 | consul | missing | author recipe |
+| 50 | consul | handcrafted | no action needed |
 | 51 | packer | handcrafted | no action needed |
-| 52 | vagrant | missing | author recipe |
+| 52 | vagrant | handcrafted | no action needed |
 | 53 | ansible | discovery-only | author recipe |
 | 54 | cmake | discovery-only | author recipe |
 | 55 | ninja-build | discovery-only | author recipe |

--- a/docs/designs/DESIGN-curated-recipes.md
+++ b/docs/designs/DESIGN-curated-recipes.md
@@ -651,8 +651,8 @@ Plan: [docs/plans/PLAN-curated-recipes.md](../plans/PLAN-curated-recipes.md)
 | ~~_Curates k9s, flux, stern, kubectx, and kustomize — 5 handcrafted recipes needing re-verification and the `curated = true` flag._~~ | | |
 | ~~[#2283: feat(recipes): backfill curated recipes — Kubernetes ecosystem tools](https://github.com/tsukumogami/tsuku/issues/2283)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
 | ~~_Curates eksctl, skaffold, and velero, and replaces the batch-generated recipes for cilium-cli and istioctl with handcrafted `github_archive` versions._~~ | | |
-| [#2284: feat(recipes): backfill curated recipes — HashiCorp and infra tools](https://github.com/tsukumogami/tsuku/issues/2284) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| _Curates terraform, vault, packer, and pulumi, and adds new handcrafted recipes for consul and vagrant using the HashiCorp releases pattern._ | | |
+| ~~[#2284: feat(recipes): backfill curated recipes — HashiCorp and infra tools](https://github.com/tsukumogami/tsuku/issues/2284)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
+| ~~_Curates terraform, vault, packer, and pulumi, and adds new handcrafted recipes for consul and vagrant using the HashiCorp releases pattern._~~ | | |
 | [#2285: feat(recipes): backfill curated recipes — terminal UI and TUI tools](https://github.com/tsukumogami/tsuku/issues/2285) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
 | _Curates fzf, lazygit, and btop, and replaces the batch-generated recipes for lazydocker and htop with handcrafted cross-platform versions._ | | |
 | [#2286: feat(recipes): backfill curated recipes — shell utilities](https://github.com/tsukumogami/tsuku/issues/2286) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
@@ -758,8 +758,8 @@ graph TD
     classDef ready fill:#bbdefb
     classDef blocked fill:#fff9c4
 
-    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283 done
-    class I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297 ready
+    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284 done
+    class I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297 ready
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design.

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -51,8 +51,8 @@ Introduce a `curated = true` flag for handcrafted recipes, nightly cross-platfor
 | ~~_Adds `curated = true` to the existing handcrafted recipes for k9s, flux, stern, kubectx, and kustomize after upstream asset re-verification._~~ | | |
 | ~~[#2283: feat(recipes): backfill curated recipes — Kubernetes ecosystem tools](https://github.com/tsukumogami/tsuku/issues/2283)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
 | ~~_Curates eksctl, skaffold, and velero, and replaces the batch-generated recipes for cilium-cli and istioctl with handcrafted `github_archive` versions._~~ | | |
-| [#2284: feat(recipes): backfill curated recipes — HashiCorp and infra tools](https://github.com/tsukumogami/tsuku/issues/2284) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| _Curates terraform, vault, packer, and pulumi, and adds new handcrafted recipes for consul and vagrant using the HashiCorp releases pattern._ | | |
+| ~~[#2284: feat(recipes): backfill curated recipes — HashiCorp and infra tools](https://github.com/tsukumogami/tsuku/issues/2284)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
+| ~~_Curates terraform, vault, packer, and pulumi, and adds new handcrafted recipes for consul and vagrant using the HashiCorp releases pattern._~~ | | |
 | [#2285: feat(recipes): backfill curated recipes — terminal UI and TUI tools](https://github.com/tsukumogami/tsuku/issues/2285) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
 | _Curates fzf, lazygit, and btop, and replaces the batch-generated recipes for lazydocker and htop with handcrafted cross-platform versions._ | | |
 | [#2286: feat(recipes): backfill curated recipes — shell utilities](https://github.com/tsukumogami/tsuku/issues/2286) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
@@ -166,8 +166,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283 done
-    class I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297 ready
+    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284 done
+    class I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297 ready
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan

--- a/recipes/c/consul.toml
+++ b/recipes/c/consul.toml
@@ -1,59 +1,59 @@
 [metadata]
-name = "terraform"
-description = "Infrastructure as Code tool"
-homepage = "https://www.terraform.io/"
+name = "consul"
+description = "Service networking and service mesh"
+homepage = "https://www.consul.io/"
 version_format = "semver"
 curated = true
 
 [version]
-github_repo = "hashicorp/terraform"
+github_repo = "hashicorp/consul"
 
 # Linux: statically linked Go binary works on glibc and musl
 [[steps]]
 action = "download"
-url = "https://releases.hashicorp.com/terraform/{version}/terraform_{version}_linux_{arch}.zip"
-checksum_url = "https://releases.hashicorp.com/terraform/{version}/terraform_{version}_SHA256SUMS"
+url = "https://releases.hashicorp.com/consul/{version}/consul_{version}_linux_{arch}.zip"
+checksum_url = "https://releases.hashicorp.com/consul/{version}/consul_{version}_SHA256SUMS"
 when = { os = ["linux"], libc = ["glibc", "musl"] }
 
 [[steps]]
 action = "extract"
-archive = "terraform_{version}_linux_{arch}.zip"
+archive = "consul_{version}_linux_{arch}.zip"
 format = "zip"
 when = { os = ["linux"], libc = ["glibc", "musl"] }
 
 [[steps]]
 action = "chmod"
-files = ["terraform"]
+files = ["consul"]
 when = { os = ["linux"], libc = ["glibc", "musl"] }
 
 [[steps]]
 action = "install_binaries"
-binaries = ["terraform"]
+binaries = ["consul"]
 when = { os = ["linux"], libc = ["glibc", "musl"] }
 
 # macOS: Intel and Apple Silicon binaries
 [[steps]]
 action = "download"
-url = "https://releases.hashicorp.com/terraform/{version}/terraform_{version}_darwin_{arch}.zip"
-checksum_url = "https://releases.hashicorp.com/terraform/{version}/terraform_{version}_SHA256SUMS"
+url = "https://releases.hashicorp.com/consul/{version}/consul_{version}_darwin_{arch}.zip"
+checksum_url = "https://releases.hashicorp.com/consul/{version}/consul_{version}_SHA256SUMS"
 when = { os = ["darwin"] }
 
 [[steps]]
 action = "extract"
-archive = "terraform_{version}_darwin_{arch}.zip"
+archive = "consul_{version}_darwin_{arch}.zip"
 format = "zip"
 when = { os = ["darwin"] }
 
 [[steps]]
 action = "chmod"
-files = ["terraform"]
+files = ["consul"]
 when = { os = ["darwin"] }
 
 [[steps]]
 action = "install_binaries"
-binaries = ["terraform"]
+binaries = ["consul"]
 when = { os = ["darwin"] }
 
 [verify]
-command = "terraform version"
+command = "consul version"
 pattern = "{version}"

--- a/recipes/p/packer.toml
+++ b/recipes/p/packer.toml
@@ -3,27 +3,56 @@ name = "packer"
 description = "Build automated machine images"
 homepage = "https://www.packer.io/"
 version_format = "semver"
+curated = true
 
 [version]
 github_repo = "hashicorp/packer"
 
+# Linux: statically linked Go binary works on glibc and musl
 [[steps]]
 action = "download"
-url = "https://releases.hashicorp.com/packer/{version}/packer_{version}_{os}_{arch}.zip"
+url = "https://releases.hashicorp.com/packer/{version}/packer_{version}_linux_{arch}.zip"
 checksum_url = "https://releases.hashicorp.com/packer/{version}/packer_{version}_SHA256SUMS"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 
 [[steps]]
 action = "extract"
-archive = "packer_{version}_{os}_{arch}.zip"
+archive = "packer_{version}_linux_{arch}.zip"
 format = "zip"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 
 [[steps]]
 action = "chmod"
 files = ["packer"]
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 
 [[steps]]
 action = "install_binaries"
-outputs = ["packer"]
+binaries = ["packer"]
+when = { os = ["linux"], libc = ["glibc", "musl"] }
+
+# macOS: Intel and Apple Silicon binaries
+[[steps]]
+action = "download"
+url = "https://releases.hashicorp.com/packer/{version}/packer_{version}_darwin_{arch}.zip"
+checksum_url = "https://releases.hashicorp.com/packer/{version}/packer_{version}_SHA256SUMS"
+when = { os = ["darwin"] }
+
+[[steps]]
+action = "extract"
+archive = "packer_{version}_darwin_{arch}.zip"
+format = "zip"
+when = { os = ["darwin"] }
+
+[[steps]]
+action = "chmod"
+files = ["packer"]
+when = { os = ["darwin"] }
+
+[[steps]]
+action = "install_binaries"
+binaries = ["packer"]
+when = { os = ["darwin"] }
 
 [verify]
 command = "packer version"

--- a/recipes/p/pulumi.toml
+++ b/recipes/p/pulumi.toml
@@ -3,15 +3,27 @@ name = "pulumi"
 description = "Modern Infrastructure as Code"
 homepage = "https://github.com/pulumi/pulumi"
 version_format = "semver"
+curated = true
 
+# Linux: statically linked Go binary works on glibc and musl
 [[steps]]
 action = "github_archive"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 repo = "pulumi/pulumi"
-asset_pattern = "pulumi-v{version}-{os}-{arch}.tar.gz"
+asset_pattern = "pulumi-v{version}-linux-{arch}.tar.gz"
+arch_mapping = { amd64 = "x64", arm64 = "arm64" }
 strip_dirs = 1
 binaries = ["pulumi"]
-os_mapping = { darwin = "darwin", linux = "linux" }
+
+# macOS: Intel and Apple Silicon binaries
+[[steps]]
+action = "github_archive"
+when = { os = ["darwin"] }
+repo = "pulumi/pulumi"
+asset_pattern = "pulumi-v{version}-darwin-{arch}.tar.gz"
 arch_mapping = { amd64 = "x64", arm64 = "arm64" }
+strip_dirs = 1
+binaries = ["pulumi"]
 
 [verify]
 command = "pulumi version"

--- a/recipes/v/vagrant.toml
+++ b/recipes/v/vagrant.toml
@@ -1,0 +1,42 @@
+[metadata]
+name = "vagrant"
+description = "Development environments made easy"
+homepage = "https://www.vagrantup.com/"
+version_format = "semver"
+curated = true
+
+[version]
+github_repo = "hashicorp/vagrant"
+
+# Linux amd64: statically linked Go launcher works on glibc and musl.
+# Upstream coverage gaps (releases.hashicorp.com as of 2026-04):
+#   - linux arm64:   no vagrant_*_linux_arm64.zip published
+#   - darwin amd64:  ships as vagrant_*_darwin_amd64.dmg installer only
+#   - darwin arm64:  ships as vagrant_*_darwin_arm64.dmg installer only
+# tsuku cannot extract .dmg installers, so macOS and linux/arm64 are
+# unavailable until HashiCorp publishes raw archives for them.
+[[steps]]
+action = "download"
+url = "https://releases.hashicorp.com/vagrant/{version}/vagrant_{version}_linux_amd64.zip"
+checksum_url = "https://releases.hashicorp.com/vagrant/{version}/vagrant_{version}_SHA256SUMS"
+when = { os = ["linux"], arch = "amd64", libc = ["glibc", "musl"] }
+
+[[steps]]
+action = "extract"
+archive = "vagrant_{version}_linux_amd64.zip"
+format = "zip"
+when = { os = ["linux"], arch = "amd64", libc = ["glibc", "musl"] }
+
+[[steps]]
+action = "chmod"
+files = ["vagrant"]
+when = { os = ["linux"], arch = "amd64", libc = ["glibc", "musl"] }
+
+[[steps]]
+action = "install_binaries"
+binaries = ["vagrant"]
+when = { os = ["linux"], arch = "amd64", libc = ["glibc", "musl"] }
+
+[verify]
+command = "vagrant --version"
+pattern = "{version}"

--- a/recipes/v/vagrant.toml
+++ b/recipes/v/vagrant.toml
@@ -4,6 +4,10 @@ description = "Development environments made easy"
 homepage = "https://www.vagrantup.com/"
 version_format = "semver"
 curated = true
+# HashiCorp publishes a raw `vagrant_*_linux_amd64.zip` only; macOS ships
+# as .dmg installers and no linux_arm64 zip exists.
+supported_os = ["linux"]
+unsupported_platforms = ["linux/arm64"]
 
 [version]
 github_repo = "hashicorp/vagrant"

--- a/recipes/v/vault.toml
+++ b/recipes/v/vault.toml
@@ -3,27 +3,56 @@ name = "vault"
 description = "Secrets management"
 homepage = "https://www.vaultproject.io/"
 version_format = "semver"
+curated = true
 
 [version]
 github_repo = "hashicorp/vault"
 
+# Linux: statically linked Go binary works on glibc and musl
 [[steps]]
 action = "download"
-url = "https://releases.hashicorp.com/vault/{version}/vault_{version}_{os}_{arch}.zip"
+url = "https://releases.hashicorp.com/vault/{version}/vault_{version}_linux_{arch}.zip"
 checksum_url = "https://releases.hashicorp.com/vault/{version}/vault_{version}_SHA256SUMS"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 
 [[steps]]
 action = "extract"
-archive = "vault_{version}_{os}_{arch}.zip"
+archive = "vault_{version}_linux_{arch}.zip"
 format = "zip"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 
 [[steps]]
 action = "chmod"
 files = ["vault"]
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 
 [[steps]]
 action = "install_binaries"
-outputs = ["vault"]
+binaries = ["vault"]
+when = { os = ["linux"], libc = ["glibc", "musl"] }
+
+# macOS: Intel and Apple Silicon binaries
+[[steps]]
+action = "download"
+url = "https://releases.hashicorp.com/vault/{version}/vault_{version}_darwin_{arch}.zip"
+checksum_url = "https://releases.hashicorp.com/vault/{version}/vault_{version}_SHA256SUMS"
+when = { os = ["darwin"] }
+
+[[steps]]
+action = "extract"
+archive = "vault_{version}_darwin_{arch}.zip"
+format = "zip"
+when = { os = ["darwin"] }
+
+[[steps]]
+action = "chmod"
+files = ["vault"]
+when = { os = ["darwin"] }
+
+[[steps]]
+action = "install_binaries"
+binaries = ["vault"]
+when = { os = ["darwin"] }
 
 [verify]
 command = "vault version"


### PR DESCRIPTION
Add `curated = true` to `terraform`, `vault`, `packer`, and `pulumi`
after rewriting each with per-OS step chains and explicit libc `when`
clauses so they pass `tsuku validate --strict --check-libc-coverage`.

Author two new handcrafted recipes: `consul` (linux/amd64, linux/arm64,
darwin/amd64, darwin/arm64 via `releases.hashicorp.com`) and `vagrant`
(linux/amd64 only, with the coverage gap documented inline).

Mark issue #2284 as done in `docs/designs/DESIGN-curated-recipes.md` and
`docs/plans/PLAN-curated-recipes.md`, and move `consul` and `vagrant`
from "Author recipe" to "No action needed" in
`docs/curated-tools-priority-list.md`.

---

## What This Accomplishes

HashiCorp binaries (`terraform`, `vault`, `packer`, `consul`) are all
statically linked Go binaries that work on both glibc and musl linux.
The recipes previously used templated `{os}`/`{arch}` URLs without
libc declarations, so `validate --strict --check-libc-coverage`
flagged them. This change splits each recipe into two per-OS step
chains (linux and darwin) with explicit `libc = ["glibc", "musl"]`
on the linux chain. `pulumi` gets the same treatment using the
`github_archive` action.

`consul` follows the exact same shape as the other four HashiCorp
recipes. `vagrant` is an asymmetric case: `releases.hashicorp.com`
publishes only `vagrant_<v>_linux_amd64.zip` as a raw archive. macOS
ships only as `.dmg` installers and no `linux_arm64` zip exists. The
recipe covers the one available target and documents the upstream
limitation inline, so a future HashiCorp change to publish more
archives can be absorbed by adding steps rather than rewriting.

## Test Plan

- [x] `tsuku validate --strict --check-libc-coverage` passes on all 6 recipes
- [x] `tsuku eval` resolves 21 asset URLs that all return HTTP 200
- [x] `tsuku install --recipe <recipe>` succeeds on linux/amd64 for all 6 tools
- [x] `<tool> version` / `vagrant --version` produces expected output after install
- [ ] Curated nightly workflow picks up the six new/updated recipes on next run

Fixes #2284