### PR TITLE
feat(recipes): backfill curated recipes for IaC quality and policy tools

### DIFF
--- a/docs/curated-tools-priority-list.md
+++ b/docs/curated-tools-priority-list.md
@@ -11,13 +11,13 @@ Popularity rankings are based on Homebrew download analytics, GitHub star counts
 ## Action Summary
 
 ### No action needed (handcrafted or curated — full platform support)
-git, docker, terraform, gh, golang, python, rust, fzf, btop, curl, httpie, lazygit, k9s, stern, kubectx, direnv, mise, asdf, pyenv, eksctl, flux, skaffold, kustomize, velero, vault, packer, bun, yarn, deno, pnpm, nvm, claude, gemini, trivy, grype, cosign, syft, actionlint, golangci-lint, ruff, black, prettier, eslint, tflint, pulumi, caddy, age, mkcert, sops, step, consul, vagrant, lazydocker, jq, wget, tmux, act, earthly, goreleaser, make, ninja-build, meson, argocd
+git, docker, terraform, gh, golang, python, rust, fzf, btop, curl, httpie, lazygit, k9s, stern, kubectx, direnv, mise, asdf, pyenv, eksctl, flux, skaffold, kustomize, velero, vault, packer, bun, yarn, deno, pnpm, nvm, claude, gemini, trivy, grype, cosign, syft, actionlint, golangci-lint, ruff, black, prettier, eslint, tflint, pulumi, caddy, age, mkcert, sops, step, consul, vagrant, lazydocker, jq, wget, tmux, act, earthly, goreleaser, make, ninja-build, meson, argocd, terragrunt, infracost, lefthook, pre-commit, checkov
 
 ### Review coverage (batch — may need platform expansion or full handcrafting)
-helm, ripgrep, fd, eza, zoxide, htop, cilium-cli, istioctl, bazel, ollama, shellcheck, shfmt, infracost, terragrunt
+helm, ripgrep, fd, eza, zoxide, htop, cilium-cli, istioctl, bazel, ollama, shellcheck, shfmt
 
 ### Author recipe (missing or discovery-only — needs a recipe)
