### PR TITLE
feat(recipes): backfill curated recipes — CI/CD automation tools

### DIFF
--- a/docs/curated-tools-priority-list.md
+++ b/docs/curated-tools-priority-list.md
@@ -11,13 +11,16 @@ Popularity rankings are based on Homebrew download analytics, GitHub star counts
 ## Action Summary
 
 ### No action needed (handcrafted — full platform support)
-git, docker, terraform, gh, golang, fzf, btop, curl, httpie, lazygit, k9s, stern, kubectx, direnv, mise, asdf, pyenv, eksctl, flux, skaffold, kustomize, velero, vault, packer, bun, yarn, deno, pnpm, nvm, claude, gemini, trivy, grype, cosign, syft, actionlint, golangci-lint, ruff, black, prettier, eslint, tflint, pulumi, caddy, age, mkcert, sops, step, consul, vagrant, lazydocker, jq, wget, tmux
+git, docker, terraform, gh, golang, fzf, btop, curl, httpie, lazygit, k9s, stern, kubectx, direnv, mise, asdf, pyenv, eksctl, flux, skaffold, kustomize, velero, vault, packer, bun, yarn, deno, pnpm, nvm, claude, gemini, trivy, grype, cosign, syft, actionlint, golangci-lint, ruff, black, prettier, eslint, tflint, pulumi, caddy, age, mkcert, sops, step, consul, vagrant, lazydocker, jq, wget, tmux, act, earthly, goreleaser
 
 ### Review coverage (batch — may need platform expansion or full handcrafting)
-helm, ripgrep, fd, eza, zoxide, htop, cilium-cli, istioctl, bazel, ollama, act, earthly, goreleaser, shellcheck, shfmt, infracost, terragrunt
+helm, ripgrep, fd, eza, zoxide, htop, cilium-cli, istioctl, bazel, ollama, shellcheck, shfmt, infracost, terragrunt
 
 ### Author recipe (missing or discovery-only — needs a recipe)
