### PR TITLE
feat(recipes): backfill curated recipes — crypto, secrets, and certificate tools

### DIFF
--- a/docs/curated-tools-priority-list.md
+++ b/docs/curated-tools-priority-list.md
@@ -11,13 +11,13 @@ Popularity rankings are based on Homebrew download analytics, GitHub star counts
 ## Action Summary
 
 ### No action needed (handcrafted — full platform support)
-git, docker, terraform, gh, golang, fzf, btop, curl, httpie, lazygit, k9s, stern, kubectx, direnv, mise, asdf, pyenv, eksctl, flux, skaffold, kustomize, velero, vault, packer, bun, yarn, deno, pnpm, nvm, claude, gemini, trivy, grype, cosign, syft, actionlint, golangci-lint, ruff, black, prettier, eslint, tflint, pulumi, caddy, age, consul, vagrant, lazydocker, jq, wget, tmux
+git, docker, terraform, gh, golang, fzf, btop, curl, httpie, lazygit, k9s, stern, kubectx, direnv, mise, asdf, pyenv, eksctl, flux, skaffold, kustomize, velero, vault, packer, bun, yarn, deno, pnpm, nvm, claude, gemini, trivy, grype, cosign, syft, actionlint, golangci-lint, ruff, black, prettier, eslint, tflint, pulumi, caddy, age, mkcert, sops, step, consul, vagrant, lazydocker, jq, wget, tmux
 
 ### Review coverage (batch — may need platform expansion or full handcrafting)
-helm, ripgrep, fd, eza, zoxide, htop, cilium-cli, istioctl, bazel, ollama, act, earthly, goreleaser, shellcheck, shfmt, infracost, terragrunt, mkcert
+helm, ripgrep, fd, eza, zoxide, htop, cilium-cli, istioctl, bazel, ollama, act, earthly, goreleaser, shellcheck, shfmt, infracost, terragrunt
 
 ### Author recipe (missing or discovery-only — needs a recipe)
-node, python, kubectl, aws-cli, rust, bat, starship, neovim, delta, rbenv, gcloud, azure-cli, argocd, ansible, cmake, ninja-build, meson, make, gradle, maven, sbt, aider, copilot, ko, dive, hadolint, pre-commit, lefthook, checkov, sops, step
+node, python, kubectl, aws-cli, rust, bat, starship, neovim, delta, rbenv, gcloud, azure-cli, argocd, ansible, cmake, ninja-build, meson, make, gradle, maven, sbt, aider, copilot, ko, dive, hadolint, pre-commit, lefthook, checkov
 
 ## Tool Ranking
 
@@ -119,7 +119,7 @@ node, python, kubectl, aws-cli, rust, bat, starship, neovim, delta, rbenv, gclou
 | 94 | terragrunt | batch | review coverage |
 | 95 | pulumi | handcrafted | no action needed |
 | 96 | caddy | handcrafted | no action needed |
-| 97 | mkcert | batch | review coverage |
+| 97 | mkcert | handcrafted | no action needed |
 | 98 | age | handcrafted | no action needed |
-| 99 | sops | discovery-only | author recipe |
-| 100 | step | discovery-only | author recipe |
+| 99 | sops | handcrafted | no action needed |
+| 100 | step | handcrafted | no action needed |

