### PR TITLE
feat(recipes): curate terminal UI and TUI tools

### DIFF
--- a/docs/curated-tools-priority-list.md
+++ b/docs/curated-tools-priority-list.md
@@ -11,10 +11,10 @@ Popularity rankings are based on Homebrew download analytics, GitHub star counts
 ## Action Summary
 
 ### No action needed (handcrafted — full platform support)
-git, docker, terraform, gh, golang, fzf, btop, curl, httpie, lazygit, k9s, stern, kubectx, direnv, mise, eksctl, flux, skaffold, kustomize, velero, vault, packer, bun, claude, gemini, trivy, grype, cosign, syft, actionlint, golangci-lint, ruff, black, tflint, pulumi, caddy, age, consul, vagrant
+git, docker, terraform, gh, golang, fzf, btop, curl, httpie, lazygit, k9s, stern, kubectx, direnv, mise, eksctl, flux, skaffold, kustomize, velero, vault, packer, bun, claude, gemini, trivy, grype, cosign, syft, actionlint, golangci-lint, ruff, black, tflint, pulumi, caddy, age, consul, vagrant, lazydocker
 
 ### Review coverage (batch — may need platform expansion or full handcrafting)
-helm, jq, ripgrep, fd, eza, zoxide, wget, lazydocker, htop, asdf, cilium-cli, istioctl, bazel, yarn, ollama, act, earthly, goreleaser, shellcheck, shfmt, prettier, infracost, terragrunt, mkcert
+helm, jq, ripgrep, fd, eza, zoxide, wget, htop, asdf, cilium-cli, istioctl, bazel, yarn, ollama, act, earthly, goreleaser, shellcheck, shfmt, prettier, infracost, terragrunt, mkcert
 
 ### Author recipe (missing or discovery-only — needs a recipe)
 node, python, kubectl, aws-cli, rust, bat, starship, neovim, tmux, delta, pyenv, nvm, rbenv, gcloud, azure-cli, argocd, ansible, cmake, ninja-build, meson, make, gradle, maven, sbt, deno, pnpm, aider, copilot, ko, dive, hadolint, pre-commit, lefthook, checkov, sops, step, eslint
@@ -51,7 +51,7 @@ node, python, kubectl, aws-cli, rust, bat, starship, neovim, tmux, delta, pyenv,
 | 26 | httpie | handcrafted | no action needed |
 | 27 | delta | discovery-only | author recipe |
 | 28 | lazygit | handcrafted | no action needed |
-| 29 | lazydocker | batch | review coverage |
+| 29 | lazydocker | handcrafted | no action needed |
 | 30 | k9s | handcrafted | no action needed |
 | 31 | stern | handcrafted | no action needed |
 | 32 | kubectx | handcrafted | no action needed |

