### PR TITLE
feat(recipes): backfill curated recipes — Go and shell linters

### DIFF
--- a/docs/curated-tools-priority-list.md
+++ b/docs/curated-tools-priority-list.md
@@ -103,12 +103,12 @@ node, python, kubectl, aws-cli, rust, bat, starship, neovim, delta, rbenv, gclou
 | 78 | cosign | handcrafted | no action needed |
 | 79 | syft | handcrafted | no action needed |
 | 80 | hadolint | discovery-only | author recipe |
-| 81 | shellcheck | batch | review coverage |
-| 82 | shfmt | batch | review coverage |
+| 81 | shellcheck | handcrafted | curated |
+| 82 | shfmt | handcrafted | curated |
 | 83 | pre-commit | discovery-only | author recipe |
 | 84 | lefthook | discovery-only | author recipe |
-| 85 | actionlint | handcrafted | no action needed |
-| 86 | golangci-lint | handcrafted | no action needed |
+| 85 | actionlint | handcrafted | curated |
+| 86 | golangci-lint | handcrafted | curated |
 | 87 | ruff | handcrafted | no action needed |
 | 88 | black | handcrafted | no action needed |
 | 89 | prettier | batch | review coverage |

--- a/docs/designs/DESIGN-curated-recipes.md
+++ b/docs/designs/DESIGN-curated-recipes.md
@@ -661,8 +661,8 @@ Plan: [docs/plans/PLAN-curated-recipes.md](../plans/PLAN-curated-recipes.md)
 | ~~_Curates direnv and mise, rewrites the batch recipe for asdf, and authors new recipes for pyenv and rbenv._~~ | | |
 | ~~[#2288: feat(recipes): backfill curated recipes — JS and Node.js ecosystem](https://github.com/tsukumogami/tsuku/issues/2288)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
 | ~~_Curates bun, rewrites the batch recipe for yarn, and authors new recipes for deno, pnpm, and nvm._~~ | | |
-| [#2289: feat(recipes): backfill curated recipes — Go and shell linters](https://github.com/tsukumogami/tsuku/issues/2289) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| _Curates actionlint and golangci-lint, and replaces the batch-generated recipes for shellcheck and shfmt._ | | |
+| ~~[#2289: feat(recipes): backfill curated recipes — Go and shell linters](https://github.com/tsukumogami/tsuku/issues/2289)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
+| ~~_Curates actionlint and golangci-lint, and replaces the batch-generated recipes for shellcheck and shfmt._~~ | | |
 | [#2290: feat(recipes): backfill curated recipes — Python and JS linters and formatters](https://github.com/tsukumogami/tsuku/issues/2290) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
 | _Curates ruff and black, rewrites the batch recipe for prettier, and authors a new `npm_install` recipe for eslint._ | | |
 | [#2291: feat(recipes): backfill curated recipes — crypto, secrets, and certificate tools](https://github.com/tsukumogami/tsuku/issues/2291) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
@@ -758,8 +758,8 @@ graph TD
     classDef ready fill:#bbdefb
     classDef blocked fill:#fff9c4
 
-    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288 done
-    class I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297 ready
+    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289 done
+    class I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297 ready
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design.

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -61,8 +61,8 @@ Introduce a `curated = true` flag for handcrafted recipes, nightly cross-platfor
 | ~~_Curates direnv and mise, rewrites the batch recipe for asdf, and authors new recipes for pyenv and rbenv following the shell-based clone-and-install pattern._~~ | | |
 | ~~[#2288: feat(recipes): backfill curated recipes — JS and Node.js ecosystem](https://github.com/tsukumogami/tsuku/issues/2288)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
 | ~~_Curates bun, rewrites the batch recipe for yarn, and authors new recipes for deno, pnpm, and nvm._~~ | | |
-| [#2289: feat(recipes): backfill curated recipes — Go and shell linters](https://github.com/tsukumogami/tsuku/issues/2289) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| _Curates actionlint and golangci-lint, and replaces the batch-generated recipes for shellcheck and shfmt._ | | |
+| ~~[#2289: feat(recipes): backfill curated recipes — Go and shell linters](https://github.com/tsukumogami/tsuku/issues/2289)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
+| ~~_Curates actionlint and golangci-lint, and replaces the batch-generated recipes for shellcheck and shfmt._~~ | | |
 | [#2290: feat(recipes): backfill curated recipes — Python and JS linters and formatters](https://github.com/tsukumogami/tsuku/issues/2290) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
 | _Curates ruff and black, rewrites the batch recipe for prettier, and authors a new `npm_install` recipe for eslint._ | | |
 | [#2291: feat(recipes): backfill curated recipes — crypto, secrets, and certificate tools](https://github.com/tsukumogami/tsuku/issues/2291) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
@@ -178,8 +178,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288 done
-    class I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297,I2312,I2315 ready
+    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289 done
+    class I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297,I2312,I2315 ready
     class I2313 blocked
 ```
 

--- a/recipes/a/actionlint.toml
+++ b/recipes/a/actionlint.toml
@@ -3,14 +3,24 @@ name = "actionlint"
 description = "Static checker for GitHub Actions workflow files"
 homepage = "https://github.com/rhysd/actionlint"
 version_format = "semver"
+curated = true
 
 [[steps]]
 action = "github_archive"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 repo = "rhysd/actionlint"
 asset_pattern = "actionlint_{version}_{os}_{arch}.tar.gz"
 strip_dirs = 0
 binaries = ["actionlint"]
-os_mapping = { darwin = "darwin", linux = "linux" }
+arch_mapping = { amd64 = "amd64", arm64 = "arm64" }
+
+[[steps]]
+action = "github_archive"
+when = { os = ["darwin"] }
+repo = "rhysd/actionlint"
+asset_pattern = "actionlint_{version}_{os}_{arch}.tar.gz"
+strip_dirs = 0
+binaries = ["actionlint"]
 arch_mapping = { amd64 = "amd64", arm64 = "arm64" }
 
 [verify]

--- a/recipes/g/golangci-lint.toml
+++ b/recipes/g/golangci-lint.toml
@@ -3,14 +3,24 @@ name = "golangci-lint"
 description = "Fast Go linters runner"
 homepage = "https://github.com/golangci/golangci-lint"
 version_format = "semver"
+curated = true
 
 [[steps]]
 action = "github_archive"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 repo = "golangci/golangci-lint"
 asset_pattern = "golangci-lint-{version}-{os}-{arch}.tar.gz"
 strip_dirs = 1
 binaries = ["golangci-lint"]
-os_mapping = { linux = "linux", darwin = "darwin" }
+arch_mapping = { amd64 = "amd64", arm64 = "arm64" }
+
+[[steps]]
+action = "github_archive"
+when = { os = ["darwin"] }
+repo = "golangci/golangci-lint"
+asset_pattern = "golangci-lint-{version}-{os}-{arch}.tar.gz"
+strip_dirs = 1
+binaries = ["golangci-lint"]
 arch_mapping = { amd64 = "amd64", arm64 = "arm64" }
 
 [verify]

--- a/recipes/s/shellcheck.toml
+++ b/recipes/s/shellcheck.toml
@@ -36,4 +36,5 @@ arch_mapping = { amd64 = "x86_64", arm64 = "aarch64" }
 
 [verify]
 command = "shellcheck --version"
-pattern = "{version}"
+mode = "output"
+reason = "apk_install on Alpine may provide a different version than the GitHub release"

--- a/recipes/s/shellcheck.toml
+++ b/recipes/s/shellcheck.toml
@@ -1,35 +1,39 @@
 [metadata]
-  name = "shellcheck"
-  description = "Static analysis and lint tool, for (ba)sh scripts"
-  homepage = "https://www.shellcheck.net/"
-  version_format = ""
-  requires_sudo = false
-  runtime_dependencies = ["gmp"]
-  tier = 0
-  type = ""
-  llm_validation = "skipped"
+name = "shellcheck"
+description = "Static analysis tool for shell scripts"
+homepage = "https://www.shellcheck.net/"
+version_format = "semver"
+curated = true
 
 [version]
-  source = ""
-  github_repo = ""
-  tag_prefix = ""
-  module = ""
-  formula = ""
-  cask = ""
-  tap = ""
-  fossil_repo = ""
-  project_name = ""
-  version_separator = ""
-  timeline_tag = ""
+github_repo = "koalaman/shellcheck"
+tag_prefix = "v"
+
+# glibc Linux: prebuilt Haskell binaries from GitHub releases
+[[steps]]
+action = "github_archive"
+when = { os = ["linux"], libc = ["glibc"] }
+repo = "koalaman/shellcheck"
+asset_pattern = "shellcheck-v{version}.{os}.{arch}.tar.gz"
+strip_dirs = 1
+binaries = ["shellcheck"]
+arch_mapping = { amd64 = "x86_64", arm64 = "aarch64" }
+
+# musl Linux (Alpine): prebuilt binaries are glibc-only; use system package instead
+[[steps]]
+action = "apk_install"
+when = { os = ["linux"], libc = ["musl"] }
+packages = ["shellcheck"]
 
 [[steps]]
-  action = "homebrew"
-  formula = "shellcheck"
-
-[[steps]]
-  action = "install_binaries"
-  binaries = ["bin/shellcheck"]
+action = "github_archive"
+when = { os = ["darwin"] }
+repo = "koalaman/shellcheck"
+asset_pattern = "shellcheck-v{version}.{os}.{arch}.tar.gz"
+strip_dirs = 1
+binaries = ["shellcheck"]
+arch_mapping = { amd64 = "x86_64", arm64 = "aarch64" }
 
 [verify]
-  command = "shellcheck --version"
-  pattern = ""
+command = "shellcheck --version"
+pattern = "{version}"

--- a/recipes/s/shfmt.toml
+++ b/recipes/s/shfmt.toml
@@ -1,21 +1,20 @@
 [metadata]
-  name = "shfmt"
-  description = "Autoformat shell script source code"
-  homepage = "https://github.com/mvdan/sh"
-  version_format = ""
-  requires_sudo = false
-  tier = 0
-  type = ""
-  llm_validation = "skipped"
+name = "shfmt"
+description = "Shell script formatter"
+homepage = "https://github.com/mvdan/sh"
+version_format = "semver"
+curated = true
+
+[version]
+github_repo = "mvdan/sh"
+tag_prefix = "v"
 
 [[steps]]
-  action = "homebrew"
-  formula = "shfmt"
-
-[[steps]]
-  action = "install_binaries"
-  binaries = ["bin/shfmt"]
+action = "github_file"
+repo = "mvdan/sh"
+asset_pattern = "shfmt_v{version}_{os}_{arch}"
+binaries = [{src = "shfmt_v{version}_{os}_{arch}", dest = "bin/shfmt"}]
 
 [verify]
-  command = "shfmt --version"
-  pattern = ""
+command = "shfmt --version"
+pattern = "{version}"


### PR DESCRIPTION
Adds handcrafted curated recipes for actionlint, golangci-lint, shellcheck, and shfmt. All four carry `curated = true` and pass `tsuku validate --strict --check-libc-coverage`.

**actionlint** and **golangci-lint** were already handcrafted with correct asset patterns; this PR adds `curated = true` and splits each into explicit linux/darwin steps with `libc = ["glibc", "musl"]` (both are statically linked Go binaries that run on any libc).

**shellcheck** replaces the batch homebrew-only recipe with `github_archive` steps for glibc Linux and macOS, plus an `apk_install` fallback for musl/Alpine systems. The Haskell prebuilt binaries are glibc-linked, so musl gets shellcheck from the Alpine package index.

**shfmt** replaces the batch homebrew-only recipe with `github_file`, matching the single-binary release format from `mvdan/sh`. No archive extraction needed.

`docs/curated-tools-priority-list.md` updated: shellcheck and shfmt move from `batch` to `handcrafted | curated`; actionlint and golangci-lint updated from `no action needed` to `curated`.

---

Fixes #2289

## Test plan

- [ ] `tsuku validate --strict --check-libc-coverage` passes for all four recipes
- [ ] Sandbox install succeeds on linux/amd64 for each recipe