--- a/docs/designs/DESIGN-curated-recipes.md
+++ b/docs/designs/DESIGN-curated-recipes.md
@@ -665,8 +665,8 @@ Plan: [docs/plans/PLAN-curated-recipes.md](../plans/PLAN-curated-recipes.md)
 | ~~_Curates actionlint and golangci-lint, and replaces the batch-generated recipes for shellcheck and shfmt._~~ | | |
 | ~~[#2290: feat(recipes): backfill curated recipes — Python and JS linters and formatters](https://github.com/tsukumogami/tsuku/issues/2290)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
 | ~~_Curates ruff and black, rewrites the batch recipe for prettier, and authors a new `npm_install` recipe for eslint._~~ | | |
-| [#2291: feat(recipes): backfill curated recipes — crypto, secrets, and certificate tools](https://github.com/tsukumogami/tsuku/issues/2291) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| _Curates caddy and age, rewrites the batch recipe for mkcert, and authors new recipes for sops and step._ | | |
+| ~~[#2291: feat(recipes): backfill curated recipes — crypto, secrets, and certificate tools](https://github.com/tsukumogami/tsuku/issues/2291)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
+| ~~_Curates caddy and age, rewrites the batch recipe for mkcert, and authors new recipes for sops and step._~~ | | |
 | [#2292: feat(recipes): backfill curated recipes — CI/CD automation tools](https://github.com/tsukumogami/tsuku/issues/2292) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
 | _Rewrites the batch recipes for act, earthly, and goreleaser, and authors a new recipe for the GitHub copilot CLI._ | | |
 | [#2293: feat(recipes): backfill curated recipes — container and image tools](https://github.com/tsukumogami/tsuku/issues/2293) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
@@ -758,8 +758,8 @@ graph TD
     classDef ready fill:#bbdefb
     classDef blocked fill:#fff9c4
 
-    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290 done
-    class I2291,I2292,I2293,I2294,I2295,I2296,I2297 ready
+    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291 done
+    class I2292,I2293,I2294,I2295,I2296,I2297 ready
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design.

--- a/recipes/a/age.toml
+++ b/recipes/a/age.toml
@@ -1,18 +1,27 @@
 [metadata]
 name = "age"
-description = "Simple file encryption tool"
+description = "Simple, modern file encryption"
 homepage = "https://github.com/FiloSottile/age"
 version_format = "semver"
+curated = true
+
+# Linux: statically linked Go binary works on glibc and musl
+[[steps]]
+action = "github_archive"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
+repo = "FiloSottile/age"
+asset_pattern = "age-v{version}-linux-{arch}.tar.gz"
+strip_dirs = 1
+binaries = ["age", "age-keygen"]
 
 [[steps]]
 action = "github_archive"
+when = { os = ["darwin"] }
 repo = "FiloSottile/age"
-asset_pattern = "age-v{version}-{os}-{arch}.tar.gz"
+asset_pattern = "age-v{version}-darwin-{arch}.tar.gz"
 strip_dirs = 1
-binaries = ["age"]
-os_mapping = { darwin = "darwin", linux = "linux" }
-arch_mapping = { amd64 = "amd64", arm64 = "arm64" }
+binaries = ["age", "age-keygen"]
 
 [verify]
 command = "age --version"
-pattern = "{version}"
+pattern = "v{version}"

--- a/recipes/c/caddy.toml
+++ b/recipes/c/caddy.toml
@@ -3,15 +3,24 @@ name = "caddy"
 description = "Fast HTTP server with automatic HTTPS"
 homepage = "https://caddyserver.com/"
 version_format = "semver"
+curated = true
+
+# Linux: statically linked Go binary works on glibc and musl
+[[steps]]
+action = "github_archive"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
+repo = "caddyserver/caddy"
+asset_pattern = "caddy_{version}_linux_{arch}.tar.gz"
+strip_dirs = 0
+binaries = ["caddy"]
 
 [[steps]]
 action = "github_archive"
+when = { os = ["darwin"] }
 repo = "caddyserver/caddy"
-asset_pattern = "caddy_{version}_{os}_{arch}.tar.gz"
+asset_pattern = "caddy_{version}_mac_{arch}.tar.gz"
 strip_dirs = 0
 binaries = ["caddy"]
-os_mapping = { darwin = "mac", linux = "linux" }
-arch_mapping = { amd64 = "amd64", arm64 = "arm64" }
 
 [verify]
 command = "caddy version"

--- a/recipes/m/mkcert.toml
+++ b/recipes/m/mkcert.toml
@@ -1,22 +1,16 @@
 [metadata]
-  name = "mkcert"
-  description = "Simple tool to make locally trusted development certificates"
-  homepage = "https://github.com/FiloSottile/mkcert"
-  version_format = ""
-  requires_sudo = false
-  tier = 0
-  type = ""
-  llm_validation = "skipped"
-supported_os = ["darwin"]
+name = "mkcert"
+description = "Simple tool to make locally trusted development certificates"
+homepage = "https://github.com/FiloSottile/mkcert"
+version_format = "semver"
+curated = true
 
 [[steps]]
-  action = "homebrew"
-  formula = "mkcert"
-
-[[steps]]
-  action = "install_binaries"
-  binaries = ["bin/mkcert"]
+action = "github_file"
+repo = "FiloSottile/mkcert"
+asset_pattern = "mkcert-v{version}-{os}-{arch}"
+binary = "mkcert"
 
 [verify]
-  command = "mkcert --version"
-  pattern = ""
+command = "mkcert --version"
+pattern = "v{version}"

--- a/recipes/s/sops.toml
+++ b/recipes/s/sops.toml
@@ -1,0 +1,16 @@
+[metadata]
+name = "sops"
+description = "Simple and flexible tool for managing secrets"
+homepage = "https://github.com/getsops/sops"
+version_format = "semver"
+curated = true
+
+[[steps]]
+action = "github_file"
+repo = "getsops/sops"
+asset_pattern = "sops-v{version}.{os}.{arch}"
+binary = "sops"
+
+[verify]
+command = "sops --version"
+pattern = "{version}"

--- a/recipes/s/step.toml
+++ b/recipes/s/step.toml
@@ -1,0 +1,31 @@
+[metadata]
+name = "step"
+description = "A zero-trust swiss army knife for working with X.509, OAuth, JWT, OATH OTP"
+homepage = "https://smallstep.com/cli/"
+version_format = "semver"
+curated = true
+
+[version]
+github_repo = "smallstep/cli"
+tag_prefix = "v"
+
+# Linux: statically linked Go binary works on glibc and musl
+[[steps]]
+action = "github_archive"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
+repo = "smallstep/cli"
+asset_pattern = "step_linux_{version}_{arch}.tar.gz"
+strip_dirs = 1
+binaries = ["bin/step"]
+
+[[steps]]
+action = "github_archive"
+when = { os = ["darwin"] }
+repo = "smallstep/cli"
+asset_pattern = "step_darwin_{version}_{arch}.tar.gz"
+strip_dirs = 1
+binaries = ["bin/step"]
+
+[verify]
+command = "step --version"
+pattern = "{version}"

--- a/recipes/s/step.toml
+++ b/recipes/s/step.toml
@@ -5,10 +5,6 @@ homepage = "https://smallstep.com/cli/"
 version_format = "semver"
 curated = true
 
-[version]
-github_repo = "smallstep/cli"
-tag_prefix = "v"
-
 # Linux: statically linked Go binary works on glibc and musl
 [[steps]]
 action = "github_archive"


### PR DESCRIPTION
Adds handcrafted curated recipes for five crypto, secrets, and certificate tools from the top-100 priority list. Two existing handcrafted recipes (caddy, age) gain `curated = true` and proper libc coverage declarations. The batch mkcert recipe is replaced with a clean `github_file` recipe. Two new recipes (sops, step) are authored from scratch.

**caddy**: Split into linux and darwin steps. The linux step carries `libc = ["glibc", "musl"]` following the k9s pattern — caddy is a statically linked Go binary and the same release asset works on Alpine without a separate musl path.

**age**: Same split. Also adds `age-keygen` to the binaries list (the archive ships both `age` and `age-keygen` at `strip_dirs = 1`). Verify pattern updated to `v{version}` to match `age --version` output.

**mkcert**: Replaces the batch recipe (Homebrew-only, macOS-only) with a `github_file` recipe covering linux/amd64, linux/arm64, darwin/amd64, and darwin/arm64. `github_file` is not in the glibc-bound action set so no libc when clauses are needed.

**sops**: New `github_file` recipe. Asset pattern `sops-v{version}.{os}.{arch}` covers all four platforms in a single step.

**step**: New `github_archive` recipe with two steps (linux + darwin). The archive contains `bin/step` at depth 2 (`step_0.30.2/bin/step`), so `strip_dirs = 1` and `binaries = ["bin/step"]`.

All five pass `tsuku validate --strict --check-libc-coverage` and sandbox install on linux/amd64. The priority list is updated to reflect handcrafted status for mkcert, sops, and step.

---

Fixes #2291