--- a/docs/designs/DESIGN-curated-recipes.md
+++ b/docs/designs/DESIGN-curated-recipes.md
@@ -653,8 +653,8 @@ Plan: [docs/plans/PLAN-curated-recipes.md](../plans/PLAN-curated-recipes.md)
 | ~~_Curates eksctl, skaffold, and velero, and replaces the batch-generated recipes for cilium-cli and istioctl with handcrafted `github_archive` versions._~~ | | |
 | ~~[#2284: feat(recipes): backfill curated recipes — HashiCorp and infra tools](https://github.com/tsukumogami/tsuku/issues/2284)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
 | ~~_Curates terraform, vault, packer, and pulumi, and adds new handcrafted recipes for consul and vagrant using the HashiCorp releases pattern._~~ | | |
-| [#2285: feat(recipes): backfill curated recipes — terminal UI and TUI tools](https://github.com/tsukumogami/tsuku/issues/2285) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| _Curates fzf, lazygit, and btop, and replaces the batch-generated recipes for lazydocker and htop with handcrafted cross-platform versions._ | | |
+| ~~[#2285: feat(recipes): backfill curated recipes — terminal UI and TUI tools](https://github.com/tsukumogami/tsuku/issues/2285)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
+| ~~_Curates fzf, lazygit, and btop, and replaces the batch-generated recipes for lazydocker and htop with handcrafted cross-platform versions._~~ | | |
 | [#2286: feat(recipes): backfill curated recipes — shell utilities](https://github.com/tsukumogami/tsuku/issues/2286) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
 | _Curates git, curl, and httpie; rewrites the batch recipes for wget and jq; and authors a new recipe for tmux._ | | |
 | [#2287: feat(recipes): backfill curated recipes — environment and version managers](https://github.com/tsukumogami/tsuku/issues/2287) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
@@ -758,8 +758,8 @@ graph TD
     classDef ready fill:#bbdefb
     classDef blocked fill:#fff9c4
 
-    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284 done
-    class I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297 ready
+    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285 done
+    class I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297 ready
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design.

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -53,8 +53,8 @@ Introduce a `curated = true` flag for handcrafted recipes, nightly cross-platfor
 | ~~_Curates eksctl, skaffold, and velero, and replaces the batch-generated recipes for cilium-cli and istioctl with handcrafted `github_archive` versions._~~ | | |
 | ~~[#2284: feat(recipes): backfill curated recipes — HashiCorp and infra tools](https://github.com/tsukumogami/tsuku/issues/2284)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
 | ~~_Curates terraform, vault, packer, and pulumi, and adds new handcrafted recipes for consul and vagrant using the HashiCorp releases pattern._~~ | | |
-| [#2285: feat(recipes): backfill curated recipes — terminal UI and TUI tools](https://github.com/tsukumogami/tsuku/issues/2285) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| _Curates fzf, lazygit, and btop, and replaces the batch-generated recipes for lazydocker and htop with handcrafted cross-platform versions._ | | |
+| ~~[#2285: feat(recipes): backfill curated recipes — terminal UI and TUI tools](https://github.com/tsukumogami/tsuku/issues/2285)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
+| ~~_Curates fzf, lazygit, and btop, and replaces the batch-generated recipes for lazydocker and htop with handcrafted cross-platform versions._~~ | | |
 | [#2286: feat(recipes): backfill curated recipes — shell utilities](https://github.com/tsukumogami/tsuku/issues/2286) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
 | _Curates git, curl, and httpie; rewrites the batch recipes for wget and jq; and authors a new recipe for tmux. Several tools here may require source build fallbacks on some platforms._ | | |
 | [#2287: feat(recipes): backfill curated recipes — environment and version managers](https://github.com/tsukumogami/tsuku/issues/2287) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
@@ -166,8 +166,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284 done
-    class I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297 ready
+    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285 done
+    class I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297 ready
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan

--- a/recipes/b/btop.toml
+++ b/recipes/b/btop.toml
@@ -3,17 +3,22 @@ name = "btop"
 description = "Resource monitor that shows usage and stats"
 homepage = "https://github.com/aristocratos/btop"
 version_format = "semver"
+curated = true
+# Upstream publishes only linux-musl binaries (statically linked, runs on
+# both glibc and musl). No darwin binaries are published; macOS users
+# typically install via Homebrew or source build.
 supported_os = ["linux"]
 
+# Linux: statically linked musl binary works on glibc and musl
 [[steps]]
 action = "github_archive"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 repo = "aristocratos/btop"
-asset_pattern = "btop-{arch}-unknown-{os}-musl.tbz"
+asset_pattern = "btop-{arch}-unknown-linux-musl.tbz"
 archive_format = "tbz"
+arch_mapping = { amd64 = "x86_64", arm64 = "aarch64" }
 strip_dirs = 0
 binaries = ["btop/bin/btop"]
-os_mapping = { linux = "linux" }
-arch_mapping = { amd64 = "x86_64", arm64 = "aarch64" }
 
 [verify]
 command = "btop --version"

--- a/recipes/f/fzf.toml
+++ b/recipes/f/fzf.toml
@@ -3,15 +3,25 @@ name = "fzf"
 description = "Command-line fuzzy finder"
 homepage = "https://github.com/junegunn/fzf"
 version_format = "semver"
+curated = true
 
+# Linux: statically linked Go binary works on glibc and musl
 [[steps]]
 action = "github_archive"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 repo = "junegunn/fzf"
-asset_pattern = "fzf-{version}-{os}_{arch}.tar.gz"
+asset_pattern = "fzf-{version}-linux_{arch}.tar.gz"
 strip_dirs = 0
 binaries = ["fzf"]
-os_mapping = { darwin = "darwin", linux = "linux" }
-arch_mapping = { amd64 = "amd64", arm64 = "arm64" }
+
+# macOS: Intel and Apple Silicon binaries
+[[steps]]
+action = "github_archive"
+when = { os = ["darwin"] }
+repo = "junegunn/fzf"
+asset_pattern = "fzf-{version}-darwin_{arch}.tar.gz"
+strip_dirs = 0
+binaries = ["fzf"]
 
 [verify]
 command = "fzf --version"

--- a/recipes/l/lazydocker.toml
+++ b/recipes/l/lazydocker.toml
@@ -1,34 +1,30 @@
 [metadata]
-  name = "lazydocker"
-  description = "Lazier way to manage everything docker"
-  homepage = "https://github.com/jesseduffield/lazydocker"
-  version_format = ""
-  requires_sudo = false
-  tier = 0
-  type = ""
-  llm_validation = "skipped"
+name = "lazydocker"
+description = "Lazier way to manage everything docker"
+homepage = "https://github.com/jesseduffield/lazydocker"
+version_format = "semver"
+curated = true
 
-[version]
-  source = ""
-  github_repo = ""
-  tag_prefix = ""
-  module = ""
-  formula = ""
-  cask = ""
-  tap = ""
-  fossil_repo = ""
-  project_name = ""
-  version_separator = ""
-  timeline_tag = ""
-
+# Linux: statically linked Go binary works on glibc and musl
 [[steps]]
-  action = "homebrew"
-  formula = "lazydocker"
+action = "github_archive"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
+repo = "jesseduffield/lazydocker"
+asset_pattern = "lazydocker_{version}_Linux_{arch}.tar.gz"
+arch_mapping = { amd64 = "x86_64", arm64 = "arm64" }
+strip_dirs = 0
+binaries = ["lazydocker"]
 
+# macOS: Intel and Apple Silicon binaries
 [[steps]]
-  action = "install_binaries"
-  binaries = ["bin/lazydocker"]
+action = "github_archive"
+when = { os = ["darwin"] }
+repo = "jesseduffield/lazydocker"
+asset_pattern = "lazydocker_{version}_Darwin_{arch}.tar.gz"
+arch_mapping = { amd64 = "x86_64", arm64 = "arm64" }
+strip_dirs = 0
+binaries = ["lazydocker"]
 
 [verify]
-  command = "lazydocker --version"
-  pattern = ""
+command = "lazydocker --version"
+pattern = "{version}"

--- a/recipes/l/lazygit.toml
+++ b/recipes/l/lazygit.toml
@@ -3,15 +3,27 @@ name = "lazygit"
 description = "Simple terminal UI for git"
 homepage = "https://github.com/jesseduffield/lazygit"
 version_format = "semver"
+curated = true
 
+# Linux: statically linked Go binary works on glibc and musl
 [[steps]]
 action = "github_archive"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 repo = "jesseduffield/lazygit"
-asset_pattern = "lazygit_{version}_{os}_{arch}.tar.gz"
+asset_pattern = "lazygit_{version}_linux_{arch}.tar.gz"
+arch_mapping = { amd64 = "x86_64", arm64 = "arm64" }
 strip_dirs = 0
 binaries = ["lazygit"]
-os_mapping = { linux = "linux", darwin = "darwin" }
+
+# macOS: Intel and Apple Silicon binaries
+[[steps]]
+action = "github_archive"
+when = { os = ["darwin"] }
+repo = "jesseduffield/lazygit"
+asset_pattern = "lazygit_{version}_darwin_{arch}.tar.gz"
 arch_mapping = { amd64 = "x86_64", arm64 = "arm64" }
+strip_dirs = 0
+binaries = ["lazygit"]
 
 [verify]
 command = "lazygit --version"


### PR DESCRIPTION
Rewrite `recipes/f/fzf.toml`, `recipes/l/lazygit.toml`, and
`recipes/b/btop.toml` into per-OS \`github_archive\` step chains with
explicit \`libc = ["glibc", "musl"]\` declarations on the linux path so
each passes \`validate --strict --check-libc-coverage\`, and add
\`curated = true\` to their metadata.

Replace the batch-era homebrew recipe \`recipes/l/lazydocker.toml\` with
a handcrafted \`github_archive\` version covering linux and darwin on
amd64 and arm64 from \`jesseduffield/lazydocker\`.

\`btop\` upstream publishes only \`linux-musl\` archives (statically
linked, runs on glibc and musl); no darwin binaries exist. The recipe
keeps \`supported_os = ["linux"]\` and documents the gap inline.

\`htop\` is deferred to a follow-up: upstream ships only source
tarballs, and the ncurses recipe it depends on is currently
darwin-only, so a source-build effort warrants its own issue.

Mark #2285 as done in \`docs/designs/DESIGN-curated-recipes.md\`,
\`docs/plans/PLAN-curated-recipes.md\`, and
\`docs/curated-tools-priority-list.md\`.

---

## Recipes

| Recipe | Change | Coverage |
|--------|--------|----------|
| \`recipes/f/fzf.toml\` | modernize, curate | linux/amd64, linux/arm64, darwin/amd64, darwin/arm64 |
| \`recipes/l/lazygit.toml\` | modernize, curate | linux/amd64, linux/arm64, darwin/amd64, darwin/arm64 |
| \`recipes/b/btop.toml\` | modernize, curate | linux/amd64, linux/arm64 (upstream linux-musl only; darwin gap documented) |
| \`recipes/l/lazydocker.toml\` | rewrite from batch, curate | linux/amd64, linux/arm64, darwin/amd64, darwin/arm64 |

## Verification

- \`./tsuku validate --strict --check-libc-coverage\` — all 4 pass
- 14 resolved asset URLs all return HTTP 200
- \`./tsuku install --recipe <recipe>\` succeeds on linux/amd64 for all 4 tools; each \`--version\` produces expected output

## htop

Deferred to #2305.

## Test plan

- [ ] CI: validate, lint, and PR checks pass
- [ ] Curated nightly picks up the four new/updated recipes on next run

Fixes #2285