### PR TITLE
feat(recipes): backfill curated recipes — container and image tools

### DIFF
--- a/docs/curated-tools-priority-list.md
+++ b/docs/curated-tools-priority-list.md
@@ -29,7 +29,7 @@ copilot — the gh-copilot CLI extension was deprecated in September 2025 (upstr
 | 1 | git | handcrafted | no action needed |
 | 2 | node | discovery-only | author recipe |
 | 3 | python | missing | author recipe |
-| 4 | docker | handcrafted | no action needed |
+| 4 | docker | handcrafted | curated |
 | 5 | kubectl | batch | review coverage |
 | 6 | terraform | handcrafted | no action needed |
 | 7 | aws-cli | discovery-only | author recipe |
@@ -99,13 +99,13 @@ copilot — the gh-copilot CLI extension was deprecated in September 2025 (upstr
 | 71 | act | handcrafted | no action needed |
 | 72 | earthly | handcrafted | no action needed |
 | 73 | goreleaser | handcrafted | no action needed |
-| 74 | ko | discovery-only | author recipe |
-| 75 | dive | discovery-only | author recipe |
+| 74 | ko | handcrafted | curated |
+| 75 | dive | handcrafted | curated |
 | 76 | trivy | handcrafted | no action needed |
 | 77 | grype | handcrafted | no action needed |
 | 78 | cosign | handcrafted | no action needed |
 | 79 | syft | handcrafted | no action needed |
-| 80 | hadolint | discovery-only | author recipe |
+| 80 | hadolint | handcrafted | curated |
 | 81 | shellcheck | handcrafted | curated |
 | 82 | shfmt | handcrafted | curated |
 | 83 | pre-commit | discovery-only | author recipe |

--- a/docs/designs/DESIGN-curated-recipes.md
+++ b/docs/designs/DESIGN-curated-recipes.md
@@ -669,8 +669,8 @@ Plan: [docs/plans/PLAN-curated-recipes.md](../plans/PLAN-curated-recipes.md)
 | ~~_Curates caddy and age, rewrites the batch recipe for mkcert, and authors new recipes for sops and step._~~ | | |
 | ~~[#2292: feat(recipes): backfill curated recipes — CI/CD automation tools](https://github.com/tsukumogami/tsuku/issues/2292)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
 | ~~_Rewrites the batch recipes for act, earthly, and goreleaser. Copilot skipped: the gh-copilot extension was deprecated upstream in September 2025._~~ | | |
-| [#2293: feat(recipes): backfill curated recipes — container and image tools](https://github.com/tsukumogami/tsuku/issues/2293) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| _Curates the docker CLI recipe and authors new recipes for ko, dive, and hadolint._ | | |
+| ~~[#2293: feat(recipes): backfill curated recipes — container and image tools](https://github.com/tsukumogami/tsuku/issues/2293)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
+| ~~_Curates the docker CLI recipe and authors new recipes for ko, dive, and hadolint._~~ | | |
 | [#2294: feat(recipes): backfill curated recipes — language runtimes](https://github.com/tsukumogami/tsuku/issues/2294) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
 | _Curates the golang toolchain recipe and authors new recipes for python, rust, and ruby._ | | |
 | [#2295: feat(recipes): backfill curated recipes — C++ and JVM build tools](https://github.com/tsukumogami/tsuku/issues/2295) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
@@ -758,8 +758,8 @@ graph TD
     classDef ready fill:#bbdefb
     classDef blocked fill:#fff9c4
 
-    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292 done
-    class I2293,I2294,I2295,I2296,I2297 ready
+    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293 done
+    class I2294,I2295,I2296,I2297 ready
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design.

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -65,12 +65,12 @@ Introduce a `curated = true` flag for handcrafted recipes, nightly cross-platfor
 | ~~_Curates actionlint and golangci-lint, and replaces the batch-generated recipes for shellcheck and shfmt._~~ | | |
 | ~~[#2290: feat(recipes): backfill curated recipes — Python and JS linters and formatters](https://github.com/tsukumogami/tsuku/issues/2290)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
 | ~~_Curates ruff and black, rewrites the batch recipe for prettier, and authors a new `npm_install` recipe for eslint._~~ | | |
-| [#2291: feat(recipes): backfill curated recipes — crypto, secrets, and certificate tools](https://github.com/tsukumogami/tsuku/issues/2291) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| _Curates caddy and age, rewrites the batch recipe for mkcert, and authors new recipes for sops and step._ | | |
-| [#2292: feat(recipes): backfill curated recipes — CI/CD automation tools](https://github.com/tsukumogami/tsuku/issues/2292) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| _Rewrites the batch recipes for act, earthly, and goreleaser, and authors a new recipe for the GitHub copilot CLI._ | | |
-| [#2293: feat(recipes): backfill curated recipes — container and image tools](https://github.com/tsukumogami/tsuku/issues/2293) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| _Curates the docker CLI recipe and authors new recipes for ko, dive, and hadolint._ | | |
+| ~~[#2291: feat(recipes): backfill curated recipes — crypto, secrets, and certificate tools](https://github.com/tsukumogami/tsuku/issues/2291)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
+| ~~_Curates caddy and age, rewrites the batch recipe for mkcert, and authors new recipes for sops and step._~~ | | |
+| ~~[#2292: feat(recipes): backfill curated recipes — CI/CD automation tools](https://github.com/tsukumogami/tsuku/issues/2292)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
+| ~~_Rewrites the batch recipes for act, earthly, and goreleaser. Copilot skipped: the gh-copilot extension was deprecated upstream in September 2025._~~ | | |
+| ~~[#2293: feat(recipes): backfill curated recipes — container and image tools](https://github.com/tsukumogami/tsuku/issues/2293)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
+| ~~_Curates the docker CLI recipe and authors new recipes for ko, dive, and hadolint._~~ | | |
 | [#2294: feat(recipes): backfill curated recipes — language runtimes](https://github.com/tsukumogami/tsuku/issues/2294) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
 | _Curates the golang toolchain recipe and authors new recipes for python, rust, and ruby._ | | |
 | [#2295: feat(recipes): backfill curated recipes — C++ and JVM build tools](https://github.com/tsukumogami/tsuku/issues/2295) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
@@ -178,8 +178,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290 done
-    class I2291,I2292,I2293,I2294,I2295,I2296,I2297,I2312,I2315 ready
+    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293 done
+    class I2294,I2295,I2296,I2297,I2312,I2315 ready
     class I2313 blocked
 ```
 

--- a/recipes/d/dive.toml
+++ b/recipes/d/dive.toml
@@ -1,0 +1,27 @@
+[metadata]
+name = "dive"
+description = "A tool for exploring each layer in a docker image"
+homepage = "https://github.com/wagoodman/dive"
+version_format = "semver"
+curated = true
+
+# Linux: statically linked Go binary works on glibc and musl
+[[steps]]
+action = "github_archive"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
+repo = "wagoodman/dive"
+asset_pattern = "dive_{version}_linux_{arch}.tar.gz"
+strip_dirs = 0
+binaries = ["dive"]
+
+[[steps]]
+action = "github_archive"
+when = { os = ["darwin"] }
+repo = "wagoodman/dive"
+asset_pattern = "dive_{version}_darwin_{arch}.tar.gz"
+strip_dirs = 0
+binaries = ["dive"]
+
+[verify]
+command = "dive --version"
+pattern = "{version}"

--- a/recipes/d/docker.toml
+++ b/recipes/d/docker.toml
@@ -3,42 +3,30 @@ name = "docker"
 description = "Container runtime platform"
 homepage = "https://www.docker.com"
 version_format = "semver"
+curated = true
+# docker ships glibc-linked binaries; no musl/alpine static build available for v25+
+supported_libc = ["glibc"]
 
-# macOS: Install Docker Desktop via Homebrew Cask
 [[steps]]
-action = "brew_cask"
-packages = ["docker"]
+action = "homebrew"
+when = { os = ["linux"], libc = ["glibc"] }
+formula = "docker"
 
-# Debian/Ubuntu: Install docker.io from system repos
 [[steps]]
-action = "apt_install"
-packages = ["docker.io"]
+action = "install_binaries"
+when = { os = ["linux"], libc = ["glibc"] }
+binaries = ["bin/docker"]
 
-# RHEL/Fedora: Install moby-engine from system repos
 [[steps]]
-action = "dnf_install"
-packages = ["moby-engine"]
+action = "homebrew"
+when = { os = ["darwin"] }
+formula = "docker"
 
-# Arch Linux: Install docker from system repos
 [[steps]]
-action = "pacman_install"
-packages = ["docker"]
-
-# Alpine: Install docker from system repos
-[[steps]]
-action = "apk_install"
-packages = ["docker"]
-
-# SUSE/openSUSE: Install docker from system repos
-[[steps]]
-action = "zypper_install"
-packages = ["docker"]
-
-# Verify docker is available
-[[steps]]
-action = "require_command"
-command = "docker"
+action = "install_binaries"
+when = { os = ["darwin"] }
+binaries = ["bin/docker"]
 
 [verify]
 command = "docker --version"
-pattern = "Docker version {version}"
+pattern = "{version}"

--- a/recipes/d/docker.toml
+++ b/recipes/d/docker.toml
@@ -4,18 +4,14 @@ description = "Container runtime platform"
 homepage = "https://www.docker.com"
 version_format = "semver"
 curated = true
-# docker ships glibc-linked binaries; no musl/alpine static build available for v25+
-supported_libc = ["glibc"]
 
 [[steps]]
-action = "homebrew"
-when = { os = ["linux"], libc = ["glibc"] }
-formula = "docker"
-
-[[steps]]
-action = "install_binaries"
-when = { os = ["linux"], libc = ["glibc"] }
-binaries = ["bin/docker"]
+action = "download_archive"
+when = { os = ["linux"] }
+url = "https://download.docker.com/linux/static/stable/{arch}/docker-{version}.tgz"
+strip_dirs = 1
+binaries = ["docker"]
+arch_mapping = { amd64 = "x86_64", arm64 = "aarch64" }
 
 [[steps]]
 action = "homebrew"

--- a/recipes/h/hadolint.toml
+++ b/recipes/h/hadolint.toml
@@ -1,0 +1,19 @@
+[metadata]
+name = "hadolint"
+description = "Dockerfile linter, validate inline bash"
+homepage = "https://github.com/hadolint/hadolint"
+version_format = "semver"
+curated = true
+
+# Single step covers all platforms; hadolint assets use "macos" instead of "darwin"
+[[steps]]
+action = "github_file"
+repo = "hadolint/hadolint"
+asset_pattern = "hadolint-{os}-{arch}"
+binary = "hadolint"
+os_mapping = { darwin = "macos" }
+arch_mapping = { amd64 = "x86_64" }
+
+[verify]
+command = "hadolint --version"
+pattern = "{version}"

--- a/recipes/k/ko.toml
+++ b/recipes/k/ko.toml
@@ -1,0 +1,29 @@
+[metadata]
+name = "ko"
+description = "Build and deploy Go applications on Kubernetes"
+homepage = "https://ko.build"
+version_format = "semver"
+curated = true
+
+# Linux: statically linked Go binary works on glibc and musl
+[[steps]]
+action = "github_archive"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
+repo = "ko-build/ko"
+asset_pattern = "ko_{version}_Linux_{arch}.tar.gz"
+strip_dirs = 0
+binaries = ["ko"]
+arch_mapping = { amd64 = "x86_64" }
+
+[[steps]]
+action = "github_archive"
+when = { os = ["darwin"] }
+repo = "ko-build/ko"
+asset_pattern = "ko_{version}_Darwin_{arch}.tar.gz"
+strip_dirs = 0
+binaries = ["ko"]
+arch_mapping = { amd64 = "x86_64" }
+
+[verify]
+command = "ko version"
+pattern = "{version}"


### PR DESCRIPTION
Rewrites the docker recipe to use the static Linux binary from
download.docker.com/linux/static/stable, which is statically linked and works
on both glibc and musl. macOS uses the homebrew bottle since Docker does not
publish standalone macOS CLI binaries.

Authors three new curated recipes: ko (Build and deploy Go applications on
Kubernetes), dive (explore Docker image layers), and hadolint (Dockerfile
linter). The ko and dive recipes use statically linked Go binaries that work
on both glibc and musl. The hadolint recipe uses github_file with os_mapping
to handle hadolint's non-standard "macos" OS name in release asset names.

---

## Recipes

**docker** — rewritten; Linux uses `download_archive` from `download.docker.com/linux/static/stable` (static, glibc+musl); macOS uses homebrew bottle

**ko** — new; github_archive; static Go binary, glibc and musl

**dive** — new; github_archive; static Go binary, glibc and musl

**hadolint** — new; github_file with `os_mapping = { darwin = "macos" }` and `arch_mapping = { amd64 = "x86_64" }`

## Test Plan

All four recipes sandbox-tested on debian; docker also tested on alpine with the static tsuku binary:

```
docker   PASSED (debian, alpine)
ko       PASSED (debian)
dive     PASSED (debian)
hadolint PASSED (debian)
```

ko and dive alpine coverage comes from CI, which builds tsuku with CGO_ENABLED=0.

Fixes #2293