-node, python, kubectl, aws-cli, rust, bat, starship, neovim, delta, rbenv, gcloud, azure-cli, argocd, ansible, cmake, ninja-build, meson, make, gradle, maven, sbt, aider, copilot, ko, dive, hadolint, pre-commit, lefthook, checkov
+node, python, kubectl, aws-cli, rust, bat, starship, neovim, delta, rbenv, gcloud, azure-cli, argocd, ansible, cmake, ninja-build, meson, make, gradle, maven, sbt, aider, ko, dive, hadolint, pre-commit, lefthook, checkov
+
+### Not available (deprecated or no standalone binary)
+copilot — the gh-copilot CLI extension was deprecated in September 2025 (upstream notice: https://github.blog/changelog/2025-09-25-upcoming-deprecation-of-gh-copilot-cli-extension/); Copilot features are now integrated into the gh CLI directly
 
 ## Tool Ranking
 
@@ -92,10 +95,10 @@ node, python, kubectl, aws-cli, rust, bat, starship, neovim, delta, rbenv, gclou
 | 67 | gemini | handcrafted | no action needed |
 | 68 | aider | missing | author recipe |
 | 69 | ollama | batch | review coverage |
-| 70 | copilot | missing | author recipe |
-| 71 | act | batch | review coverage |
-| 72 | earthly | batch | review coverage |
-| 73 | goreleaser | batch | review coverage |
+| 70 | copilot | n/a | deprecated (gh-copilot extension shut down Sep 2025) |
+| 71 | act | handcrafted | no action needed |
+| 72 | earthly | handcrafted | no action needed |
+| 73 | goreleaser | handcrafted | no action needed |
 | 74 | ko | discovery-only | author recipe |
 | 75 | dive | discovery-only | author recipe |
 | 76 | trivy | handcrafted | no action needed |

--- a/docs/designs/DESIGN-curated-recipes.md
+++ b/docs/designs/DESIGN-curated-recipes.md
@@ -667,8 +667,8 @@ Plan: [docs/plans/PLAN-curated-recipes.md](../plans/PLAN-curated-recipes.md)
 | ~~_Curates ruff and black, rewrites the batch recipe for prettier, and authors a new `npm_install` recipe for eslint._~~ | | |
 | ~~[#2291: feat(recipes): backfill curated recipes — crypto, secrets, and certificate tools](https://github.com/tsukumogami/tsuku/issues/2291)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
 | ~~_Curates caddy and age, rewrites the batch recipe for mkcert, and authors new recipes for sops and step._~~ | | |
-| [#2292: feat(recipes): backfill curated recipes — CI/CD automation tools](https://github.com/tsukumogami/tsuku/issues/2292) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| _Rewrites the batch recipes for act, earthly, and goreleaser, and authors a new recipe for the GitHub copilot CLI._ | | |
+| ~~[#2292: feat(recipes): backfill curated recipes — CI/CD automation tools](https://github.com/tsukumogami/tsuku/issues/2292)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
+| ~~_Rewrites the batch recipes for act, earthly, and goreleaser. Copilot skipped: the gh-copilot extension was deprecated upstream in September 2025._~~ | | |
 | [#2293: feat(recipes): backfill curated recipes — container and image tools](https://github.com/tsukumogami/tsuku/issues/2293) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
 | _Curates the docker CLI recipe and authors new recipes for ko, dive, and hadolint._ | | |
 | [#2294: feat(recipes): backfill curated recipes — language runtimes](https://github.com/tsukumogami/tsuku/issues/2294) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
@@ -758,8 +758,8 @@ graph TD
     classDef ready fill:#bbdefb
     classDef blocked fill:#fff9c4
 
-    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291 done
-    class I2292,I2293,I2294,I2295,I2296,I2297 ready
+    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292 done
+    class I2293,I2294,I2295,I2296,I2297 ready
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design.

--- a/recipes/a/act.toml
+++ b/recipes/a/act.toml
@@ -1,22 +1,30 @@
 [metadata]
-  name = "act"
-  description = "Run your GitHub Actions locally"
-  homepage = "https://github.com/nektos/act"
-  version_format = ""
-  requires_sudo = false
-  tier = 0
-  type = ""
-  llm_validation = "skipped"
-supported_os = ["darwin"]
+name = "act"
+description = "Run your GitHub Actions locally"
+homepage = "https://github.com/nektos/act"
+version_format = "semver"
+curated = true
+# act ships glibc-linked binaries; no musl/alpine build available upstream
+supported_libc = ["glibc"]
 
 [[steps]]
-  action = "homebrew"
-  formula = "act"
+action = "github_archive"
+when = { os = ["linux"], libc = ["glibc"] }
+repo = "nektos/act"
+asset_pattern = "act_Linux_{arch}.tar.gz"
+strip_dirs = 0
+binaries = ["act"]
+arch_mapping = { amd64 = "x86_64" }
 
 [[steps]]
-  action = "install_binaries"
-  binaries = ["bin/act"]
+action = "github_archive"
+when = { os = ["darwin"] }
+repo = "nektos/act"
+asset_pattern = "act_Darwin_{arch}.tar.gz"
+strip_dirs = 0
+binaries = ["act"]
+arch_mapping = { amd64 = "x86_64" }
 
 [verify]
-  command = "act --version"
-  pattern = ""
+command = "act --version"
+pattern = "{version}"

--- a/recipes/e/earthly.toml
+++ b/recipes/e/earthly.toml
@@ -1,34 +1,18 @@
 [metadata]
-  name = "earthly"
-  description = "Build automation tool for the container era"
-  homepage = "https://earthly.dev/"
-  version_format = ""
-  requires_sudo = false
-  tier = 0
-  type = ""
-  llm_validation = "skipped"
-
-[version]
-  source = ""
-  github_repo = ""
-  tag_prefix = ""
-  module = ""
-  formula = ""
-  cask = ""
-  tap = ""
-  fossil_repo = ""
-  project_name = ""
-  version_separator = ""
-  timeline_tag = ""
+name = "earthly"
+description = "Build automation tool for the container era"
+homepage = "https://earthly.dev/"
+version_format = "semver"
+curated = true
+# earthly ships glibc-linked binaries; no musl/alpine build available upstream
+supported_libc = ["glibc"]
 
 [[steps]]
-  action = "homebrew"
-  formula = "earthly"
-
-[[steps]]
-  action = "install_binaries"
-  binaries = ["bin/earthly"]
+action = "github_file"
+repo = "earthly/earthly"
+asset_pattern = "earthly-{os}-{arch}"
+binary = "earthly"
 
 [verify]
-  command = "earthly --version"
-  pattern = ""
+command = "earthly --version"
+pattern = "{version}"

--- a/recipes/g/goreleaser.toml
+++ b/recipes/g/goreleaser.toml
@@ -1,34 +1,30 @@
 [metadata]
-  name = "goreleaser"
-  description = "Deliver Go binaries as fast and easily as possible"
-  homepage = "https://goreleaser.com/"
-  version_format = ""
-  requires_sudo = false
-  tier = 0
-  type = ""
-  llm_validation = "skipped"
-
-[version]
-  source = ""
-  github_repo = ""
-  tag_prefix = ""
-  module = ""
-  formula = ""
-  cask = ""
-  tap = ""
-  fossil_repo = ""
-  project_name = ""
-  version_separator = ""
-  timeline_tag = ""
+name = "goreleaser"
+description = "Deliver Go binaries as fast and easily as possible"
+homepage = "https://goreleaser.com/"
+version_format = "semver"
+curated = true
+# goreleaser ships glibc-linked binaries; no musl/alpine build available upstream
+supported_libc = ["glibc"]
 
 [[steps]]
-  action = "homebrew"
-  formula = "goreleaser"
+action = "github_archive"
+when = { os = ["linux"], libc = ["glibc"] }
+repo = "goreleaser/goreleaser"
+asset_pattern = "goreleaser_Linux_{arch}.tar.gz"
+strip_dirs = 0
+binaries = ["goreleaser"]
+arch_mapping = { amd64 = "x86_64" }
 
 [[steps]]
-  action = "install_binaries"
-  binaries = ["bin/goreleaser"]
+action = "github_archive"
+when = { os = ["darwin"] }
+repo = "goreleaser/goreleaser"
+asset_pattern = "goreleaser_Darwin_{arch}.tar.gz"
+strip_dirs = 0
+binaries = ["goreleaser"]
+arch_mapping = { amd64 = "x86_64" }
 
 [verify]
-  command = "goreleaser --version"
-  pattern = ""
+command = "goreleaser --version"
+pattern = "{version}"


### PR DESCRIPTION
Rewrites the batch-generated stubs for act, earthly, and goreleaser with handcrafted curated recipes. Each recipe uses `github_archive` or `github_file` actions for direct upstream binary downloads, replacing the broken Homebrew-only stubs from the batch pipeline.

All three tools distribute glibc-linked binaries only (no musl/alpine upstream build). `supported_libc = ["glibc"]` is set in each recipe's metadata so CI skips alpine testing, matching how the CI skip logic works (grep for `supported_libc` without `"musl"`).

The gh-copilot CLI extension was deprecated upstream in September 2025 — no replacement standalone binary exists, so no copilot recipe is authored. This is noted in the priority list.

---

Fixes #2292

## What This Changes

- `recipes/a/act.toml` — rewritten from Homebrew stub to `github_archive` against `nektos/act`, linux + darwin, `arch_mapping = { amd64 = "x86_64" }`
- `recipes/e/earthly.toml` — rewritten from Homebrew stub to `github_file` against `earthly/earthly` (single-step cross-platform, binaries named `earthly-{os}-{arch}`)
- `recipes/g/goreleaser.toml` — rewritten from Homebrew stub to `github_archive` against `goreleaser/goreleaser`, linux + darwin, `arch_mapping = { amd64 = "x86_64" }`
- `docs/curated-tools-priority-list.md` — act/earthly/goreleaser moved to handcrafted; copilot marked deprecated
- `docs/designs/DESIGN-curated-recipes.md` — #2292 marked complete, Mermaid diagram updated

## Notes

- `validate --strict` passes for all three recipes
- `validate --strict --check-libc-coverage` warns for act and goreleaser (github_archive is glibc-bound, no musl fallback). This check is only enforced by CI for embedded recipes in `internal/recipe/recipes/`; the PR test-recipe.yml workflow skips alpine for recipes declaring `supported_libc = ["glibc"]`
- act's GitHub releases had transient 502 errors during local testing; the debian sandbox test passed before the outage began, and CI has retry logic for network errors