-node, kubectl, aws-cli, bat, starship, neovim, delta, rbenv, gcloud, ansible, azure-cli, cmake, gradle, maven, sbt, aider, ko, dive, hadolint, pre-commit, lefthook, checkov
+node, kubectl, aws-cli, bat, starship, neovim, delta, rbenv, gcloud, ansible, azure-cli, cmake, gradle, maven, sbt, aider, ko, dive, hadolint
 
 ### Not available (deprecated or no standalone binary)
 copilot — the gh-copilot CLI extension was deprecated in September 2025 (upstream notice: https://github.blog/changelog/2025-09-25-upcoming-deprecation-of-gh-copilot-cli-extension/); Copilot features are now integrated into the gh CLI directly
@@ -108,8 +108,8 @@ copilot — the gh-copilot CLI extension was deprecated in September 2025 (upstr
 | 80 | hadolint | handcrafted | curated |
 | 81 | shellcheck | handcrafted | curated |
 | 82 | shfmt | handcrafted | curated |
-| 83 | pre-commit | discovery-only | author recipe |
-| 84 | lefthook | discovery-only | author recipe |
+| 83 | pre-commit | curated | curated |
+| 84 | lefthook | curated | curated |
 | 85 | actionlint | handcrafted | curated |
 | 86 | golangci-lint | handcrafted | curated |
 | 87 | ruff | handcrafted | curated |
@@ -117,9 +117,9 @@ copilot — the gh-copilot CLI extension was deprecated in September 2025 (upstr
 | 89 | prettier | handcrafted | curated |
 | 90 | eslint | handcrafted | curated |
 | 91 | tflint | handcrafted | no action needed |
-| 92 | checkov | discovery-only | author recipe |
-| 93 | infracost | batch | review coverage |
-| 94 | terragrunt | batch | review coverage |
+| 92 | checkov | curated | curated |
+| 93 | infracost | curated | curated |
+| 94 | terragrunt | curated | curated |
 | 95 | pulumi | handcrafted | no action needed |
 | 96 | caddy | handcrafted | no action needed |
 | 97 | mkcert | handcrafted | no action needed |

--- a/docs/designs/DESIGN-curated-recipes.md
+++ b/docs/designs/DESIGN-curated-recipes.md
@@ -677,8 +677,8 @@ Plan: [docs/plans/PLAN-curated-recipes.md](../plans/PLAN-curated-recipes.md)
 | ~~_Curates the embedded recipes for make, ninja, and meson. Gradle, maven, and sbt deferred: #2325 (milestone-tag handling for gradle and sbt) and #2327 (openjdk recipe needed before any JVM tool can be verified)._~~ | | |
 | ~~[#2296: feat(recipes): backfill curated recipes — cloud CLIs and orchestration](https://github.com/tsukumogami/tsuku/issues/2296)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
 | ~~_Curates argocd. Deferred: gcloud (#2328), bazel (#2330), ansible and azure-cli (#2331 — pipx version-constraint needed because python-standalone 3.10 cannot install the latest pypi releases)._~~ | | |
-| [#2297: feat(recipes): backfill curated recipes — IaC quality and policy tools](https://github.com/tsukumogami/tsuku/issues/2297) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| _Rewrites the batch recipes for terragrunt and infracost, and authors new recipes for pre-commit, lefthook, and checkov._ | | |
+| ~~[#2297: feat(recipes): backfill curated recipes — IaC quality and policy tools](https://github.com/tsukumogami/tsuku/issues/2297)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
+| ~~_Rewrites the batch recipes for terragrunt and infracost, and authors new recipes for pre-commit, lefthook, and checkov._~~ | | |
 
 ```mermaid
 graph TD
@@ -758,8 +758,7 @@ graph TD
     classDef ready fill:#bbdefb
     classDef blocked fill:#fff9c4
 
-    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296 done
-    class I2297 ready
+    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297 done
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design.

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -77,8 +77,8 @@ Introduce a `curated = true` flag for handcrafted recipes, nightly cross-platfor
 | ~~_Curates the embedded recipes for make, ninja, and meson. Gradle, maven, and sbt deferred to follow-ups: #2325 (gradle and sbt resolve to milestone-tag pre-releases) and #2327 (the JVM tools cannot be verified without an `openjdk` recipe to declare as a runtime dependency)._~~ | | |
 | ~~[#2296: feat(recipes): backfill curated recipes — cloud CLIs and orchestration](https://github.com/tsukumogami/tsuku/issues/2296)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
 | ~~_Authors a new curated recipe for argocd. Other tools deferred: gcloud to #2328 (no version source for Google's distribution channel), bazel to #2330 (single-binary self-extraction fails in the test-recipe sandbox), and ansible plus azure-cli to #2331 (the bundled python-standalone is 3.10 and pipx_install picks the latest pypi version, which has dropped 3.10 support; needs version-constraint support)._~~ | | |
-| [#2297: feat(recipes): backfill curated recipes — IaC quality and policy tools](https://github.com/tsukumogami/tsuku/issues/2297) | [#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260) | testable |
-| _Rewrites the batch recipes for terragrunt and infracost, and authors new recipes for pre-commit, lefthook, and checkov._ | | |
+| ~~[#2297: feat(recipes): backfill curated recipes — IaC quality and policy tools](https://github.com/tsukumogami/tsuku/issues/2297)~~ | ~~[#2259](https://github.com/tsukumogami/tsuku/issues/2259), [#2260](https://github.com/tsukumogami/tsuku/issues/2260)~~ | ~~testable~~ |
+| ~~_Rewrites the batch recipes for terragrunt and infracost, and authors new recipes for pre-commit, lefthook, and checkov._~~ | | |
 | [#2312: feat(recipes): fix macOS library dependencies needed for curl, wget, tmux, and git](https://github.com/tsukumogami/tsuku/issues/2312) | None | testable |
 | _Adds the `nghttp3` recipe (curl), fixes the macOS path for `libevent` (tmux), rewrites `utf8proc` from batch garbage (tmux), and updates `pcre2` to install its dylib on macOS (git). Unblocks darwin coverage for all four tools._ | | |
 | [#2313: feat(recipes): add macOS support to curl, wget, tmux, and git recipes](https://github.com/tsukumogami/tsuku/issues/2313) | [#2312](https://github.com/tsukumogami/tsuku/issues/2312) | testable |
@@ -178,8 +178,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296 done
-    class I2297,I2312,I2315 ready
+    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297 done
+    class I2312,I2315 ready
     class I2313 blocked
 ```
 

--- a/recipes/c/checkov.toml
+++ b/recipes/c/checkov.toml
@@ -1,0 +1,29 @@
+[metadata]
+name = "checkov"
+description = "Static analysis for infrastructure-as-code"
+homepage = "https://www.checkov.io/"
+version_format = "semver"
+curated = true
+# Checkov pulls a wide native dependency closure (cryptography, lxml, ...);
+# musl wheels are spotty and Alpine has no upstream apk package, so the
+# install fails to compile from source. Restrict to glibc Linux and macOS.
+supported_libc = ["glibc"]
+
+# glibc Linux: pipx pulls the checkov distribution from PyPI.
+[[steps]]
+action = "pipx_install"
+when = { os = ["linux"], libc = ["glibc"] }
+package = "checkov"
+executables = ["checkov"]
+
+# macOS: pipx works for both Intel and Apple Silicon.
+[[steps]]
+action = "pipx_install"
+when = { os = ["darwin"] }
+package = "checkov"
+executables = ["checkov"]
+
+[verify]
+command = "checkov --version"
+mode = "output"
+reason = "checkov --version prints just a numeric version with no tool prefix; output mode confirms the binary is runnable"

--- a/recipes/i/infracost.toml
+++ b/recipes/i/infracost.toml
@@ -1,34 +1,30 @@
 [metadata]
-  name = "infracost"
-  description = "Cost estimates for Terraform"
-  homepage = "https://www.infracost.io/docs/"
-  version_format = ""
-  requires_sudo = false
-  tier = 0
-  type = ""
-  llm_validation = "skipped"
+name = "infracost"
+description = "Cloud cost estimates for Terraform"
+homepage = "https://www.infracost.io/"
+version_format = "semver"
+curated = true
 
 [version]
-  source = ""
-  github_repo = ""
-  tag_prefix = ""
-  module = ""
-  formula = ""
-  cask = ""
-  tap = ""
-  fossil_repo = ""
-  project_name = ""
-  version_separator = ""
-  timeline_tag = ""
+github_repo = "infracost/infracost"
+tag_prefix = "v"
 
+# Linux: statically linked Go binary in a tar.gz; works on glibc and musl.
 [[steps]]
-  action = "homebrew"
-  formula = "infracost"
+action = "github_archive"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
+repo = "infracost/infracost"
+asset_pattern = "infracost-linux-{arch}.tar.gz"
+binaries = [{src = "infracost-linux-{arch}", dest = "bin/infracost"}]
 
+# macOS: per-arch tarball with the same internal binary name.
 [[steps]]
-  action = "install_binaries"
-  binaries = ["bin/infracost"]
+action = "github_archive"
+when = { os = ["darwin"] }
+repo = "infracost/infracost"
+asset_pattern = "infracost-darwin-{arch}.tar.gz"
+binaries = [{src = "infracost-darwin-{arch}", dest = "bin/infracost"}]
 
 [verify]
-  command = "infracost --version"
-  pattern = ""
+command = "infracost --version"
+pattern = "Infracost v{version}"

--- a/recipes/l/lefthook.toml
+++ b/recipes/l/lefthook.toml
@@ -16,7 +16,7 @@ when = { os = ["linux"], libc = ["glibc", "musl"] }
 repo = "evilmartians/lefthook"
 asset_pattern = "lefthook_{version}_Linux_{arch}"
 arch_mapping = { amd64 = "x86_64", arm64 = "arm64" }
-binaries = [{src = "lefthook_{version}_Linux_{arch}", dest = "bin/lefthook"}]
+binary = "lefthook"
 
 # macOS: per-arch binary; upstream uses "MacOS" (not "Darwin") in the asset name.
 [[steps]]
@@ -25,7 +25,7 @@ when = { os = ["darwin"] }
 repo = "evilmartians/lefthook"
 asset_pattern = "lefthook_{version}_MacOS_{arch}"
 arch_mapping = { amd64 = "x86_64", arm64 = "arm64" }
-binaries = [{src = "lefthook_{version}_MacOS_{arch}", dest = "bin/lefthook"}]
+binary = "lefthook"
 
 [verify]
 command = "lefthook version"

--- a/recipes/l/lefthook.toml
+++ b/recipes/l/lefthook.toml
@@ -1,0 +1,32 @@
+[metadata]
+name = "lefthook"
+description = "Fast and powerful Git hooks manager"
+homepage = "https://lefthook.dev/"
+version_format = "semver"
+curated = true
+
+[version]
+github_repo = "evilmartians/lefthook"
+tag_prefix = "v"
+
+# Linux: statically linked Go binary, works on glibc and musl.
+[[steps]]
+action = "github_file"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
+repo = "evilmartians/lefthook"
+asset_pattern = "lefthook_{version}_Linux_{arch}"
+arch_mapping = { amd64 = "x86_64", arm64 = "arm64" }
+binaries = [{src = "lefthook_{version}_Linux_{arch}", dest = "bin/lefthook"}]
+
+# macOS: per-arch binary; upstream uses "MacOS" (not "Darwin") in the asset name.
+[[steps]]
+action = "github_file"
+when = { os = ["darwin"] }
+repo = "evilmartians/lefthook"
+asset_pattern = "lefthook_{version}_MacOS_{arch}"
+arch_mapping = { amd64 = "x86_64", arm64 = "arm64" }
+binaries = [{src = "lefthook_{version}_MacOS_{arch}", dest = "bin/lefthook"}]
+
+[verify]
+command = "lefthook version"
+pattern = "{version}"

--- a/recipes/p/pre-commit.toml
+++ b/recipes/p/pre-commit.toml
@@ -1,0 +1,31 @@
+[metadata]
+name = "pre-commit"
+description = "Framework for managing and maintaining multi-language pre-commit hooks"
+homepage = "https://pre-commit.com/"
+version_format = "semver"
+curated = true
+
+# glibc Linux: pipx pulls a pure-Python wheel; pre-commit 4.x supports Python 3.10+.
+[[steps]]
+action = "pipx_install"
+when = { os = ["linux"], libc = ["glibc"] }
+package = "pre-commit"
+executables = ["pre-commit"]
+
+# musl Linux (Alpine): pipx is fragile on musl; use the system package.
+[[steps]]
+action = "apk_install"
+when = { os = ["linux"], libc = ["musl"] }
+packages = ["pre-commit"]
+
+# macOS: pipx works for the pure-Python pre-commit distribution.
+[[steps]]
+action = "pipx_install"
+when = { os = ["darwin"] }
+package = "pre-commit"
+executables = ["pre-commit"]
+
+[verify]
+command = "pre-commit --version"
+mode = "output"
+reason = "Alpine package version may differ from upstream pypi release; output mode confirms the tool is runnable on every platform"

--- a/recipes/t/terragrunt.toml
+++ b/recipes/t/terragrunt.toml
@@ -1,22 +1,30 @@
 [metadata]
-  name = "terragrunt"
-  description = "Thin wrapper for Terraform e.g. for locking state"
-  homepage = "https://terragrunt.gruntwork.io/"
-  version_format = ""
-  requires_sudo = false
-  tier = 0
-  type = ""
-  llm_validation = "skipped"
-supported_os = ["darwin"]
+name = "terragrunt"
+description = "Thin wrapper for Terraform that adds tooling for keeping configurations DRY"
+homepage = "https://terragrunt.gruntwork.io/"
+version_format = "semver"
+curated = true
 
-[[steps]]
-  action = "homebrew"
-  formula = "terragrunt"
+[version]
+github_repo = "gruntwork-io/terragrunt"
+tag_prefix = "v"
 
+# Linux: statically linked Go binary, works on glibc and musl.
 [[steps]]
-  action = "install_binaries"
-  binaries = ["bin/terragrunt"]
+action = "github_file"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
+repo = "gruntwork-io/terragrunt"
+asset_pattern = "terragrunt_linux_{arch}"
+binaries = [{src = "terragrunt_linux_{arch}", dest = "bin/terragrunt"}]
+
+# macOS: per-arch single binary.
+[[steps]]
+action = "github_file"
+when = { os = ["darwin"] }
+repo = "gruntwork-io/terragrunt"
+asset_pattern = "terragrunt_darwin_{arch}"
+binaries = [{src = "terragrunt_darwin_{arch}", dest = "bin/terragrunt"}]
 
 [verify]
-  command = "terragrunt --version"
-  pattern = ""
+command = "terragrunt --version"
+pattern = "terragrunt version v{version}"


### PR DESCRIPTION
Rewrite the batch-generated `recipes/t/terragrunt.toml` and `recipes/i/infracost.toml` with full cross-platform coverage (linux glibc and musl on amd64 and arm64, darwin amd64 and arm64). Both ship statically linked Go binaries from GitHub releases: terragrunt as a bare binary, infracost inside a per-OS-and-arch tar.gz. Add three new curated recipes: `recipes/l/lefthook.toml` uses `github_file` against `evilmartians/lefthook`, with separate steps for linux and darwin because upstream uses `MacOS` rather than `Darwin` in the asset filename; `recipes/p/pre-commit.toml` follows the pure-Python pattern from `black.toml` (pipx on glibc and darwin, apk on musl, output-mode verify); `recipes/c/checkov.toml` uses pipx on glibc Linux and macOS, with `supported_libc = ["glibc"]` because checkov pulls a wide native dependency closure (cryptography, lxml) that lacks reliable musl wheels and has no Alpine package. Update the priority list, plan, and design docs.

---

## What This Accomplishes

Closes the IaC-quality-and-policy slice of the curated-recipes milestone. All five tools in the original batch ship in this PR.

## Reviewer Notes

- pre-commit 4.6.0 declares `requires_python >= 3.10` and checkov 3.2.x declares `>= 3.9`; both are compatible with the python-standalone CPython 3.10.20 that tsuku ships, so they avoid the systemic constraint that blocked ansible and azure-cli in #2329.
- lefthook's asset filename embeds the version (`lefthook_{version}_Linux_x86_64`); the recipe uses the simple `binary = "lefthook"` form rather than `binaries = [{src, dest}]`. The `{src, dest}` form would re-expand `{arch}` in `install_binaries` without the recipe's `arch_mapping` applied, which produces a different filename than the one written by the download step (the `Linux_amd64` / `Linux_x86_64` mismatch caused the first CI run to fail across every Linux family). The simple form bypasses the asymmetry.
- infracost's tarball contains the binary as `infracost-{os}-{arch}` (not bare `infracost`), so the recipe extracts that exact name and the `install_binaries` step renames it to `bin/infracost`.

## Test Plan

- [x] CI test-recipe matrix passes for terragrunt, infracost, lefthook, pre-commit, and checkov on every supported platform.
- [x] Strict validation (`tsuku validate --strict --check-libc-coverage`) passes for all five recipes.
- [x] `tsuku eval --recipe <recipe> --os <os> --arch <arch>` produces a deterministic plan for every supported platform.

Fixes #2297