### PR TITLE
feat(version): SemVer-aware prerelease detection with stable qualifiers

### DIFF
--- a/cmd/tsuku/cmd_self_update.go
+++ b/cmd/tsuku/cmd_self_update.go
@@ -29,7 +29,7 @@ var selfUpdateCmd = &cobra.Command{
 
 		// Resolve latest version
 		res := version.New()
-		provider := version.NewGitHubProvider(res, updates.SelfRepo)
+		provider := version.NewGitHubProvider(res, updates.SelfRepo, nil)
 		latest, err := provider.ResolveLatest(cmd.Context())
 		if err != nil {
 			return fmt.Errorf("resolve latest version: %w", err)

--- a/docs/designs/DESIGN-prerelease-detection.md
+++ b/docs/designs/DESIGN-prerelease-detection.md
@@ -13,25 +13,27 @@ problem: |
 decision: |
   Replace the substring keyword filter with a SemVer-aware definition: any
   version whose `splitPrerelease` yields a non-empty prerelease component is
-  unstable, with one exception. Add an opt-in `[version] stable_qualifiers`
-  recipe field that names hyphenated suffixes which the upstream uses as
-  release qualifiers rather than prereleases. The default is empty
-  (= strict SemVer); recipes whose upstream uses RELEASE/FINAL-style
-  conventions opt in by listing those qualifiers explicitly. The change is
-  scoped to the GitHub provider's filter and to the parallel filter in the
-  Fossil provider; the comparison logic in `version_utils.go` is unchanged.
+  unstable, except when the prerelease component matches a known
+  stable-release qualifier. Ship a default qualifier list of `["release",
+  "final", "lts", "ga", "stable"]` so the common JVM-ecosystem conventions
+  Just Work. Recipes whose upstream uses an exotic qualifier override the
+  default with a `[version] stable_qualifiers = [...]` field (replace
+  semantic, not append). The change is scoped to the GitHub provider's
+  filter and to the parallel filter in the Fossil provider; the comparison
+  logic in `version_utils.go` is unchanged.
 rationale: |
   The filter and the comparison logic disagree today about what counts as a
   prerelease. The comparison logic uses `splitPrerelease`, which is the
   SemVer-correct definition. The filter uses substring matching, which is a
   weaker heuristic that misses milestone tags. Aligning the filter with the
-  comparison logic eliminates the underlying mismatch without inventing a new
-  abstraction. Per-recipe opt-in for stable qualifiers reflects the empirical
-  reality that tagging conventions vary across upstreams but are stable within
-  a single repository, and lets the recipe author encode their upstream's
-  convention in the same place they encode the version source. A small global
-  default allowlist was considered and rejected as needlessly impositional —
-  the few projects that use these qualifiers can declare them once.
+  comparison logic eliminates the underlying mismatch without inventing a
+  new abstraction. The default qualifier list reflects the empirical
+  observation that a small set of suffixes (`RELEASE`, `FINAL`, `LTS`,
+  `GA`, `stable`) are universally used to *signal stability*, never the
+  opposite — admitting them by default reduces the audit and per-recipe
+  configuration burden without any realistic false-positive risk. The
+  per-recipe override exists for upstreams whose convention is genuinely
+  exotic and is rarely needed.
 ---
 
 # DESIGN: Prerelease Detection in Version Providers
@@ -134,21 +136,28 @@ Out of scope (intentionally not driving the design):
 
 ## Considered Options
 
-### Option A: Strict SemVer with per-recipe `stable_qualifiers` field (chosen)
+### Option A: Strict SemVer with default stable-qualifier list and per-recipe override (chosen)
 
-Replace the substring filter with `_, pre := splitPrerelease(v); pre == ""`,
-and add an opt-in `[version] stable_qualifiers` recipe field listing
-hyphenated suffixes the upstream uses as release qualifiers.
+Replace the substring filter with `_, pre := splitPrerelease(v); pre ==
+"" || stableQualifiers[lower(pre)]`. Ship a default qualifier list of
+`["release", "final", "lts", "ga", "stable"]` so common JVM-ecosystem
+conventions Just Work. Recipes whose upstream uses an exotic qualifier
+override the default with a `[version] stable_qualifiers = [...]` field
+(replace semantic, not append).
 
 - Pro: Aligns the filter with the comparison logic. Catches every exotic
-  prerelease format by construction. Recipe authors document upstream
-  convention where it belongs (in the recipe).
-- Pro: Per-recipe scope reflects empirical reality — tagging conventions
-  vary across upstreams but are stable within a single repository.
-- Con: Requires an audit of existing recipes whose upstream tags use
-  hyphen-suffixed stables before flipping the default to strict.
-- Con: New recipe authors must check upstream convention. Small ask
-  (`git ls-remote --tags` plus a glance), but one extra step.
+  prerelease format by construction.
+- Pro: The default list covers the universally-used "this is the
+  release" qualifiers. Most recipes need no change at all; the audit
+  becomes "find recipes whose upstream uses an *unusual* qualifier,"
+  which is rare.
+- Pro: When an override is needed, the recipe encodes upstream
+  convention in the same place it encodes the version source.
+- Con: Adds a small surface to the schema (one optional list field).
+- Con: A future upstream could in theory tag `X.Y.Z-RELEASE` as a
+  *prerelease*; if that happens, the recipe author overrides with a
+  smaller `stable_qualifiers` list. Realistic risk is essentially zero
+  since `RELEASE` etc. mean "this is the release" by convention.
 
 ### Option B: Extend the keyword blocklist
 
@@ -160,18 +169,21 @@ against the prerelease component. Keep everything else unchanged.
   ecosystem brings us back to this issue. The substring approach is
   the underlying flaw.
 
-### Option C: Strict SemVer with a global stable-qualifier allowlist
+### Option C: Strict SemVer with no default qualifiers, per-recipe opt-in only
 
-Hardcode `["release", "final", "lts", "ga", "stable"]` into the provider
-as universally-admitted prerelease components.
+Replace the filter with strict SemVer (any prerelease is unstable) and
+require recipes whose upstream uses RELEASE/FINAL-style conventions to
+opt in via `stable_qualifiers`. No defaults shipped.
 
-- Pro: No per-recipe configuration; existing recipes that depend on
-  RELEASE-suffixed tags keep working without changes.
-- Con: A global list risks both false positives (admitting a prerelease
-  the upstream actually intends as unstable) and false negatives (missing
-  a project-specific qualifier we did not anticipate). Tagging
-  conventions vary across upstreams; a global list cannot get every
-  upstream right.
+- Pro: Most conservative; nothing is admitted unless a recipe author
+  explicitly says so.
+- Con: Every recipe whose upstream uses a hyphen-suffixed stable
+  qualifier — Spring, Hibernate, several Apache projects — needs an
+  explicit field. The audit step becomes onerous and easy to miss.
+- Con: The convention set (RELEASE/FINAL/LTS/GA/stable) is
+  well-established across many upstreams. Forcing every recipe to
+  opt in repeats boilerplate without buying any safety, given the
+  universal English meaning of these qualifiers.
 
 ### Option D: Per-recipe regex tag filter
 
@@ -197,28 +209,47 @@ the upstream's intent.
 
 ## Decision Outcome
 
-Chose **Option A: Strict SemVer with per-recipe `stable_qualifiers` field**.
+Chose **Option A: Strict SemVer with default stable-qualifier list and per-recipe override**.
 
 Option A satisfies all five decision drivers. The strict SemVer baseline
 catches the immediate gradle/sbt bug and every future exotic prerelease
-format by construction (driver 1). The per-recipe override admits the JVM
-RELEASE/FINAL-style conventions without globally weakening the filter
-(driver 2). The audit step protects existing recipes from regression
-(driver 3). Reusing `splitPrerelease` reuses an existing primitive
-(driver 4). A single new recipe field is minimal new abstraction (driver 5).
+format by construction (driver 1). The default qualifier list admits the
+universal "this is the release" suffixes without per-recipe boilerplate
+(driver 2). The default-plus-override shape lets existing recipes resolve
+to the same versions they do today, with the audit narrowing to the
+unusual cases (driver 3). Reusing `splitPrerelease` reuses an existing
+primitive (driver 4). A single optional list field is minimal new
+abstraction (driver 5).
 
 Option B was rejected because it does not address driver 1 generally —
 the next exotic prerelease format requires another keyword addition.
-Option C was rejected because the user observed that tagging conventions
-vary across upstreams but are stable within a repository, which makes
-per-recipe configuration the correct abstraction. Option D was rejected
-as more general than needed. Option E was rejected because it does not
-work uniformly across the tags and releases code paths.
+Option C (strict SemVer with no defaults) was rejected because it forces
+every Spring/Hibernate/Apache-style recipe to opt in for no real safety
+gain. Option D was rejected as more general than needed. Option E was
+rejected because it does not work uniformly across the tags and releases
+code paths.
 
 ## Solution Architecture
 
 The solution lives entirely in the version-resolution layer of tsuku. No
 runtime, executor, or recipe-action changes are involved.
+
+### Default qualifier list
+
+The provider package exposes a single source of truth for the default
+list:
+
+```go
+// DefaultStableQualifiers names hyphenated suffixes that universally
+// signal a stable release across upstream conventions. Recipes whose
+// upstream uses an exotic qualifier override this list with
+// [version] stable_qualifiers.
+var DefaultStableQualifiers = []string{"release", "final", "lts", "ga", "stable"}
+```
+
+When a recipe declares no `stable_qualifiers` field, the provider uses
+this list. When the recipe declares the field, the recipe's list
+*replaces* the default (not appends).
 
 ### New recipe field
 
@@ -228,24 +259,29 @@ runtime, executor, or recipe-action changes are involved.
 StableQualifiers []string `toml:"stable_qualifiers"`
 ```
 
-Recipes whose upstream uses hyphen-suffixed stable qualifiers list them
-explicitly:
+Most recipes need no `stable_qualifiers` field at all because the
+default list already covers their upstream's convention. Recipes whose
+upstream uses an exotic qualifier (for example, a project that uses
+`-prod` or some uncommon marker) override the default explicitly:
 
 ```toml
 [version]
-github_repo = "spring-projects/spring-framework"
-tag_prefix = "v"
-stable_qualifiers = ["release"]
+github_repo = "some-org/exotic-project"
+stable_qualifiers = ["prod"]
 ```
+
+A recipe that wants to *narrow* the default — for example, one whose
+upstream tags both `1.0.0-RELEASE` (stable) and `1.0.0-LTS` (a
+prerelease, hypothetically) — lists only the qualifiers that apply:
 
 ```toml
 [version]
-github_repo = "hibernate/hibernate-orm"
-stable_qualifiers = ["final", "ga"]
+github_repo = "some-org/odd-lts-convention"
+stable_qualifiers = ["release"]   # excludes lts/final/ga/stable from the default
 ```
 
-The default is empty (`StableQualifiers = nil` or `[]`), meaning strict
-SemVer: any hyphenated suffix is a prerelease.
+In both override cases the field's contents fully define what is
+stable; nothing is implicitly added.
 
 ### Updated filter predicate
 
@@ -262,7 +298,10 @@ func isStableVersion(version string, stableQualifiers map[string]bool) bool {
 ```
 
 The `stableQualifiers` map is constructed once at provider construction
-time from the recipe's `StableQualifiers` slice (lowercased keys).
+time. If the recipe's `StableQualifiers` slice is empty, the provider
+builds the map from `DefaultStableQualifiers`. If it is non-empty, the
+provider builds the map from the recipe's slice (the default is
+discarded — replace, not append).
 
 ### Threading the field through the providers
 
@@ -329,18 +368,21 @@ The implementation lands in #2325 in three contained slices:
      no longer needed but the prerelease test catches them).
 3. **Audit and recipe updates.**
    - Run `git grep -l 'github_repo' recipes/ internal/recipe/recipes/`.
-   - For each recipe, inspect upstream tags via
-     `git ls-remote --tags <repo> | tail -50` (or the GitHub API) to
-     check for hyphen-suffixed stable releases.
-   - Recipes whose upstream uses hyphen-suffixed stables receive a
+   - For each recipe, check upstream tags only when there is reason to
+     suspect an exotic convention. The default qualifier list already
+     covers `RELEASE`, `FINAL`, `LTS`, `GA`, and `stable`, so the audit
+     is narrowed to recipes whose upstream uses something else.
+   - Realistic finding: most recipes use plain semver and need no
+     change. The set that does need the field is small and exotic.
+   - Recipes that need an override receive a
      `stable_qualifiers = [...]` line in the same PR as the filter
      change.
-   - The PR description explicitly lists the audit results so reviewers
-     can flag any miss.
+   - The PR description lists the audit results so reviewers can flag
+     any miss.
 
 The three slices land in a single PR because the filter change without
-the audit risks regression and the recipe updates without the schema
-change do not parse.
+the audit risks regression on exotic-qualifier upstreams, and the recipe
+updates without the schema change do not parse.
 
 ## Security Considerations
 
@@ -387,17 +429,21 @@ data that already flows through tsuku at install time:
 
 ### Negative
 
-- **Behavior change for existing recipes whose upstream tags use
-  hyphen-suffixed stables.** Mitigation: the audit step in the
-  Implementation Approach catches these, and the same PR adds the
-  `stable_qualifiers` field to each affected recipe.
-- **Recipe authors of new tools must know the upstream's tagging
-  convention.** This is a small ask but it is one extra step in the
-  recipe-authoring flow. We should document it in the recipe-author
-  skill.
+- **Behavior change for existing recipes whose upstream tags use exotic
+  hyphen-suffixed stables** (anything outside the default list).
+  Mitigation: the audit step in the Implementation Approach catches
+  these, and the same PR adds the `stable_qualifiers` field to each
+  affected recipe.
+- **Recipe authors of new tools usually need to do nothing**, since the
+  default list covers the common cases. They only need to think about
+  the field when the upstream uses an exotic convention.
 - The change touches a stable, well-exercised code path. We must add
   the table-driven tests described in the Implementation Approach to
   pin behavior before flipping the default.
+- **Hypothetical: an upstream tags `X.Y.Z-RELEASE` as a prerelease of
+  `X.Y.Z`.** The default would then admit a prerelease. No real example
+  is known; if one is found, the recipe overrides
+  `stable_qualifiers` with a list that excludes the offending suffix.
 
 ### Affected Components
 

--- a/docs/designs/DESIGN-prerelease-detection.md
+++ b/docs/designs/DESIGN-prerelease-detection.md
@@ -500,6 +500,7 @@ data that already flows through tsuku at install time:
 | Issue | Dependencies | Tier |
 |-------|--------------|------|
 | ~~[#2325: fix(version): treat -Mn milestone tags as pre-releases in GitHub provider](https://github.com/tsukumogami/tsuku/issues/2325)~~ | ~~None~~ | ~~testable~~ |
+| ~~_Replaces the substring-keyword `isStableVersion` filter with a SemVer-aware predicate plus a non-SemVer fallback. Adds the `[version] stable_qualifiers` recipe field with default `["release", "final", "lts", "ga", "stable"]`. Implementation lives in `internal/version/provider_github.go` and `internal/version/fossil_provider.go`._~~ | | |
 
 ```mermaid
 graph TD
@@ -509,3 +510,5 @@ graph TD
 
     class I2325 done
 ```
+
+**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design

--- a/docs/designs/DESIGN-prerelease-detection.md
+++ b/docs/designs/DESIGN-prerelease-detection.md
@@ -1,0 +1,289 @@
+---
+status: Proposed
+problem: |
+  The GitHub version provider's `isStableVersion` filter uses substring matching
+  against a hardcoded keyword list (`preview`, `alpha`, `beta`, `rc`, `dev`,
+  `snapshot`, `nightly`). This admits exotic prerelease formats like `9.6.0-M1`
+  (gradle), `2.0.0-M5` (sbt), and any ecosystem-specific qualifier the keyword
+  list happens not to mention, causing `tsuku eval` to resolve to a milestone
+  build that does not exist on the upstream's distribution server. The filter
+  is also too aggressive in the other direction: a stricter SemVer-aware
+  definition would falsely reject hyphen-suffixed stable qualifiers like
+  `-RELEASE`, `-FINAL`, `-LTS`, and `-GA` used by some JVM-ecosystem projects.
+decision: |
+  Replace the substring keyword filter with a SemVer-aware definition: any
+  version whose `splitPrerelease` yields a non-empty prerelease component is
+  unstable, with one exception. Add an opt-in `[version] stable_qualifiers`
+  recipe field that names hyphenated suffixes which the upstream uses as
+  release qualifiers rather than prereleases. The default is empty
+  (= strict SemVer); recipes whose upstream uses RELEASE/FINAL-style
+  conventions opt in by listing those qualifiers explicitly. The change is
+  scoped to the GitHub provider's filter and to the parallel filter in the
+  Fossil provider; the comparison logic in `version_utils.go` is unchanged.
+rationale: |
+  The filter and the comparison logic disagree today about what counts as a
+  prerelease. The comparison logic uses `splitPrerelease`, which is the
+  SemVer-correct definition. The filter uses substring matching, which is a
+  weaker heuristic that misses milestone tags. Aligning the filter with the
+  comparison logic eliminates the underlying mismatch without inventing a new
+  abstraction. Per-recipe opt-in for stable qualifiers reflects the empirical
+  reality that tagging conventions vary across upstreams but are stable within
+  a single repository, and lets the recipe author encode their upstream's
+  convention in the same place they encode the version source. A small global
+  default allowlist was considered and rejected as needlessly impositional —
+  the few projects that use these qualifiers can declare them once.
+---
+
+# DESIGN: Prerelease Detection in Version Providers
+
+## Status
+
+Proposed
+
+## Context and Problem Statement
+
+The GitHub version provider's job is to take a `[version] github_repo = "..."`
+declaration and return the latest stable release. With a `tag_prefix`, it
+filters tags by prefix, sorts them, and returns the first one that
+`isStableVersion` admits.
+
+`isStableVersion` lives in `internal/version/provider_github.go` and is
+implemented as a case-insensitive substring search against a fixed keyword
+list:
+
+```go
+func isStableVersion(version string) bool {
+    lower := strings.ToLower(version)
+    unstablePatterns := []string{"preview", "alpha", "beta", "rc", "dev", "snapshot", "nightly"}
+    for _, pattern := range unstablePatterns {
+        if strings.Contains(lower, pattern) {
+            return false
+        }
+    }
+    return true
+}
+```
+
+The keyword list catches the most common prerelease markers, and Maven-style
+tags (`maven-4.0.0-rc-5`, `maven-4.0.0-beta-3`, `maven-4.0.0-alpha-13`) flow
+through it correctly.
+
+It does not catch milestone tags. Two real-world examples surfaced during
+the curated-recipe milestone:
+
+- `gradle/gradle` publishes milestone pre-releases tagged `v9.6.0-M1`,
+  `v9.5.0-M7`, `v9.5.0-RC4`. The RC tags are filtered. The M tags are not:
+  `9.6.0-M1` lowercased contains `m1`, which matches none of the keywords.
+- `sbt/sbt` publishes the same shape: `v2.0.0-M5`, `v2.0.0-RC12`, etc. The M
+  tags pass the filter; the RC tags do not.
+
+The version comparison logic in `internal/version/version_utils.go` ranks
+`9.6.0-M1` *above* `9.4.1` (the genuine latest stable) because
+`compareCoreParts` compares major.minor.patch first, and only falls back to
+`comparePrereleases` when the core matches. So the provider returns the
+milestone tag, the recipe derives a download URL like
+`gradle-9.6.0-M1-bin.zip`, and `tsuku eval` fails with a 404 because that
+URL does not exist on the gradle distribution server.
+
+This is the immediate trigger for tightening the filter. But naively
+tightening it — for example, by treating any hyphenated suffix as a
+prerelease — would break a different class of upstream that uses hyphenated
+suffixes to *signal stability*:
+
+- **Spring** (historically): tags like `5.3.39-RELEASE` predate the project's
+  move to plain semver in 6.x.
+- **Hibernate** and other JBoss-era projects: `5.6.15-Final` (the Final
+  qualifier signals "this is a stable release", not "this is a prerelease").
+- **General availability releases**: occasional tags ending in `-GA` from
+  Apache and similar projects.
+- **Long-term support markers**: sometimes `-LTS` appears in distro and
+  framework versioning.
+- **Pure stability markers**: occasional tags ending in `-stable`.
+
+By strict SemVer, every one of these is a prerelease. By the project's own
+intent, none of them is. The filter cannot get this right without knowing
+the upstream's convention.
+
+## Goals
+
+1. Stop returning milestone (or other exotic) prereleases as the latest
+   stable when the upstream also publishes plain semver stables.
+2. Continue to admit upstreams whose hyphenated suffix signals stability
+   (`-RELEASE`, `-FINAL`, `-LTS`, `-GA`, `-stable`).
+3. Keep existing curated and handcrafted recipes resolving to the same
+   versions they do today, except in cases where they were silently
+   resolving to a wrong (milestone) version that happened not to break.
+4. Avoid inventing new abstractions. Reuse the SemVer-aware
+   `splitPrerelease` already in `version_utils.go`.
+
+## Non-Goals
+
+- Adding a general-purpose tag-filter regex to `[version]`. That is more
+  expressive than the problem requires and shifts complexity onto recipe
+  authors who would have to design and debug regular expressions per recipe.
+  Captured as a future option in "Alternatives Considered" below.
+- Distinguishing "alpha < beta < rc" within prereleases. That ordering
+  already lives in `comparePrereleaseIdentifiers` and is unchanged.
+- Filtering pre-releases out of `ListVersions`. The lister must continue
+  to return every tag so that explicit version pins (e.g.,
+  `tsuku install gradle@9.6.0-M1`) keep working.
+
+## Decision
+
+### 1. Replace the substring filter with a SemVer-aware predicate
+
+Change `isStableVersion` to:
+
+```go
+func isStableVersion(version string, stableQualifiers map[string]bool) bool {
+    _, prerelease := splitPrerelease(version)
+    if prerelease == "" {
+        return true
+    }
+    return stableQualifiers[strings.ToLower(prerelease)]
+}
+```
+
+The function gains a `stableQualifiers` parameter sourced from the recipe.
+Default (empty map) means "strict SemVer: any prerelease is unstable."
+
+### 2. Add `[version] stable_qualifiers` recipe field
+
+Extend `recipe.VersionSection` with:
+
+```go
+StableQualifiers []string `toml:"stable_qualifiers"`
+```
+
+The field is a list of lowercase prerelease identifiers that the upstream
+uses as stable release qualifiers. Recipe example:
+
+```toml
+[version]
+github_repo = "spring-projects/spring-framework"
+tag_prefix = "v"
+stable_qualifiers = ["release"]
+```
+
+The provider builds the `map[string]bool` from this slice once at
+construction time and passes it into `isStableVersion`.
+
+### 3. Apply the same change to the Fossil provider
+
+`internal/version/fossil_provider.go` calls `isStableVersion(v)` in
+`ResolveLatest` (the only other caller). Update the signature consistently
+so the Fossil provider receives the same `stableQualifiers` map plumbed
+through from the recipe.
+
+### 4. Audit existing recipes before flipping the default
+
+`git grep -l 'github_repo' recipes/ internal/recipe/recipes/` produces the
+candidate list. For each, check whether the upstream's latest stable is
+plain semver (no change needed) or hyphen-suffixed (add
+`stable_qualifiers`). Realistically the second category is small and
+likely does not include any currently-curated recipe.
+
+## Consequences
+
+### Positive
+
+- Gradle and sbt recipes resolve correctly with the same `[version]
+  github_repo` shape every other recipe uses, with no special-casing in
+  the recipe.
+- The filter and the comparison logic finally agree on what a prerelease
+  is. Future exotic tag formats (which will appear) are caught by
+  construction without code changes.
+- Recipes that need stable-qualifier handling document their upstream's
+  convention in the recipe itself, where the next person reading it can
+  see why the recipe is structured the way it is.
+- Tests gain a clear pinning surface: each behavior is exercised by a
+  small input, not by a substring trick.
+
+### Negative / Risks
+
+- **Behavior change for existing recipes whose upstream tags use
+  hyphen-suffixed stables.** Mitigation: audit + add `stable_qualifiers`
+  to those recipes in the same PR. The PR description should call out
+  the audit explicitly so reviewers can flag any miss.
+- **Recipe authors of new tools must know the upstream's tagging
+  convention.** This is a small ask — `git ls-remote --tags` plus a
+  glance is enough — but it is one extra step.
+- The change touches a stable, well-exercised code path. We should add
+  table-driven tests for `isStableVersion` covering: plain semver,
+  alpha/beta/rc, milestone (`-M1`, `-M2`, with and without numeric
+  suffix), each stable qualifier (`release`, `final`, `lts`, `ga`,
+  `stable`), build metadata after `+`, and the existing keywords (since
+  they are no longer special-cased — they should still be rejected
+  through the prerelease check, but the test pins that behavior).
+
+## Alternatives Considered
+
+### A. Extend the keyword blocklist
+
+Add `milestone` and a regex matching `^m\d+$` against the prerelease
+component. Rejected: whack-a-mole. The next exotic prerelease format from
+another ecosystem brings us back to this issue.
+
+### B. Strict SemVer with a global allowlist
+
+Hardcode `["release", "final", "lts", "ga", "stable"]` into the provider.
+Rejected: the user pointed out that tagging conventions vary across
+repositories but are stable within a repository. A global allowlist
+risks both false positives (admitting a prerelease the upstream actually
+intends as unstable) and false negatives (missing a project-specific
+qualifier we did not anticipate). The cost of per-recipe configuration
+is one extra line in the recipes that need it.
+
+### C. Per-recipe regex tag filter
+
+Add `[version] tag_filter = "regex"` that admits only matching tags.
+Rejected for now: more general but more complex. The regex would need
+to handle prefix-stripped vs raw tags, escape semantics, and recipe
+authors would have to design and debug a regex per recipe. We can
+revisit if the `stable_qualifiers` field proves insufficient.
+
+### D. Use the GitHub releases API's `prerelease` flag
+
+The `releases` API exposes a `prerelease: bool` annotation that respects
+the upstream's intent. Rejected as a primary mechanism: it only works
+when the upstream uses the GitHub releases UI consistently and tags
+both releases and pre-releases through it. Many repos use git tags
+without GitHub releases (the existing
+`Resolver.resolveFromTags` fallback exists for exactly this case), and
+in that path no `prerelease` flag is available. The proposed solution
+works uniformly across the tags and releases code paths.
+
+## Implementation Notes
+
+- The signature change to `isStableVersion` is internal; no exported API
+  changes.
+- `provider_github.go:NewGitHubProvider` and `NewGitHubProviderWithPrefix`
+  gain a `stableQualifiers []string` argument, populated from
+  `recipe.VersionSection.StableQualifiers`.
+- The `provider_factory.go` constructor for the GitHub strategy threads
+  the field through.
+- Tests live in a new `internal/version/provider_github_test.go` (the
+  existing tests for this file are sparse) and exercise the
+  `isStableVersion` predicate directly with the table cases listed above.
+- Validation: `tsuku validate --strict` already enforces typed recipe
+  fields; adding `StableQualifiers` extends the schema with no special
+  validator work.
+
+## Open Questions
+
+None at this time. The audit in step 4 may surface recipes that need
+the new field; if any of those recipes are currently curated, the audit
+should be completed before this design moves to "Accepted" so the same
+PR can land both the filter change and the recipe updates.
+
+## Affected Components
+
+- `internal/version/provider_github.go` (filter and providers)
+- `internal/version/fossil_provider.go` (parallel filter)
+- `internal/recipe/types.go` (`VersionSection.StableQualifiers`)
+- `internal/version/provider_factory.go` (threading the field)
+- Recipes whose upstream uses hyphen-suffixed stable qualifiers (audit)
+
+## Implementation Issue
+
+This design is implemented by [#2325](https://github.com/tsukumogami/tsuku/issues/2325).

--- a/docs/designs/DESIGN-prerelease-detection.md
+++ b/docs/designs/DESIGN-prerelease-detection.md
@@ -1,5 +1,5 @@
 ---
-status: Proposed
+status: Planned
 problem: |
   The GitHub version provider's `isStableVersion` filter uses substring matching
   against a hardcoded keyword list (`preview`, `alpha`, `beta`, `rc`, `dev`,
@@ -11,14 +11,18 @@ problem: |
   definition would falsely reject hyphen-suffixed stable qualifiers like
   `-RELEASE`, `-FINAL`, `-LTS`, and `-GA` used by some JVM-ecosystem projects.
 decision: |
-  Replace the substring keyword filter with a SemVer-aware definition: any
-  version whose `splitPrerelease` yields a non-empty prerelease component is
-  unstable, except when the prerelease component matches a known
-  stable-release qualifier. Ship a default qualifier list of `["release",
-  "final", "lts", "ga", "stable"]` so the common JVM-ecosystem conventions
-  Just Work. Recipes whose upstream uses an exotic qualifier override the
-  default with a `[version] stable_qualifiers = [...]` field (replace
-  semantic, not append). The change is scoped to the GitHub provider's
+  Replace the substring keyword filter with a two-layered check. The
+  primary layer is SemVer-aware: any version whose `splitPrerelease` yields
+  a non-empty prerelease component is unstable, except when the prerelease
+  component matches a known stable-release qualifier. Ship a default
+  qualifier list of `["release", "final", "lts", "ga", "stable"]` so the
+  common JVM-ecosystem conventions Just Work. Recipes whose upstream uses
+  an exotic qualifier override the default with a `[version]
+  stable_qualifiers = [...]` field (replace semantic, not append). The
+  fallback layer preserves a small substring keyword list (`alpha`,
+  `beta`, `rc`, `preview`, `snapshot`, `nightly`, `dev`) for upstreams
+  whose tags splice prerelease markers into the version without a hyphen
+  (e.g., jq's `1.8.2rc1`). The change is scoped to the GitHub provider's
   filter and to the parallel filter in the Fossil provider; the comparison
   logic in `version_utils.go` is unchanged.
 rationale: |
@@ -40,7 +44,7 @@ rationale: |
 
 ## Status
 
-Proposed
+Planned
 
 ## Context and Problem Statement
 
@@ -290,12 +294,38 @@ stable; nothing is implicitly added.
 ```go
 func isStableVersion(version string, stableQualifiers map[string]bool) bool {
     _, prerelease := splitPrerelease(version)
-    if prerelease == "" {
-        return true
+    if prerelease != "" {
+        return stableQualifiers[strings.ToLower(prerelease)]
     }
-    return stableQualifiers[strings.ToLower(prerelease)]
+    // Fallback: catch non-SemVer prerelease markers spliced into the
+    // version without a hyphen (e.g., jq's "1.8.2rc1").
+    lower := strings.ToLower(version)
+    for _, marker := range nonSemverUnstableMarkers {
+        if strings.Contains(lower, marker) {
+            return false
+        }
+    }
+    return true
+}
+
+var nonSemverUnstableMarkers = []string{
+    "alpha", "beta", "rc", "preview", "snapshot", "nightly", "dev",
 }
 ```
+
+The check is two-layered:
+
+1. **SemVer prerelease check** (anything after the first hyphen): a
+   non-empty prerelease component is unstable unless it matches one of
+   the `stableQualifiers`. This catches every SemVer-style prerelease
+   format by construction (alpha, beta, rc, dev, M1, M2, ...) and
+   admits "this is the release" suffixes via the qualifier map.
+2. **Non-SemVer fallback** (no hyphen at all): some upstreams splice the
+   prerelease marker into the version without a separator. jq tags
+   `1.8.2rc1` (no hyphen between `2` and `rc`) is the canonical example
+   surfaced by the audit. The fallback substring match against
+   `nonSemverUnstableMarkers` preserves the historical filter's
+   behavior for these cases.
 
 The `stableQualifiers` map is constructed once at provider construction
 time. If the recipe's `StableQualifiers` slice is empty, the provider
@@ -367,18 +397,20 @@ The implementation lands in #2325 in three contained slices:
      rejected through the prerelease check, since the keyword test is
      no longer needed but the prerelease test catches them).
 3. **Audit and recipe updates.**
-   - Run `git grep -l 'github_repo' recipes/ internal/recipe/recipes/`.
-   - For each recipe, check upstream tags only when there is reason to
-     suspect an exotic convention. The default qualifier list already
-     covers `RELEASE`, `FINAL`, `LTS`, `GA`, and `stable`, so the audit
-     is narrowed to recipes whose upstream uses something else.
-   - Realistic finding: most recipes use plain semver and need no
-     change. The set that does need the field is small and exotic.
-   - Recipes that need an override receive a
-     `stable_qualifiers = [...]` line in the same PR as the filter
-     change.
-   - The PR description lists the audit results so reviewers can flag
-     any miss.
+   - Run `tsuku eval --recipe <r>` against each curated recipe with
+     `tag_prefix` set, and confirm the resolved version is unchanged
+     from main-branch behavior (or has improved by skipping a milestone
+     prerelease).
+   - The audit during the implementation of #2325 found one
+     non-SemVer-compliant case that the strict-SemVer-only design
+     would have regressed: jq tags `jq-1.8.2rc1` (no hyphen between
+     the version and `rc`). The implementation gained the non-SemVer
+     fallback layer to handle this and similar upstreams. No further
+     audit findings emerged.
+   - Recipes whose upstream uses an exotic stable qualifier (anything
+     not in the default list) receive a `stable_qualifiers = [...]`
+     line. None were found among the curated set; the field is
+     available for future recipes that need it.
 
 The three slices land in a single PR because the filter change without
 the audit risks regression on exotic-qualifier upstreams, and the recipe
@@ -444,6 +476,13 @@ data that already flows through tsuku at install time:
   `X.Y.Z`.** The default would then admit a prerelease. No real example
   is known; if one is found, the recipe overrides
   `stable_qualifiers` with a list that excludes the offending suffix.
+- **Non-SemVer fallback admits some false positives.** The substring
+  match against `nonSemverUnstableMarkers` will reject any version
+  containing `alpha/beta/rc/preview/snapshot/nightly/dev` as a
+  substring, even when the upstream meant something else. No real
+  example is known where this is wrong (the tokens are distinctive
+  enough to almost never collide with semantic version content), but
+  the constraint is documented here for future readers.
 
 ### Affected Components
 

--- a/docs/designs/DESIGN-prerelease-detection.md
+++ b/docs/designs/DESIGN-prerelease-detection.md
@@ -104,35 +104,152 @@ By strict SemVer, every one of these is a prerelease. By the project's own
 intent, none of them is. The filter cannot get this right without knowing
 the upstream's convention.
 
-## Goals
+## Decision Drivers
 
-1. Stop returning milestone (or other exotic) prereleases as the latest
-   stable when the upstream also publishes plain semver stables.
-2. Continue to admit upstreams whose hyphenated suffix signals stability
-   (`-RELEASE`, `-FINAL`, `-LTS`, `-GA`, `-stable`).
-3. Keep existing curated and handcrafted recipes resolving to the same
-   versions they do today, except in cases where they were silently
+The chosen approach must satisfy these requirements, in priority order:
+
+1. **Stop returning milestone (or other exotic) prereleases as the latest
+   stable** when the upstream also publishes plain semver stables. This is
+   the bug that triggered the work.
+2. **Continue to admit upstreams whose hyphenated suffix signals stability**
+   (`-RELEASE`, `-FINAL`, `-LTS`, `-GA`, `-stable`). The fix must not
+   regress the JVM ecosystem.
+3. **Keep existing curated and handcrafted recipes resolving to the same
+   versions they do today**, except in cases where they were silently
    resolving to a wrong (milestone) version that happened not to break.
-4. Avoid inventing new abstractions. Reuse the SemVer-aware
-   `splitPrerelease` already in `version_utils.go`.
+4. **Reuse the SemVer-aware `splitPrerelease` already in `version_utils.go`**.
+   The filter and the comparison logic disagree today about what a
+   prerelease is; aligning them is the right shape.
+5. **Avoid inventing new abstractions** unless the simpler fix cannot meet
+   the first four drivers.
 
-## Non-Goals
-
-- Adding a general-purpose tag-filter regex to `[version]`. That is more
-  expressive than the problem requires and shifts complexity onto recipe
-  authors who would have to design and debug regular expressions per recipe.
-  Captured as a future option in "Alternatives Considered" below.
+Out of scope (intentionally not driving the design):
+- Adding a general-purpose tag-filter regex to `[version]`. Captured as a
+  rejected option below.
 - Distinguishing "alpha < beta < rc" within prereleases. That ordering
   already lives in `comparePrereleaseIdentifiers` and is unchanged.
 - Filtering pre-releases out of `ListVersions`. The lister must continue
-  to return every tag so that explicit version pins (e.g.,
+  to return every tag so explicit pins (e.g.,
   `tsuku install gradle@9.6.0-M1`) keep working.
 
-## Decision
+## Considered Options
 
-### 1. Replace the substring filter with a SemVer-aware predicate
+### Option A: Strict SemVer with per-recipe `stable_qualifiers` field (chosen)
 
-Change `isStableVersion` to:
+Replace the substring filter with `_, pre := splitPrerelease(v); pre == ""`,
+and add an opt-in `[version] stable_qualifiers` recipe field listing
+hyphenated suffixes the upstream uses as release qualifiers.
+
+- Pro: Aligns the filter with the comparison logic. Catches every exotic
+  prerelease format by construction. Recipe authors document upstream
+  convention where it belongs (in the recipe).
+- Pro: Per-recipe scope reflects empirical reality — tagging conventions
+  vary across upstreams but are stable within a single repository.
+- Con: Requires an audit of existing recipes whose upstream tags use
+  hyphen-suffixed stables before flipping the default to strict.
+- Con: New recipe authors must check upstream convention. Small ask
+  (`git ls-remote --tags` plus a glance), but one extra step.
+
+### Option B: Extend the keyword blocklist
+
+Add `milestone` to the substring list and a regex matching `^m\d+$`
+against the prerelease component. Keep everything else unchanged.
+
+- Pro: Smallest possible change. Zero risk to existing recipes.
+- Con: Whack-a-mole. The next exotic prerelease format from another
+  ecosystem brings us back to this issue. The substring approach is
+  the underlying flaw.
+
+### Option C: Strict SemVer with a global stable-qualifier allowlist
+
+Hardcode `["release", "final", "lts", "ga", "stable"]` into the provider
+as universally-admitted prerelease components.
+
+- Pro: No per-recipe configuration; existing recipes that depend on
+  RELEASE-suffixed tags keep working without changes.
+- Con: A global list risks both false positives (admitting a prerelease
+  the upstream actually intends as unstable) and false negatives (missing
+  a project-specific qualifier we did not anticipate). Tagging
+  conventions vary across upstreams; a global list cannot get every
+  upstream right.
+
+### Option D: Per-recipe regex tag filter
+
+Add `[version] tag_filter = "regex"` that admits only matching tags.
+
+- Pro: Maximally expressive. Handles cases the allowlist cannot.
+- Con: More general than the problem requires. Recipe authors must design
+  and debug a regex per recipe, and the regex must handle prefix-stripped
+  vs raw tags, escape semantics, etc. Higher cost per recipe and per
+  reviewer.
+
+### Option E: Use the GitHub releases API's `prerelease` flag
+
+The `releases` API exposes a `prerelease: bool` annotation that respects
+the upstream's intent.
+
+- Pro: Authoritative when available — the upstream tells us directly.
+- Con: Only works when the upstream uses the GitHub releases UI
+  consistently. Many repos use git tags without GitHub releases (the
+  existing `Resolver.resolveFromTags` fallback exists for exactly this
+  case), and in that path no `prerelease` flag is available. Cannot be
+  the primary mechanism without losing coverage.
+
+## Decision Outcome
+
+Chose **Option A: Strict SemVer with per-recipe `stable_qualifiers` field**.
+
+Option A satisfies all five decision drivers. The strict SemVer baseline
+catches the immediate gradle/sbt bug and every future exotic prerelease
+format by construction (driver 1). The per-recipe override admits the JVM
+RELEASE/FINAL-style conventions without globally weakening the filter
+(driver 2). The audit step protects existing recipes from regression
+(driver 3). Reusing `splitPrerelease` reuses an existing primitive
+(driver 4). A single new recipe field is minimal new abstraction (driver 5).
+
+Option B was rejected because it does not address driver 1 generally —
+the next exotic prerelease format requires another keyword addition.
+Option C was rejected because the user observed that tagging conventions
+vary across upstreams but are stable within a repository, which makes
+per-recipe configuration the correct abstraction. Option D was rejected
+as more general than needed. Option E was rejected because it does not
+work uniformly across the tags and releases code paths.
+
+## Solution Architecture
+
+The solution lives entirely in the version-resolution layer of tsuku. No
+runtime, executor, or recipe-action changes are involved.
+
+### New recipe field
+
+`recipe.VersionSection` gains an optional field:
+
+```go
+StableQualifiers []string `toml:"stable_qualifiers"`
+```
+
+Recipes whose upstream uses hyphen-suffixed stable qualifiers list them
+explicitly:
+
+```toml
+[version]
+github_repo = "spring-projects/spring-framework"
+tag_prefix = "v"
+stable_qualifiers = ["release"]
+```
+
+```toml
+[version]
+github_repo = "hibernate/hibernate-orm"
+stable_qualifiers = ["final", "ga"]
+```
+
+The default is empty (`StableQualifiers = nil` or `[]`), meaning strict
+SemVer: any hyphenated suffix is a prerelease.
+
+### Updated filter predicate
+
+`isStableVersion` in `internal/version/provider_github.go` becomes:
 
 ```go
 func isStableVersion(version string, stableQualifiers map[string]bool) bool {
@@ -144,44 +261,113 @@ func isStableVersion(version string, stableQualifiers map[string]bool) bool {
 }
 ```
 
-The function gains a `stableQualifiers` parameter sourced from the recipe.
-Default (empty map) means "strict SemVer: any prerelease is unstable."
+The `stableQualifiers` map is constructed once at provider construction
+time from the recipe's `StableQualifiers` slice (lowercased keys).
 
-### 2. Add `[version] stable_qualifiers` recipe field
+### Threading the field through the providers
 
-Extend `recipe.VersionSection` with:
-
-```go
-StableQualifiers []string `toml:"stable_qualifiers"`
-```
-
-The field is a list of lowercase prerelease identifiers that the upstream
-uses as stable release qualifiers. Recipe example:
-
-```toml
-[version]
-github_repo = "spring-projects/spring-framework"
-tag_prefix = "v"
-stable_qualifiers = ["release"]
-```
-
-The provider builds the `map[string]bool` from this slice once at
-construction time and passes it into `isStableVersion`.
-
-### 3. Apply the same change to the Fossil provider
+`NewGitHubProvider` and `NewGitHubProviderWithPrefix` gain a
+`stableQualifiers []string` argument. The provider stores the lowercased
+set as a `map[string]bool` and passes it into `isStableVersion`.
 
 `internal/version/fossil_provider.go` calls `isStableVersion(v)` in
-`ResolveLatest` (the only other caller). Update the signature consistently
-so the Fossil provider receives the same `stableQualifiers` map plumbed
-through from the recipe.
+`ResolveLatest` (the only other caller in the codebase). Update the
+signature consistently and thread the recipe's
+`StableQualifiers` through the Fossil provider as well.
 
-### 4. Audit existing recipes before flipping the default
+`internal/version/provider_factory.go` reads
+`recipe.VersionSection.StableQualifiers` and passes it into the provider
+constructors.
 
-`git grep -l 'github_repo' recipes/ internal/recipe/recipes/` produces the
-candidate list. For each, check whether the upstream's latest stable is
-plain semver (no change needed) or hyphen-suffixed (add
-`stable_qualifiers`). Realistically the second category is small and
-likely does not include any currently-curated recipe.
+### Composition with the comparison logic
+
+The comparison logic (`comparePrereleases` in `version_utils.go`) is
+unchanged. It already ranks plain semver above any hyphenated version. So:
+
+- When upstream tags both `1.0.0` and `1.0.0-RELEASE`, plain wins
+  (correct: `comparePrereleases` ranks empty prerelease above any
+  non-empty prerelease).
+- When upstream tags only `1.0.0-RELEASE`, `2.0.0-RELEASE`,
+  `3.0.0-RELEASE`, the qualifier-admitted family sorts among itself
+  correctly (`compareCoreParts` ranks `3.0.0` highest, so
+  `3.0.0-RELEASE` wins).
+
+### What is explicitly out of scope
+
+- **Compound prerelease suffixes** like `1.0.0-final.1` or
+  `1.0.0-RELEASE-hotfix`. The qualifier match is exact; compound forms
+  are rejected. If a real upstream needs this, the recipe author can pin
+  manually until we add a richer mechanism.
+- **Case-and-space variations** like `Final-1` or `release_1`. Same
+  answer.
+
+## Implementation Approach
+
+The implementation lands in #2325 in three contained slices:
+
+1. **Schema and provider plumbing.**
+   - Add `StableQualifiers []string` to `recipe.VersionSection` in
+     `internal/recipe/types.go`. No validator changes required — the
+     strict-validate path already enforces typed recipe fields, and an
+     optional list with no constraint passes through.
+   - Update `NewGitHubProvider`, `NewGitHubProviderWithPrefix`, and the
+     Fossil provider constructors to accept `stableQualifiers []string`,
+     storing it as a `map[string]bool` keyed by the lowercased
+     qualifier.
+   - Update `internal/version/provider_factory.go` to read the field
+     from the recipe and pass it through.
+2. **Filter logic.**
+   - Replace the body of `isStableVersion` with the SemVer-aware
+     predicate above.
+   - Add a new `internal/version/provider_github_test.go` (existing
+     tests for this file are sparse). Table-driven cases covering:
+     plain semver, alpha/beta/rc, milestone (`-M1`, `-M2`), each stable
+     qualifier (`release`, `final`, `lts`, `ga`, `stable`), build
+     metadata after `+`, mixed qualifier and prerelease in different
+     case orderings, and the existing keywords (which should still be
+     rejected through the prerelease check, since the keyword test is
+     no longer needed but the prerelease test catches them).
+3. **Audit and recipe updates.**
+   - Run `git grep -l 'github_repo' recipes/ internal/recipe/recipes/`.
+   - For each recipe, inspect upstream tags via
+     `git ls-remote --tags <repo> | tail -50` (or the GitHub API) to
+     check for hyphen-suffixed stable releases.
+   - Recipes whose upstream uses hyphen-suffixed stables receive a
+     `stable_qualifiers = [...]` line in the same PR as the filter
+     change.
+   - The PR description explicitly lists the audit results so reviewers
+     can flag any miss.
+
+The three slices land in a single PR because the filter change without
+the audit risks regression and the recipe updates without the schema
+change do not parse.
+
+## Security Considerations
+
+This change is confined to the version-resolution layer and operates on
+data that already flows through tsuku at install time:
+
+- **No new external attack surface.** The version provider already fetches
+  tags and releases from GitHub via authenticated or anonymous API calls
+  with established error handling. The change reads the same data and
+  applies a different in-memory predicate; no new endpoints, no new
+  credential paths.
+- **No new code-execution paths.** `isStableVersion` is a pure function on
+  string input. Adding the `stableQualifiers` map does not introduce
+  reflection, dynamic loading, or shell-out behavior.
+- **Recipe field is data, not code.** `stable_qualifiers` is a list of
+  lowercase strings used only as map keys. There is no regex or template
+  evaluation; an attacker who controls a recipe cannot use the field to
+  affect any other code path. The field is also checked by the
+  strict-validate path before any plan is generated.
+- **No version-resolution regression that could install untrusted
+  binaries.** The change tightens the filter (admits fewer versions by
+  default) rather than loosening it. The qualifier opt-in only re-admits
+  versions the upstream itself published with a stable-signaling
+  hyphen-suffix, and the recipe author who wrote the field has reviewed
+  the upstream's tagging convention. Pinning behavior
+  (`tsuku install <tool>@<version>`) is unaffected because the lister
+  continues to return every tag.
 
 ## Consequences
 
@@ -199,91 +385,29 @@ likely does not include any currently-curated recipe.
 - Tests gain a clear pinning surface: each behavior is exercised by a
   small input, not by a substring trick.
 
-### Negative / Risks
+### Negative
 
 - **Behavior change for existing recipes whose upstream tags use
-  hyphen-suffixed stables.** Mitigation: audit + add `stable_qualifiers`
-  to those recipes in the same PR. The PR description should call out
-  the audit explicitly so reviewers can flag any miss.
+  hyphen-suffixed stables.** Mitigation: the audit step in the
+  Implementation Approach catches these, and the same PR adds the
+  `stable_qualifiers` field to each affected recipe.
 - **Recipe authors of new tools must know the upstream's tagging
-  convention.** This is a small ask — `git ls-remote --tags` plus a
-  glance is enough — but it is one extra step.
-- The change touches a stable, well-exercised code path. We should add
-  table-driven tests for `isStableVersion` covering: plain semver,
-  alpha/beta/rc, milestone (`-M1`, `-M2`, with and without numeric
-  suffix), each stable qualifier (`release`, `final`, `lts`, `ga`,
-  `stable`), build metadata after `+`, and the existing keywords (since
-  they are no longer special-cased — they should still be rejected
-  through the prerelease check, but the test pins that behavior).
+  convention.** This is a small ask but it is one extra step in the
+  recipe-authoring flow. We should document it in the recipe-author
+  skill.
+- The change touches a stable, well-exercised code path. We must add
+  the table-driven tests described in the Implementation Approach to
+  pin behavior before flipping the default.
 
-## Alternatives Considered
-
-### A. Extend the keyword blocklist
-
-Add `milestone` and a regex matching `^m\d+$` against the prerelease
-component. Rejected: whack-a-mole. The next exotic prerelease format from
-another ecosystem brings us back to this issue.
-
-### B. Strict SemVer with a global allowlist
-
-Hardcode `["release", "final", "lts", "ga", "stable"]` into the provider.
-Rejected: the user pointed out that tagging conventions vary across
-repositories but are stable within a repository. A global allowlist
-risks both false positives (admitting a prerelease the upstream actually
-intends as unstable) and false negatives (missing a project-specific
-qualifier we did not anticipate). The cost of per-recipe configuration
-is one extra line in the recipes that need it.
-
-### C. Per-recipe regex tag filter
-
-Add `[version] tag_filter = "regex"` that admits only matching tags.
-Rejected for now: more general but more complex. The regex would need
-to handle prefix-stripped vs raw tags, escape semantics, and recipe
-authors would have to design and debug a regex per recipe. We can
-revisit if the `stable_qualifiers` field proves insufficient.
-
-### D. Use the GitHub releases API's `prerelease` flag
-
-The `releases` API exposes a `prerelease: bool` annotation that respects
-the upstream's intent. Rejected as a primary mechanism: it only works
-when the upstream uses the GitHub releases UI consistently and tags
-both releases and pre-releases through it. Many repos use git tags
-without GitHub releases (the existing
-`Resolver.resolveFromTags` fallback exists for exactly this case), and
-in that path no `prerelease` flag is available. The proposed solution
-works uniformly across the tags and releases code paths.
-
-## Implementation Notes
-
-- The signature change to `isStableVersion` is internal; no exported API
-  changes.
-- `provider_github.go:NewGitHubProvider` and `NewGitHubProviderWithPrefix`
-  gain a `stableQualifiers []string` argument, populated from
-  `recipe.VersionSection.StableQualifiers`.
-- The `provider_factory.go` constructor for the GitHub strategy threads
-  the field through.
-- Tests live in a new `internal/version/provider_github_test.go` (the
-  existing tests for this file are sparse) and exercise the
-  `isStableVersion` predicate directly with the table cases listed above.
-- Validation: `tsuku validate --strict` already enforces typed recipe
-  fields; adding `StableQualifiers` extends the schema with no special
-  validator work.
-
-## Open Questions
-
-None at this time. The audit in step 4 may surface recipes that need
-the new field; if any of those recipes are currently curated, the audit
-should be completed before this design moves to "Accepted" so the same
-PR can land both the filter change and the recipe updates.
-
-## Affected Components
+### Affected Components
 
 - `internal/version/provider_github.go` (filter and providers)
 - `internal/version/fossil_provider.go` (parallel filter)
 - `internal/recipe/types.go` (`VersionSection.StableQualifiers`)
 - `internal/version/provider_factory.go` (threading the field)
 - Recipes whose upstream uses hyphen-suffixed stable qualifiers (audit)
+- Recipe-author skill documentation (one-line note about the new field)
 
-## Implementation Issue
+### Implementation Issue
 
 This design is implemented by [#2325](https://github.com/tsukumogami/tsuku/issues/2325).

--- a/docs/designs/DESIGN-prerelease-detection.md
+++ b/docs/designs/DESIGN-prerelease-detection.md
@@ -493,6 +493,19 @@ data that already flows through tsuku at install time:
 - Recipes whose upstream uses hyphen-suffixed stable qualifiers (audit)
 - Recipe-author skill documentation (one-line note about the new field)
 
-### Implementation Issue
+## Implementation Issues
 
-This design is implemented by [#2325](https://github.com/tsukumogami/tsuku/issues/2325).
+### Milestone: [Curated Recipe System](https://github.com/tsukumogami/tsuku/milestone/113)
+
+| Issue | Dependencies | Tier |
+|-------|--------------|------|
+| [#2325: fix(version): treat -Mn milestone tags as pre-releases in GitHub provider](https://github.com/tsukumogami/tsuku/issues/2325) | None | testable |
+
+```mermaid
+graph TD
+    I2325["#2325: SemVer-aware prerelease detection"]
+
+    classDef ready fill:#bbdefb
+
+    class I2325 ready
+```

--- a/docs/designs/DESIGN-prerelease-detection.md
+++ b/docs/designs/DESIGN-prerelease-detection.md
@@ -499,13 +499,13 @@ data that already flows through tsuku at install time:
 
 | Issue | Dependencies | Tier |
 |-------|--------------|------|
-| [#2325: fix(version): treat -Mn milestone tags as pre-releases in GitHub provider](https://github.com/tsukumogami/tsuku/issues/2325) | None | testable |
+| ~~[#2325: fix(version): treat -Mn milestone tags as pre-releases in GitHub provider](https://github.com/tsukumogami/tsuku/issues/2325)~~ | ~~None~~ | ~~testable~~ |
 
 ```mermaid
 graph TD
     I2325["#2325: SemVer-aware prerelease detection"]
 
-    classDef ready fill:#bbdefb
+    classDef done fill:#c8e6c9
 
-    class I2325 ready
+    class I2325 done
 ```

--- a/docs/designs/current/DESIGN-prerelease-detection.md
+++ b/docs/designs/current/DESIGN-prerelease-detection.md
@@ -1,5 +1,5 @@
 ---
-status: Planned
+status: Current
 problem: |
   The GitHub version provider's `isStableVersion` filter uses substring matching
   against a hardcoded keyword list (`preview`, `alpha`, `beta`, `rc`, `dev`,
@@ -44,7 +44,7 @@ rationale: |
 
 ## Status
 
-Planned
+Current
 
 ## Context and Problem Statement
 
@@ -493,22 +493,12 @@ data that already flows through tsuku at install time:
 - Recipes whose upstream uses hyphen-suffixed stable qualifiers (audit)
 - Recipe-author skill documentation (one-line note about the new field)
 
-## Implementation Issues
+## Implementation History
 
-### Milestone: [Curated Recipe System](https://github.com/tsukumogami/tsuku/milestone/113)
-
-| Issue | Dependencies | Tier |
-|-------|--------------|------|
-| ~~[#2325: fix(version): treat -Mn milestone tags as pre-releases in GitHub provider](https://github.com/tsukumogami/tsuku/issues/2325)~~ | ~~None~~ | ~~testable~~ |
-| ~~_Replaces the substring-keyword `isStableVersion` filter with a SemVer-aware predicate plus a non-SemVer fallback. Adds the `[version] stable_qualifiers` recipe field with default `["release", "final", "lts", "ga", "stable"]`. Implementation lives in `internal/version/provider_github.go` and `internal/version/fossil_provider.go`._~~ | | |
-
-```mermaid
-graph TD
-    I2325["#2325: SemVer-aware prerelease detection"]
-
-    classDef done fill:#c8e6c9
-
-    class I2325 done
-```
-
-**Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design
+Implemented by [#2325](https://github.com/tsukumogami/tsuku/issues/2325)
+in [PR #2341](https://github.com/tsukumogami/tsuku/pull/2341). The
+implementation lives in `internal/version/provider_github.go`,
+`internal/version/fossil_provider.go`,
+`internal/version/provider_factory.go`, and
+`internal/recipe/types.go`. Tests are in
+`internal/version/provider_github_test.go`.

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -130,50 +130,13 @@ Recipes that depend on a Wave 4 *code change* require a tsuku release containing
 
 ## Dependency Graph
 
+Waves 0–3 are fully complete and have been removed from the diagram for
+clarity. Their ticket histories live in this document's tables above.
+The diagram tracks active work: Wave 4 follow-ups and the Wave 5 recipe
+authoring they unblock.
+
 ```mermaid
 graph TD
-    subgraph wave0 ["Wave 0: Foundation"]
-        I2259["#2259: curated flag + CI infrastructure"]
-        I2260["#2260: top-100 priority list"]
-    end
-
-    subgraph wave1 ["Wave 1: Initial handcrafted recipes"]
-        I2261["#2261: claude + gemini-cli"]
-        I2262["#2262: cross-platform kubectl"]
-        I2263["#2263: cross-platform helm"]
-        I2264["#2264: bat + starship + neovim"]
-        I2265["#2265: node.js recipe"]
-    end
-
-    subgraph wave2 ["Wave 2: First backfill round"]
-        I2266["#2266: cloud CLIs + build tools"]
-        I2267["#2267: modern CLIs + AI tools"]
-    end
-
-    subgraph wave3 ["Wave 3: Category backfill batches"]
-        I2268["#2268: superseded by #2281–#2297"]
-        I2281["#2281: security scanners"]
-        I2282["#2282: K8s core CLIs"]
-        I2283["#2283: K8s ecosystem"]
-        I2284["#2284: HashiCorp + infra"]
-        I2285["#2285: terminal UI / TUI"]
-        I2286["#2286: shell utilities"]
-        I2287["#2287: env/version managers"]
-        I2288["#2288: JS/Node ecosystem"]
-        I2289["#2289: Go/shell linters"]
-        I2290["#2290: Python/JS formatters"]
-        I2291["#2291: crypto + certs"]
-        I2292["#2292: CI/CD automation"]
-        I2293["#2293: container + image tools"]
-        I2294["#2294: language runtimes"]
-        I2295["#2295: C++/JVM build tools"]
-        I2296["#2296: cloud CLIs + orchestration"]
-        I2297["#2297: IaC quality + policy"]
-        I2312["#2312: macOS dylib deps (libnghttp3, utf8proc; libevent + pcre2 deferred)"]
-        I2313["#2313: macOS support for wget; curl/tmux/git deferred"]
-        I2315["#2315: curate rbenv recipe"]
-    end
-
     subgraph wave4 ["Wave 4: Follow-ups from milestone work"]
         I2325["#2325: -Mn milestone tags in github provider"]
         I2327["#2327: openjdk recipe for JVM verify"]
@@ -193,53 +156,6 @@ graph TD
         I2346["#2346: gcloud recipe"]
     end
 
-    I2259 --> I2261
-    I2259 --> I2262
-    I2259 --> I2263
-    I2259 --> I2264
-    I2259 --> I2265
-    I2259 --> I2266
-    I2259 --> I2267
-    I2260 --> I2266
-    I2260 --> I2267
-    I2259 --> I2281
-    I2259 --> I2282
-    I2259 --> I2283
-    I2259 --> I2284
-    I2259 --> I2285
-    I2259 --> I2286
-    I2259 --> I2287
-    I2259 --> I2288
-    I2259 --> I2289
-    I2259 --> I2290
-    I2259 --> I2291
-    I2259 --> I2292
-    I2259 --> I2293
-    I2259 --> I2294
-    I2259 --> I2295
-    I2259 --> I2296
-    I2259 --> I2297
-    I2260 --> I2281
-    I2260 --> I2282
-    I2260 --> I2283
-    I2260 --> I2284
-    I2260 --> I2285
-    I2260 --> I2286
-    I2260 --> I2287
-    I2260 --> I2288
-    I2260 --> I2289
-    I2260 --> I2290
-    I2260 --> I2291
-    I2260 --> I2292
-    I2260 --> I2293
-    I2260 --> I2294
-    I2260 --> I2295
-    I2260 --> I2296
-    I2260 --> I2297
-    I2312 --> I2313
-    I2259 --> I2315
-    I2260 --> I2315
-
     I2333 --> I2336
     I2335 --> I2336
 
@@ -248,11 +164,6 @@ graph TD
     I2327 --> I2344
     I2331 --> I2345
     I2328 --> I2346
-
-    %% Invisible inter-wave anchor edges to force vertical wave-by-wave layout.
-    I2265 ~~~ I2267
-    I2267 ~~~ I2268
-    I2315 ~~~ I2325
 
     classDef done fill:#c8e6c9
     classDef ready fill:#bbdefb
@@ -264,7 +175,6 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297,I2312,I2313,I2315 done
     class I2325 done
     class I2327,I2328,I2330,I2331,I2333,I2335,I2338 ready
     class I2336,I2343,I2344,I2345,I2346 blocked

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -92,8 +92,8 @@ These issues capture infrastructure and recipe gaps surfaced while authoring the
 
 | Issue | Dependencies | Complexity |
 |-------|--------------|------------|
-| [#2325: fix(version): treat -Mn milestone tags as pre-releases in GitHub provider](https://github.com/tsukumogami/tsuku/issues/2325) | None | testable |
-| _The github version provider's `isStableVersion` substring filter does not catch milestone tags like `v9.6.0-M1` (gradle) or `v2.0.0-M5` (sbt), so `tsuku eval` resolves to a non-existent download URL. Blocks gradle and sbt curation._ | | |
+| ~~[#2325: fix(version): treat -Mn milestone tags as pre-releases in GitHub provider](https://github.com/tsukumogami/tsuku/issues/2325)~~ | ~~None~~ | ~~testable~~ |
+| ~~_Replaces the substring-keyword `isStableVersion` filter with a SemVer-aware predicate (any non-empty prerelease component is unstable unless it matches a stable qualifier), plus a non-SemVer fallback to catch markers spliced into the version without a hyphen (e.g., jq's `1.8.2rc1`). Default stable qualifiers `["release", "final", "lts", "ga", "stable"]` admit the common JVM RELEASE/FINAL conventions; the `[version] stable_qualifiers` recipe field overrides for exotic upstreams. Designed in `docs/designs/DESIGN-prerelease-detection.md`._~~ | | |
 | [#2327: feat(recipes): add openjdk recipe to enable JVM tool verification](https://github.com/tsukumogami/tsuku/issues/2327) | None | testable |
 | _Sandbox containers do not bundle a JDK and the registry has no `openjdk` recipe to declare as a dependency. JVM tools (maven, gradle, sbt) install successfully but fail verify because `mvn --version` etc. need a JVM at runtime._ | | |
 | [#2328: feat(version): add a version source for Google Cloud SDK to enable gcloud recipe](https://github.com/tsukumogami/tsuku/issues/2328) | None | testable |
@@ -230,7 +230,8 @@ graph TD
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
     class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297,I2312,I2313,I2315 done
-    class I2325,I2327,I2328,I2330,I2331,I2333,I2335,I2338 ready
+    class I2325 done
+    class I2327,I2328,I2330,I2331,I2333,I2335,I2338 ready
     class I2336 blocked
 ```
 

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -4,7 +4,7 @@ status: Active
 execution_mode: multi-pr
 upstream: docs/designs/DESIGN-curated-recipes.md
 milestone: "Curated Recipe System"
-issue_count: 37
+issue_count: 41
 ---
 
 ## Status
@@ -111,6 +111,23 @@ These issues capture infrastructure and recipe gaps surfaced while authoring the
 | [#2338: fix(recipes): add macOS support to curl and resolve rhel sandbox verify failure](https://github.com/tsukumogami/tsuku/issues/2338) | None | testable |
 | _A first attempt at the curl darwin step (subsequently reverted) cleared eval and macOS install but surfaced a rhel-only sandbox verify failure on Linux: install completes (`install_exit_code = 0`) but `passed = false`. Same shape as the pcre2 rhel issue. Needs local reproduction since the workflow does not upload `.log-*.txt` artifacts._ | | |
 
+### Wave 5: Recipe authoring after Wave 4 lands
+
+These recipes were attempted in Wave 3 batches and reverted because their Wave 4 prereqs were not yet available. They ship as small, focused PRs once each prereq lands. The four entries below cover every Wave 3 recipe that was deferred due to a Wave 4 blocker; the other deferred items (libevent darwin, pcre2 macOS, tmux/git darwin, curl darwin, bazel) include the recipe update inside their Wave 4 issue scope and don't need separate authoring tickets.
+
+Recipes that depend on a Wave 4 *code change* require a tsuku release containing that change, since the recipe behavior they rely on lives in the tsuku binary, not in the recipe registry.
+
+| Issue | Dependencies | Complexity |
+|-------|--------------|------------|
+| [#2343: feat(recipes): author maven recipe](https://github.com/tsukumogami/tsuku/issues/2343) | [#2327](https://github.com/tsukumogami/tsuku/issues/2327) | testable |
+| _Recipe-only change. Maven ships a single platform-agnostic Apache distribution; the recipe needs an openjdk runtime dependency so `mvn --version` can verify._ | | |
+| [#2344: feat(recipes): author gradle and sbt recipes](https://github.com/tsukumogami/tsuku/issues/2344) | [#2327](https://github.com/tsukumogami/tsuku/issues/2327), tsuku release containing [#2325](https://github.com/tsukumogami/tsuku/issues/2325) | testable |
+| _Both upstreams use `-Mn` milestone tags that #2325 now filters as prereleases (released in the binary), and both need the openjdk runtime dependency from #2327 for verify._ | | |
+| [#2345: feat(recipes): author ansible and azure-cli recipes](https://github.com/tsukumogami/tsuku/issues/2345) | tsuku release containing [#2331](https://github.com/tsukumogami/tsuku/issues/2331) | testable |
+| _Both pin to a python-3.10-compatible pypi release using the new pipx version-constraint feature in #2331. Recipe authors using the new constraint syntax need a tsuku binary that knows about it._ | | |
+| [#2346: feat(recipes): author gcloud recipe](https://github.com/tsukumogami/tsuku/issues/2346) | tsuku release containing [#2328](https://github.com/tsukumogami/tsuku/issues/2328) | testable |
+| _Recipe uses the new gcloud version source from #2328. Same release-dependency story: the recipe references a `[version] source` value that the tsuku binary must recognize._ | | |
+
 ## Dependency Graph
 
 ```mermaid
@@ -169,6 +186,13 @@ graph TD
         I2338["#2338: curl macOS + rhel sandbox failure"]
     end
 
+    subgraph wave5 ["Wave 5: Recipe authoring after Wave 4"]
+        I2343["#2343: maven recipe"]
+        I2344["#2344: gradle + sbt recipes"]
+        I2345["#2345: ansible + azure-cli recipes"]
+        I2346["#2346: gcloud recipe"]
+    end
+
     I2259 --> I2261
     I2259 --> I2262
     I2259 --> I2263
@@ -219,6 +243,12 @@ graph TD
     I2333 --> I2336
     I2335 --> I2336
 
+    I2327 --> I2343
+    I2325 --> I2344
+    I2327 --> I2344
+    I2331 --> I2345
+    I2328 --> I2346
+
     classDef done fill:#c8e6c9
     classDef ready fill:#bbdefb
     classDef blocked fill:#fff9c4
@@ -232,14 +262,14 @@ graph TD
     class I2259,I2260,I2261,I2262,I2263,I2264,I2265,I2266,I2267,I2268,I2281,I2282,I2283,I2284,I2285,I2286,I2287,I2288,I2289,I2290,I2291,I2292,I2293,I2294,I2295,I2296,I2297,I2312,I2313,I2315 done
     class I2325 done
     class I2327,I2328,I2330,I2331,I2333,I2335,I2338 ready
-    class I2336 blocked
+    class I2336,I2343,I2344,I2345,I2346 blocked
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan
 
 ## Implementation Sequence
 
-**Critical path**: #2259 → #2260 → Wave 3 backfill batches → Wave 4 follow-ups for the recipes deferred during Wave 3.
+**Critical path**: #2259 → #2260 → Wave 3 backfill batches → Wave 4 follow-ups → tsuku release containing the Wave 4 code changes → Wave 5 recipe authoring.
 
 | Wave | Issues | Start condition |
 |------|--------|----------------|
@@ -248,6 +278,7 @@ graph TD
 | Wave 2 | #2266, #2267 | After both #2259 and #2260 merge |
 | Wave 3 | #2281–#2297, #2312, #2313, #2315 (20 backfill batches) | After #2259 and #2260 merge |
 | Wave 4 | #2325, #2327, #2328, #2330, #2331, #2333, #2335, #2336, #2338 | After Wave 3 surfaces the gap each issue captures |
+| Wave 5 | #2343, #2344, #2345, #2346 | After the Wave 4 prereq for each lands and (if a code change) is included in a tsuku release |
 
 Wave 3 issues were fully independent of each other; each batch was scoped to a coherent tool category and shipped as a single PR.
 
@@ -255,5 +286,14 @@ Wave 3 issues were fully independent of each other; each batch was scoped to a c
 
 - **#2336 (tmux + git macOS)** is hard-blocked by #2333 (libevent darwin) and #2335 (pcre2 macOS dylibs).
 - **#2335 and #2338** share the same RHEL sandbox failure shape (install completes with `exit 0`, verify exits non-zero with no log artifact). Investigating one will likely produce the diagnostic capability needed for the other; consider taking them together.
-- **#2325, #2327, #2331** unblock recipe authoring rather than fixing existing recipes. After each lands, the corresponding recipes can be authored as small follow-up PRs (gradle/sbt for #2325, maven and any other JVM tool for #2327, ansible/azure-cli for #2331).
+- **#2325, #2327, #2331** unblock Wave 5 recipe authoring rather than fixing existing recipes. After each lands (and is released for the code-change ones), the corresponding Wave 5 ticket can ship.
 - **#2330 (bazel)** depends on #2327 if the chosen approach uses the `bazel_nojdk-*` asset; otherwise independent.
+
+**Wave 5 priority**: every Wave 5 ticket is small (one or two recipes per ticket), independent of the other Wave 5 tickets, and gated only by its own Wave 4 prereqs. Order is determined by which Wave 4 prereq lands first:
+
+- **#2343 (maven)** ships as soon as #2327 (openjdk recipe) lands. No tsuku release dependency since #2327 is recipe-only.
+- **#2344 (gradle, sbt)** needs #2327 *and* a tsuku release containing #2325. Among Wave 5, this is the one that can be cut as soon as #2325 ships in a tagged release and #2327 lands.
+- **#2345 (ansible, azure-cli)** is gated by a release containing #2331.
+- **#2346 (gcloud)** is gated by a release containing #2328.
+
+The "tsuku release" gate exists because recipes that use new tsuku features (custom version sources, recipe-level constraint syntax) need a tsuku binary that knows about those features. Recipes that only depend on bug-fix behavior changes (like #2325's stricter prerelease filter) don't strictly need a release, but in practice we prefer one so the recipe doesn't have to work around stale tsuku binaries in users' caches.

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -249,6 +249,11 @@ graph TD
     I2331 --> I2345
     I2328 --> I2346
 
+    %% Invisible inter-wave anchor edges to force vertical wave-by-wave layout.
+    I2265 ~~~ I2267
+    I2267 ~~~ I2268
+    I2315 ~~~ I2325
+
     classDef done fill:#c8e6c9
     classDef ready fill:#bbdefb
     classDef blocked fill:#fff9c4

--- a/internal/recipe/types.go
+++ b/internal/recipe/types.go
@@ -190,6 +190,13 @@ type VersionSection struct {
 	ProjectName      string `toml:"project_name"`      // Project name for tarball filename (e.g., "sqlite")
 	VersionSeparator string `toml:"version_separator"` // Separator in version numbers for tag conversion (e.g., "-" converts 9.0.0 to 9-0-0)
 	TimelineTag      string `toml:"timeline_tag"`      // Tag filter for timeline URL (default: "release")
+
+	// StableQualifiers names hyphenated suffixes that the upstream uses as
+	// stable release qualifiers rather than prereleases (e.g., ["release",
+	// "final"] for projects that tag stable releases as 1.0.0-RELEASE).
+	// When unset, the version provider uses DefaultStableQualifiers.
+	// When set, this list replaces the default — it does not extend it.
+	StableQualifiers []string `toml:"stable_qualifiers,omitempty"`
 }
 
 // Matchable provides platform dimension accessors for matching.

--- a/internal/updates/self.go
+++ b/internal/updates/self.go
@@ -90,7 +90,7 @@ func CheckAndApplySelf(ctx context.Context, cfg *config.Config, userCfg *usercon
 		return nil
 	}
 
-	provider := version.NewGitHubProvider(resolver, SelfRepo)
+	provider := version.NewGitHubProvider(resolver, SelfRepo, nil)
 
 	latest, err := provider.ResolveLatest(ctx)
 	if err != nil {

--- a/internal/version/fossil_integration_test.go
+++ b/internal/version/fossil_integration_test.go
@@ -15,7 +15,7 @@ func TestFossilTimelineProvider_Integration(t *testing.T) {
 	}
 
 	resolver := New()
-	provider := NewFossilTimelineProvider(resolver, "https://sqlite.org/src", "sqlite")
+	provider := NewFossilTimelineProvider(resolver, "https://sqlite.org/src", "sqlite", nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/internal/version/fossil_provider.go
+++ b/internal/version/fossil_provider.go
@@ -16,15 +16,18 @@ import (
 // Tag format: version-3.46.0, core-9-0-0 (with version_separator)
 type FossilTimelineProvider struct {
 	resolver         *Resolver
-	repo             string // Full URL to Fossil repo (e.g., "https://sqlite.org/src")
-	projectName      string // Project name for tarball (e.g., "sqlite")
-	tagPrefix        string // Prefix before version in tags (default: "version-")
-	versionSeparator string // Separator in version numbers (default: ".")
-	timelineTag      string // Tag filter for timeline URL (default: "release")
+	repo             string          // Full URL to Fossil repo (e.g., "https://sqlite.org/src")
+	projectName      string          // Project name for tarball (e.g., "sqlite")
+	tagPrefix        string          // Prefix before version in tags (default: "version-")
+	versionSeparator string          // Separator in version numbers (default: ".")
+	timelineTag      string          // Tag filter for timeline URL (default: "release")
+	stableQualifiers map[string]bool // hyphenated suffixes treated as stable (lowercased)
 }
 
 // NewFossilTimelineProvider creates a provider for Fossil-hosted projects.
-func NewFossilTimelineProvider(resolver *Resolver, repo, projectName string) *FossilTimelineProvider {
+// stableQualifiers names hyphenated suffixes the upstream uses as stable
+// release qualifiers; pass nil to use DefaultStableQualifiers.
+func NewFossilTimelineProvider(resolver *Resolver, repo, projectName string, stableQualifiers []string) *FossilTimelineProvider {
 	return &FossilTimelineProvider{
 		resolver:         resolver,
 		repo:             repo,
@@ -32,12 +35,15 @@ func NewFossilTimelineProvider(resolver *Resolver, repo, projectName string) *Fo
 		tagPrefix:        "version-",
 		versionSeparator: ".",
 		timelineTag:      "release",
+		stableQualifiers: buildStableQualifierSet(stableQualifiers),
 	}
 }
 
 // NewFossilTimelineProviderWithOptions creates a provider with custom tag format options.
-func NewFossilTimelineProviderWithOptions(resolver *Resolver, repo, projectName, tagPrefix, versionSeparator, timelineTag string) *FossilTimelineProvider {
-	p := NewFossilTimelineProvider(resolver, repo, projectName)
+// stableQualifiers names hyphenated suffixes the upstream uses as stable
+// release qualifiers; pass nil to use DefaultStableQualifiers.
+func NewFossilTimelineProviderWithOptions(resolver *Resolver, repo, projectName, tagPrefix, versionSeparator, timelineTag string, stableQualifiers []string) *FossilTimelineProvider {
+	p := NewFossilTimelineProvider(resolver, repo, projectName, stableQualifiers)
 	if tagPrefix != "" {
 		p.tagPrefix = tagPrefix
 	}
@@ -140,7 +146,7 @@ func (p *FossilTimelineProvider) ResolveLatest(ctx context.Context) (*VersionInf
 
 	// Find the first stable version
 	for _, v := range versions {
-		if isStableVersion(v) {
+		if isStableVersion(v, p.stableQualifiers) {
 			return &VersionInfo{
 				Version: v,
 				Tag:     p.versionToTag(v),

--- a/internal/version/fossil_provider_test.go
+++ b/internal/version/fossil_provider_test.go
@@ -98,7 +98,7 @@ func TestFossilTimelineProvider_ParseTimelineTags(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewFossilTimelineProviderWithOptions(nil, "https://example.com", "test", tt.tagPrefix, tt.versionSeparator, "release")
+			p := NewFossilTimelineProviderWithOptions(nil, "https://example.com", "test", tt.tagPrefix, tt.versionSeparator, "release", nil)
 			tags := p.parseTimelineTags(tt.html)
 
 			if len(tags) != len(tt.expectedTags) {
@@ -149,7 +149,7 @@ func TestFossilTimelineProvider_TagVersionConversion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewFossilTimelineProviderWithOptions(nil, "https://example.com", "test", tt.tagPrefix, tt.versionSeparator, "release")
+			p := NewFossilTimelineProviderWithOptions(nil, "https://example.com", "test", tt.tagPrefix, tt.versionSeparator, "release", nil)
 			version := p.tagToVersion(tt.tag)
 
 			if version != tt.expectedVersion {
@@ -185,7 +185,7 @@ func TestFossilTimelineProvider_VersionToTag(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewFossilTimelineProviderWithOptions(nil, "https://example.com", "test", tt.tagPrefix, tt.versionSeparator, "release")
+			p := NewFossilTimelineProviderWithOptions(nil, "https://example.com", "test", tt.tagPrefix, tt.versionSeparator, "release", nil)
 			tag := p.versionToTag(tt.version)
 
 			if tag != tt.expectedTag {
@@ -227,7 +227,7 @@ func TestFossilTimelineProvider_TarballURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewFossilTimelineProviderWithOptions(nil, tt.repo, tt.projectName, tt.tagPrefix, tt.versionSeparator, "release")
+			p := NewFossilTimelineProviderWithOptions(nil, tt.repo, tt.projectName, tt.tagPrefix, tt.versionSeparator, "release", nil)
 			url := p.TarballURL(tt.version)
 
 			if url != tt.expectedURL {
@@ -260,7 +260,7 @@ func TestFossilTimelineProvider_BuildTimelineURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p := NewFossilTimelineProviderWithOptions(nil, tt.repo, "test", "", "", tt.timelineTag)
+			p := NewFossilTimelineProviderWithOptions(nil, tt.repo, "test", "", "", tt.timelineTag, nil)
 			url := p.buildTimelineURL()
 
 			if url != tt.expectedURL {
@@ -283,7 +283,7 @@ func TestFossilTimelineProvider_ListVersions(t *testing.T) {
 
 	resolver := New()
 	resolver.httpClient = server.Client()
-	p := NewFossilTimelineProvider(resolver, server.URL, "sqlite")
+	p := NewFossilTimelineProvider(resolver, server.URL, "sqlite", nil)
 
 	versions, err := p.ListVersions(context.Background())
 	if err != nil {
@@ -316,7 +316,7 @@ func TestFossilTimelineProvider_ResolveLatest(t *testing.T) {
 
 	resolver := New()
 	resolver.httpClient = server.Client()
-	p := NewFossilTimelineProvider(resolver, server.URL, "sqlite")
+	p := NewFossilTimelineProvider(resolver, server.URL, "sqlite", nil)
 
 	info, err := p.ResolveLatest(context.Background())
 	if err != nil {
@@ -344,7 +344,7 @@ func TestFossilTimelineProvider_ResolveVersion(t *testing.T) {
 
 	resolver := New()
 	resolver.httpClient = server.Client()
-	p := NewFossilTimelineProvider(resolver, server.URL, "sqlite")
+	p := NewFossilTimelineProvider(resolver, server.URL, "sqlite", nil)
 
 	tests := []struct {
 		name          string
@@ -399,7 +399,7 @@ func TestFossilTimelineProvider_ResolveVersion(t *testing.T) {
 }
 
 func TestFossilTimelineProvider_SourceDescription(t *testing.T) {
-	p := NewFossilTimelineProvider(nil, "https://sqlite.org/src", "sqlite")
+	p := NewFossilTimelineProvider(nil, "https://sqlite.org/src", "sqlite", nil)
 	desc := p.SourceDescription()
 
 	expected := "Fossil:https://sqlite.org/src"

--- a/internal/version/provider_factory.go
+++ b/internal/version/provider_factory.go
@@ -166,9 +166,9 @@ func (s *GitHubRepoStrategy) CanHandle(r *recipe.Recipe) bool {
 
 func (s *GitHubRepoStrategy) Create(resolver *Resolver, r *recipe.Recipe) (VersionProvider, error) {
 	if r.Version.TagPrefix != "" {
-		return NewGitHubProviderWithPrefix(resolver, r.Version.GitHubRepo, r.Version.TagPrefix), nil
+		return NewGitHubProviderWithPrefix(resolver, r.Version.GitHubRepo, r.Version.TagPrefix, r.Version.StableQualifiers), nil
 	}
-	return NewGitHubProvider(resolver, r.Version.GitHubRepo), nil
+	return NewGitHubProvider(resolver, r.Version.GitHubRepo, r.Version.StableQualifiers), nil
 }
 
 // InferredGitHubStrategy infers GitHub from github_archive/github_file actions (DEPRECATED)
@@ -191,7 +191,7 @@ func (s *InferredGitHubStrategy) Create(resolver *Resolver, r *recipe.Recipe) (V
 	for _, step := range r.Steps {
 		if step.Action == "github_archive" || step.Action == "github_file" {
 			if repo, ok := step.Params["repo"].(string); ok {
-				return NewGitHubProvider(resolver, repo), nil
+				return NewGitHubProvider(resolver, repo, r.Version.StableQualifiers), nil
 			}
 		}
 	}
@@ -772,6 +772,7 @@ func (s *InferredFossilStrategy) Create(resolver *Resolver, r *recipe.Recipe) (V
 			return NewFossilTimelineProviderWithOptions(
 				resolver, repo, projectName,
 				tagPrefix, versionSeparator, timelineTag,
+				r.Version.StableQualifiers,
 			), nil
 		}
 	}

--- a/internal/version/provider_github.go
+++ b/internal/version/provider_github.go
@@ -6,30 +6,60 @@ import (
 	"strings"
 )
 
+// DefaultStableQualifiers names hyphenated suffixes that universally signal a
+// stable release across upstream conventions. Any version whose prerelease
+// component (per SemVer's splitPrerelease) is one of these is treated as
+// stable. Recipes whose upstream uses an exotic qualifier override this list
+// via [version] stable_qualifiers — the recipe's list replaces the default.
+//
+// Designed in docs/designs/DESIGN-prerelease-detection.md.
+var DefaultStableQualifiers = []string{"release", "final", "lts", "ga", "stable"}
+
 // GitHubProvider resolves versions from GitHub releases/tags.
 // Implements both VersionResolver and VersionLister interfaces.
 type GitHubProvider struct {
-	resolver  *Resolver
-	repo      string // owner/repo format (e.g., "rust-lang/rust")
-	tagPrefix string // optional prefix to filter tags (e.g., "ruby-")
+	resolver         *Resolver
+	repo             string          // owner/repo format (e.g., "rust-lang/rust")
+	tagPrefix        string          // optional prefix to filter tags (e.g., "ruby-")
+	stableQualifiers map[string]bool // hyphenated suffixes treated as stable (lowercased)
 }
 
-// NewGitHubProvider creates a provider for GitHub-based tools
-func NewGitHubProvider(resolver *Resolver, repo string) *GitHubProvider {
+// NewGitHubProvider creates a provider for GitHub-based tools.
+// stableQualifiers names hyphenated suffixes the upstream uses as stable
+// release qualifiers; pass nil to use DefaultStableQualifiers.
+func NewGitHubProvider(resolver *Resolver, repo string, stableQualifiers []string) *GitHubProvider {
 	return &GitHubProvider{
-		resolver: resolver,
-		repo:     repo,
+		resolver:         resolver,
+		repo:             repo,
+		stableQualifiers: buildStableQualifierSet(stableQualifiers),
 	}
 }
 
-// NewGitHubProviderWithPrefix creates a provider that filters tags by prefix
-// The prefix is stripped from version strings (e.g., "ruby-3.3.10" -> "3.3.10")
-func NewGitHubProviderWithPrefix(resolver *Resolver, repo, tagPrefix string) *GitHubProvider {
+// NewGitHubProviderWithPrefix creates a provider that filters tags by prefix.
+// The prefix is stripped from version strings (e.g., "ruby-3.3.10" -> "3.3.10").
+// stableQualifiers names hyphenated suffixes the upstream uses as stable
+// release qualifiers; pass nil to use DefaultStableQualifiers.
+func NewGitHubProviderWithPrefix(resolver *Resolver, repo, tagPrefix string, stableQualifiers []string) *GitHubProvider {
 	return &GitHubProvider{
-		resolver:  resolver,
-		repo:      repo,
-		tagPrefix: tagPrefix,
+		resolver:         resolver,
+		repo:             repo,
+		tagPrefix:        tagPrefix,
+		stableQualifiers: buildStableQualifierSet(stableQualifiers),
 	}
+}
+
+// buildStableQualifierSet converts a list of qualifier strings to a
+// lowercased lookup set. nil or empty input falls back to
+// DefaultStableQualifiers.
+func buildStableQualifierSet(qualifiers []string) map[string]bool {
+	if len(qualifiers) == 0 {
+		qualifiers = DefaultStableQualifiers
+	}
+	set := make(map[string]bool, len(qualifiers))
+	for _, q := range qualifiers {
+		set[strings.ToLower(q)] = true
+	}
+	return set
 }
 
 // ListVersions returns all available versions from GitHub releases/tags (newest first)
@@ -55,13 +85,36 @@ func (p *GitHubProvider) ListVersions(ctx context.Context) ([]string, error) {
 	return filtered, nil
 }
 
-// isStableVersion checks if a version string represents a stable release
-// Returns false for preview, alpha, beta, rc releases
-func isStableVersion(version string) bool {
+// nonSemverUnstableMarkers names prerelease keywords that some upstreams
+// embed directly into the version string without a hyphen separator
+// (e.g., jq's "1.8.2rc1"). The SemVer-aware splitPrerelease check cannot
+// catch these because there is no hyphen to split on; we fall back to a
+// substring match for the non-SemVer case.
+var nonSemverUnstableMarkers = []string{"alpha", "beta", "rc", "preview", "snapshot", "nightly", "dev"}
+
+// isStableVersion checks if a version string represents a stable release.
+//
+// The check is two-layered:
+//  1. SemVer prerelease (anything after the first hyphen): a non-empty
+//     prerelease is unstable unless it matches one of the stableQualifiers
+//     (case-insensitive exact match). This catches every SemVer-style
+//     prerelease format (alpha, beta, rc, dev, M1, M2, ...) by construction
+//     while admitting "this is the release" suffixes used by some
+//     JVM-ecosystem upstreams (RELEASE, FINAL, LTS, GA, stable).
+//  2. Non-SemVer prerelease (marker spliced into the version without a
+//     hyphen, e.g., jq's "1.8.2rc1"): fall back to a substring match
+//     against a small fixed keyword list. This preserves the historical
+//     behavior for upstreams that don't follow SemVer's prerelease syntax.
+//
+// Designed in docs/designs/DESIGN-prerelease-detection.md.
+func isStableVersion(version string, stableQualifiers map[string]bool) bool {
+	_, prerelease := splitPrerelease(version)
+	if prerelease != "" {
+		return stableQualifiers[strings.ToLower(prerelease)]
+	}
 	lower := strings.ToLower(version)
-	unstablePatterns := []string{"preview", "alpha", "beta", "rc", "dev", "snapshot", "nightly"}
-	for _, pattern := range unstablePatterns {
-		if strings.Contains(lower, pattern) {
+	for _, marker := range nonSemverUnstableMarkers {
+		if strings.Contains(lower, marker) {
 			return false
 		}
 	}
@@ -84,9 +137,10 @@ func (p *GitHubProvider) ResolveLatest(ctx context.Context) (*VersionInfo, error
 		return nil, fmt.Errorf("no versions found matching prefix %q", p.tagPrefix)
 	}
 
-	// Find the first stable version (skip preview, alpha, beta, rc releases)
+	// Find the first stable version (skip prereleases that aren't whitelisted
+	// as stable qualifiers).
 	for _, v := range versions {
-		if isStableVersion(v) {
+		if isStableVersion(v, p.stableQualifiers) {
 			return &VersionInfo{
 				Version: v,
 				Tag:     p.tagPrefix + v,

--- a/internal/version/provider_github_test.go
+++ b/internal/version/provider_github_test.go
@@ -1,0 +1,155 @@
+package version
+
+import "testing"
+
+// TestIsStableVersion_DefaultQualifiers covers the predicate's behavior
+// against DefaultStableQualifiers, which is what the GitHub provider uses
+// when a recipe declares no stable_qualifiers field.
+func TestIsStableVersion_DefaultQualifiers(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		// Plain semver — always stable.
+		{"plain semver", "1.0.0", true},
+		{"plain semver with two parts", "2.34", true},
+		{"plain semver with calver-like core", "2024.1.15", true},
+
+		// SemVer prerelease keywords — always unstable.
+		{"alpha", "1.0.0-alpha", false},
+		{"alpha numbered", "1.0.0-alpha.1", false},
+		{"beta", "1.0.0-beta", false},
+		{"rc", "1.0.0-rc.1", false},
+		{"dev", "1.0.0-dev", false},
+
+		// Milestone tags (the bug that triggered this design).
+		{"gradle milestone uppercase", "9.6.0-M1", false},
+		{"sbt milestone uppercase", "2.0.0-M5", false},
+		{"milestone lowercase", "1.0.0-m2", false},
+
+		// Default stable qualifiers — admitted.
+		{"RELEASE uppercase", "5.3.39-RELEASE", true},
+		{"release lowercase", "5.3.39-release", true},
+		{"FINAL uppercase", "5.6.15-FINAL", true},
+		{"Final mixed case", "5.6.15-Final", true},
+		{"LTS", "1.0.0-LTS", true},
+		{"GA", "1.0.0-GA", true},
+		{"stable", "1.0.0-stable", true},
+
+		// Compound suffixes are not in the allowlist (exact match only).
+		{"compound final.1", "1.0.0-final.1", false},
+		{"compound RELEASE-hotfix", "1.0.0-RELEASE-hotfix", false},
+
+		// Build metadata after `+` is stripped before checking.
+		{"plain with build metadata", "1.0.0+build.123", true},
+		{"prerelease with build metadata", "1.0.0-rc.1+build.5", false},
+
+		// SemVer-style variants the old keyword filter caught — still
+		// rejected, now via the prerelease check.
+		{"snapshot", "1.0.0-SNAPSHOT", false},
+		{"nightly", "1.0.0-nightly", false},
+		{"preview", "1.0.0-preview", false},
+
+		// Non-SemVer prerelease markers spliced into the version without
+		// a hyphen (e.g., jq's "1.8.2rc1"). Caught by the fallback
+		// substring check.
+		{"non-semver rc", "1.8.2rc1", false},
+		{"non-semver beta", "2.0.0beta1", false},
+		{"non-semver alpha", "1.0.0alpha", false},
+		{"non-semver SNAPSHOT", "1.0SNAPSHOT", false},
+
+		// Edge case: empty version string. The current splitPrerelease
+		// returns ("", "") for empty input, so the predicate treats it as
+		// stable. Callers are expected to never pass empty strings; this
+		// case pins the behavior so a future refactor doesn't silently
+		// change it.
+		{"empty string", "", true},
+	}
+
+	stableQualifiers := buildStableQualifierSet(nil) // nil → DefaultStableQualifiers
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isStableVersion(tt.version, stableQualifiers)
+			if got != tt.want {
+				t.Errorf("isStableVersion(%q, default) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsStableVersion_RecipeOverride covers the case where a recipe declares
+// its own stable_qualifiers list, which replaces (not extends) the default.
+func TestIsStableVersion_RecipeOverride(t *testing.T) {
+	tests := []struct {
+		name             string
+		stableQualifiers []string
+		version          string
+		want             bool
+	}{
+		// Recipe limits qualifiers to {"release"} only.
+		{"override admits release", []string{"release"}, "1.0.0-RELEASE", true},
+		{"override rejects final not in list", []string{"release"}, "1.0.0-FINAL", false},
+		{"override rejects lts not in list", []string{"release"}, "1.0.0-LTS", false},
+
+		// Recipe declares an exotic qualifier.
+		{"exotic qualifier admitted", []string{"prod"}, "1.0.0-PROD", true},
+		{"exotic qualifier rejects defaults", []string{"prod"}, "1.0.0-RELEASE", false},
+
+		// Strict-SemVer-only recipe: empty list should NOT collapse to
+		// default; an explicit empty list is treated like nil today, but
+		// that is a documented limitation rather than a desired feature.
+		// This test pins the current behavior for visibility.
+		{"empty list falls back to default", []string{}, "1.0.0-RELEASE", true},
+
+		// Plain semver always stable regardless of qualifiers.
+		{"plain semver with empty list", []string{}, "1.0.0", true},
+		{"plain semver with custom list", []string{"prod"}, "1.0.0", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isStableVersion(tt.version, buildStableQualifierSet(tt.stableQualifiers))
+			if got != tt.want {
+				t.Errorf("isStableVersion(%q, %v) = %v, want %v",
+					tt.version, tt.stableQualifiers, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildStableQualifierSet covers the set construction behavior:
+// nil and empty slices both fall back to DefaultStableQualifiers, and
+// the lookup is case-insensitive (keys are lowercased on construction).
+func TestBuildStableQualifierSet(t *testing.T) {
+	t.Run("nil falls back to default", func(t *testing.T) {
+		set := buildStableQualifierSet(nil)
+		if !set["release"] {
+			t.Errorf("nil input should fall back to DefaultStableQualifiers (missing 'release')")
+		}
+		if !set["final"] {
+			t.Errorf("nil input should fall back to DefaultStableQualifiers (missing 'final')")
+		}
+	})
+
+	t.Run("empty slice falls back to default", func(t *testing.T) {
+		set := buildStableQualifierSet([]string{})
+		if !set["release"] {
+			t.Errorf("empty input should fall back to DefaultStableQualifiers (missing 'release')")
+		}
+	})
+
+	t.Run("explicit list lowercases on insert", func(t *testing.T) {
+		set := buildStableQualifierSet([]string{"PROD", "Final"})
+		if !set["prod"] {
+			t.Errorf("expected 'prod' in set, got: %v", set)
+		}
+		if !set["final"] {
+			t.Errorf("expected 'final' in set, got: %v", set)
+		}
+		if set["release"] {
+			t.Errorf("default 'release' should not be present when override is set, got: %v", set)
+		}
+	})
+}

--- a/internal/version/provider_test.go
+++ b/internal/version/provider_test.go
@@ -205,7 +205,7 @@ func TestProviderFromRecipe_Priority(t *testing.T) {
 
 func TestGitHubProvider_Interface(t *testing.T) {
 	resolver := New()
-	provider := NewGitHubProvider(resolver, "rust-lang/rust")
+	provider := NewGitHubProvider(resolver, "rust-lang/rust", nil)
 
 	// Verify it implements VersionResolver
 	var _ VersionResolver = provider
@@ -216,7 +216,7 @@ func TestGitHubProvider_Interface(t *testing.T) {
 
 func TestGitHubProvider_SourceDescription(t *testing.T) {
 	resolver := New()
-	provider := NewGitHubProvider(resolver, "rust-lang/rust")
+	provider := NewGitHubProvider(resolver, "rust-lang/rust", nil)
 
 	desc := provider.SourceDescription()
 	expected := "GitHub:rust-lang/rust"

--- a/testdata/golden/execution-exclusions.json
+++ b/testdata/golden/execution-exclusions.json
@@ -18,6 +18,11 @@
       "reason": "compile_from_source toolchain version drift (macOS build failures)"
     },
     {
+      "recipe": "ruby",
+      "issue": "https://github.com/tsukumogami/tsuku/issues/2342",
+      "reason": "ruby-builder ubuntu-22.04 binary fails to start on rhel (fedora) and arch sandbox containers; binary works on debian/suse/alpine"
+    },
+    {
       "recipe": "netlify-cli",
       "issue": "https://github.com/tsukumogami/tsuku/issues/1592",
       "reason": "npm EBADPLATFORM: @rollup/rollup-android-arm-eabi declares Android-only platform"

--- a/testdata/golden/plans/embedded/meson/v1.9.2-darwin-amd64.json
+++ b/testdata/golden/plans/embedded/meson/v1.9.2-darwin-amd64.json
@@ -76,7 +76,7 @@
         "has_native_addons": false,
         "locked_requirements": "meson==1.9.2 \\\n    --hash=sha256:1a284dc1912929098a6462401af58dc49ae3f324e94814a38a8f1020cee07cba\n",
         "package": "meson",
-        "python_version": "3.10.19",
+        "python_version": "3.10.20",
         "version": "1.9.2"
       },
       "evaluable": false,
@@ -84,7 +84,6 @@
     }
   ],
   "verify": {
-    "command": "meson --version",
-    "pattern": "{version}"
+    "command": "meson --version"
   }
 }

--- a/testdata/golden/plans/embedded/meson/v1.9.2-linux-alpine-amd64.json
+++ b/testdata/golden/plans/embedded/meson/v1.9.2-linux-alpine-amd64.json
@@ -1,0 +1,26 @@
+{
+  "format_version": 5,
+  "tool": "meson",
+  "version": "1.9.2",
+  "platform": {
+    "os": "linux",
+    "arch": "amd64",
+    "linux_family": "alpine"
+  },
+  "deterministic": false,
+  "steps": [
+    {
+      "action": "apk_install",
+      "params": {
+        "packages": [
+          "meson"
+        ]
+      },
+      "evaluable": false,
+      "deterministic": false
+    }
+  ],
+  "verify": {
+    "command": "meson --version"
+  }
+}

--- a/testdata/golden/plans/embedded/meson/v1.9.2-linux-arch-amd64.json
+++ b/testdata/golden/plans/embedded/meson/v1.9.2-linux-arch-amd64.json
@@ -3,33 +3,34 @@
   "tool": "meson",
   "version": "1.9.2",
   "platform": {
-    "os": "darwin",
-    "arch": "arm64"
+    "os": "linux",
+    "arch": "amd64",
+    "linux_family": "arch"
   },
   "deterministic": false,
   "dependencies": [
     {
       "tool": "python-standalone",
-      "version": "20260203",
+      "version": "20260414",
       "steps": [
         {
           "action": "download_file",
           "params": {
-            "checksum": "f2cd9caf1f04d59c620aeb3183ec78f880024a0e9246d2bd2fb59cc4bfedac21",
+            "checksum": "303047011b2c9f58504a930fc974d84547477cf69a3f2962f25552e2395c13af",
             "checksum_algo": "sha256",
-            "dest": "cpython-3.10.19+20260203-aarch64-apple-darwin-install_only.tar.gz",
-            "url": "https://github.com/indygreg/python-build-standalone/releases/download/20260203/cpython-3.10.19+20260203-aarch64-apple-darwin-install_only.tar.gz"
+            "dest": "cpython-3.10.20+20260414-x86_64-unknown-linux-gnu-install_only.tar.gz",
+            "url": "https://github.com/indygreg/python-build-standalone/releases/download/20260414/cpython-3.10.20+20260414-x86_64-unknown-linux-gnu-install_only.tar.gz"
           },
           "evaluable": true,
           "deterministic": true,
-          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20260203/cpython-3.10.19+20260203-aarch64-apple-darwin-install_only.tar.gz",
-          "checksum": "f2cd9caf1f04d59c620aeb3183ec78f880024a0e9246d2bd2fb59cc4bfedac21",
-          "size": 19530228
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20260414/cpython-3.10.20+20260414-x86_64-unknown-linux-gnu-install_only.tar.gz",
+          "checksum": "303047011b2c9f58504a930fc974d84547477cf69a3f2962f25552e2395c13af",
+          "size": 44135353
         },
         {
           "action": "extract",
           "params": {
-            "archive": "cpython-3.10.19+20260203-aarch64-apple-darwin-install_only.tar.gz",
+            "archive": "cpython-3.10.20+20260414-x86_64-unknown-linux-gnu-install_only.tar.gz",
             "format": "tar.gz",
             "strip_dirs": 1
           },

--- a/testdata/golden/plans/embedded/meson/v1.9.2-linux-debian-amd64.json
+++ b/testdata/golden/plans/embedded/meson/v1.9.2-linux-debian-amd64.json
@@ -3,33 +3,34 @@
   "tool": "meson",
   "version": "1.9.2",
   "platform": {
-    "os": "darwin",
-    "arch": "arm64"
+    "os": "linux",
+    "arch": "amd64",
+    "linux_family": "debian"
   },
   "deterministic": false,
   "dependencies": [
     {
       "tool": "python-standalone",
-      "version": "20260203",
+      "version": "20260414",
       "steps": [
         {
           "action": "download_file",
           "params": {
-            "checksum": "f2cd9caf1f04d59c620aeb3183ec78f880024a0e9246d2bd2fb59cc4bfedac21",
+            "checksum": "303047011b2c9f58504a930fc974d84547477cf69a3f2962f25552e2395c13af",
             "checksum_algo": "sha256",
-            "dest": "cpython-3.10.19+20260203-aarch64-apple-darwin-install_only.tar.gz",
-            "url": "https://github.com/indygreg/python-build-standalone/releases/download/20260203/cpython-3.10.19+20260203-aarch64-apple-darwin-install_only.tar.gz"
+            "dest": "cpython-3.10.20+20260414-x86_64-unknown-linux-gnu-install_only.tar.gz",
+            "url": "https://github.com/indygreg/python-build-standalone/releases/download/20260414/cpython-3.10.20+20260414-x86_64-unknown-linux-gnu-install_only.tar.gz"
           },
           "evaluable": true,
           "deterministic": true,
-          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20260203/cpython-3.10.19+20260203-aarch64-apple-darwin-install_only.tar.gz",
-          "checksum": "f2cd9caf1f04d59c620aeb3183ec78f880024a0e9246d2bd2fb59cc4bfedac21",
-          "size": 19530228
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20260414/cpython-3.10.20+20260414-x86_64-unknown-linux-gnu-install_only.tar.gz",
+          "checksum": "303047011b2c9f58504a930fc974d84547477cf69a3f2962f25552e2395c13af",
+          "size": 44135353
         },
         {
           "action": "extract",
           "params": {
-            "archive": "cpython-3.10.19+20260203-aarch64-apple-darwin-install_only.tar.gz",
+            "archive": "cpython-3.10.20+20260414-x86_64-unknown-linux-gnu-install_only.tar.gz",
             "format": "tar.gz",
             "strip_dirs": 1
           },

--- a/testdata/golden/plans/embedded/meson/v1.9.2-linux-rhel-amd64.json
+++ b/testdata/golden/plans/embedded/meson/v1.9.2-linux-rhel-amd64.json
@@ -4,32 +4,33 @@
   "version": "1.9.2",
   "platform": {
     "os": "linux",
-    "arch": "amd64"
+    "arch": "amd64",
+    "linux_family": "rhel"
   },
   "deterministic": false,
   "dependencies": [
     {
       "tool": "python-standalone",
-      "version": "20260203",
+      "version": "20260414",
       "steps": [
         {
           "action": "download_file",
           "params": {
-            "checksum": "3397194408bd9afd3463a70313dc83d9d8abcf4beb37fc7335fa666a1501784c",
+            "checksum": "303047011b2c9f58504a930fc974d84547477cf69a3f2962f25552e2395c13af",
             "checksum_algo": "sha256",
-            "dest": "cpython-3.10.19+20260203-x86_64-unknown-linux-gnu-install_only.tar.gz",
-            "url": "https://github.com/indygreg/python-build-standalone/releases/download/20260203/cpython-3.10.19+20260203-x86_64-unknown-linux-gnu-install_only.tar.gz"
+            "dest": "cpython-3.10.20+20260414-x86_64-unknown-linux-gnu-install_only.tar.gz",
+            "url": "https://github.com/indygreg/python-build-standalone/releases/download/20260414/cpython-3.10.20+20260414-x86_64-unknown-linux-gnu-install_only.tar.gz"
           },
           "evaluable": true,
           "deterministic": true,
-          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20260203/cpython-3.10.19+20260203-x86_64-unknown-linux-gnu-install_only.tar.gz",
-          "checksum": "3397194408bd9afd3463a70313dc83d9d8abcf4beb37fc7335fa666a1501784c",
-          "size": 43880933
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20260414/cpython-3.10.20+20260414-x86_64-unknown-linux-gnu-install_only.tar.gz",
+          "checksum": "303047011b2c9f58504a930fc974d84547477cf69a3f2962f25552e2395c13af",
+          "size": 44135353
         },
         {
           "action": "extract",
           "params": {
-            "archive": "cpython-3.10.19+20260203-x86_64-unknown-linux-gnu-install_only.tar.gz",
+            "archive": "cpython-3.10.20+20260414-x86_64-unknown-linux-gnu-install_only.tar.gz",
             "format": "tar.gz",
             "strip_dirs": 1
           },
@@ -84,7 +85,6 @@
     }
   ],
   "verify": {
-    "command": "meson --version",
-    "pattern": "{version}"
+    "command": "meson --version"
   }
 }

--- a/testdata/golden/plans/embedded/meson/v1.9.2-linux-suse-amd64.json
+++ b/testdata/golden/plans/embedded/meson/v1.9.2-linux-suse-amd64.json
@@ -3,33 +3,34 @@
   "tool": "meson",
   "version": "1.9.2",
   "platform": {
-    "os": "darwin",
-    "arch": "arm64"
+    "os": "linux",
+    "arch": "amd64",
+    "linux_family": "suse"
   },
   "deterministic": false,
   "dependencies": [
     {
       "tool": "python-standalone",
-      "version": "20260203",
+      "version": "20260414",
       "steps": [
         {
           "action": "download_file",
           "params": {
-            "checksum": "f2cd9caf1f04d59c620aeb3183ec78f880024a0e9246d2bd2fb59cc4bfedac21",
+            "checksum": "303047011b2c9f58504a930fc974d84547477cf69a3f2962f25552e2395c13af",
             "checksum_algo": "sha256",
-            "dest": "cpython-3.10.19+20260203-aarch64-apple-darwin-install_only.tar.gz",
-            "url": "https://github.com/indygreg/python-build-standalone/releases/download/20260203/cpython-3.10.19+20260203-aarch64-apple-darwin-install_only.tar.gz"
+            "dest": "cpython-3.10.20+20260414-x86_64-unknown-linux-gnu-install_only.tar.gz",
+            "url": "https://github.com/indygreg/python-build-standalone/releases/download/20260414/cpython-3.10.20+20260414-x86_64-unknown-linux-gnu-install_only.tar.gz"
           },
           "evaluable": true,
           "deterministic": true,
-          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20260203/cpython-3.10.19+20260203-aarch64-apple-darwin-install_only.tar.gz",
-          "checksum": "f2cd9caf1f04d59c620aeb3183ec78f880024a0e9246d2bd2fb59cc4bfedac21",
-          "size": 19530228
+          "url": "https://github.com/indygreg/python-build-standalone/releases/download/20260414/cpython-3.10.20+20260414-x86_64-unknown-linux-gnu-install_only.tar.gz",
+          "checksum": "303047011b2c9f58504a930fc974d84547477cf69a3f2962f25552e2395c13af",
+          "size": 44135353
         },
         {
           "action": "extract",
           "params": {
-            "archive": "cpython-3.10.19+20260203-aarch64-apple-darwin-install_only.tar.gz",
+            "archive": "cpython-3.10.20+20260414-x86_64-unknown-linux-gnu-install_only.tar.gz",
             "format": "tar.gz",
             "strip_dirs": 1
           },

--- a/testdata/golden/plans/embedded/ruby/v4.0.0-darwin-amd64.json
+++ b/testdata/golden/plans/embedded/ruby/v4.0.0-darwin-amd64.json
@@ -123,7 +123,6 @@
     }
   ],
   "verify": {
-    "command": "ruby --version",
-    "pattern": "ruby {version}"
+    "command": "ruby --version"
   }
 }

--- a/testdata/golden/plans/embedded/ruby/v4.0.0-linux-alpine-amd64.json
+++ b/testdata/golden/plans/embedded/ruby/v4.0.0-linux-alpine-amd64.json
@@ -40,7 +40,6 @@
     }
   ],
   "verify": {
-    "command": "ruby --version",
-    "pattern": "ruby {version}"
+    "command": "ruby --version"
   }
 }

--- a/testdata/golden/plans/embedded/ruby/v4.0.0-linux-arch-amd64.json
+++ b/testdata/golden/plans/embedded/ruby/v4.0.0-linux-arch-amd64.json
@@ -177,7 +177,6 @@
     }
   ],
   "verify": {
-    "command": "ruby --version",
-    "pattern": "ruby {version}"
+    "command": "ruby --version"
   }
 }

--- a/testdata/golden/plans/embedded/ruby/v4.0.0-linux-debian-amd64.json
+++ b/testdata/golden/plans/embedded/ruby/v4.0.0-linux-debian-amd64.json
@@ -177,7 +177,6 @@
     }
   ],
   "verify": {
-    "command": "ruby --version",
-    "pattern": "ruby {version}"
+    "command": "ruby --version"
   }
 }

--- a/testdata/golden/plans/embedded/ruby/v4.0.0-linux-rhel-amd64.json
+++ b/testdata/golden/plans/embedded/ruby/v4.0.0-linux-rhel-amd64.json
@@ -177,7 +177,6 @@
     }
   ],
   "verify": {
-    "command": "ruby --version",
-    "pattern": "ruby {version}"
+    "command": "ruby --version"
   }
 }

--- a/testdata/golden/plans/embedded/ruby/v4.0.0-linux-suse-amd64.json
+++ b/testdata/golden/plans/embedded/ruby/v4.0.0-linux-suse-amd64.json
@@ -177,7 +177,6 @@
     }
   ],
   "verify": {
-    "command": "ruby --version",
-    "pattern": "ruby {version}"
+    "command": "ruby --version"
   }
 }

--- a/testdata/golden/plans/embedded/rust/v1.93.1-linux-alpine-amd64.json
+++ b/testdata/golden/plans/embedded/rust/v1.93.1-linux-alpine-amd64.json
@@ -4,7 +4,8 @@
   "version": "1.93.1",
   "platform": {
     "os": "linux",
-    "arch": "amd64"
+    "arch": "amd64",
+    "linux_family": "alpine"
   },
   "deterministic": false,
   "dependencies": [
@@ -30,6 +31,16 @@
     }
   ],
   "steps": [
+    {
+      "action": "apk_install",
+      "params": {
+        "packages": [
+          "libgcc"
+        ]
+      },
+      "evaluable": false,
+      "deterministic": false
+    },
     {
       "action": "download_file",
       "params": {

--- a/testdata/golden/plans/embedded/rust/v1.93.1-linux-arch-amd64.json
+++ b/testdata/golden/plans/embedded/rust/v1.93.1-linux-arch-amd64.json
@@ -4,7 +4,8 @@
   "version": "1.93.1",
   "platform": {
     "os": "linux",
-    "arch": "amd64"
+    "arch": "amd64",
+    "linux_family": "arch"
   },
   "deterministic": false,
   "steps": [

--- a/testdata/golden/plans/embedded/rust/v1.93.1-linux-debian-amd64.json
+++ b/testdata/golden/plans/embedded/rust/v1.93.1-linux-debian-amd64.json
@@ -4,7 +4,8 @@
   "version": "1.93.1",
   "platform": {
     "os": "linux",
-    "arch": "amd64"
+    "arch": "amd64",
+    "linux_family": "debian"
   },
   "deterministic": false,
   "steps": [

--- a/testdata/golden/plans/embedded/rust/v1.93.1-linux-rhel-amd64.json
+++ b/testdata/golden/plans/embedded/rust/v1.93.1-linux-rhel-amd64.json
@@ -4,7 +4,8 @@
   "version": "1.93.1",
   "platform": {
     "os": "linux",
-    "arch": "amd64"
+    "arch": "amd64",
+    "linux_family": "rhel"
   },
   "deterministic": false,
   "steps": [

--- a/testdata/golden/plans/embedded/rust/v1.93.1-linux-suse-amd64.json
+++ b/testdata/golden/plans/embedded/rust/v1.93.1-linux-suse-amd64.json
@@ -4,7 +4,8 @@
   "version": "1.93.1",
   "platform": {
     "os": "linux",
-    "arch": "amd64"
+    "arch": "amd64",
+    "linux_family": "suse"
   },
   "deterministic": false,
   "steps": [


### PR DESCRIPTION
Implements `docs/designs/DESIGN-prerelease-detection.md`. Replace the substring-keyword `isStableVersion` filter in `internal/version/provider_github.go` with a two-layered check: a SemVer-aware layer that uses the existing `splitPrerelease` helper plus an opt-in `stable_qualifiers` set for the JVM-ecosystem `RELEASE/FINAL/LTS/GA/stable` conventions, and a non-SemVer fallback layer that preserves the historical substring filter for upstreams that splice prerelease markers into the version without a hyphen (e.g., jq's `1.8.2rc1`). Add `DefaultStableQualifiers = ["release", "final", "lts", "ga", "stable"]` and a `[version] stable_qualifiers` recipe field for exotic upstreams (replace, not append). Thread the field through `NewGitHubProvider`, `NewGitHubProviderWithPrefix`, the Fossil providers, and the matching strategies in `provider_factory.go`. Add table-driven tests in `internal/version/provider_github_test.go`.

The design doc moves from Proposed to Planned; the PLAN entry for #2325 is marked done with a description of the implementation. The audit step in the design's Implementation Approach section captures the jq finding that drove the non-SemVer fallback layer.

---

## What This Accomplishes

Closes #2325. Unblocks gradle and sbt recipe authoring (both deferred from #2295) — `tsuku eval` against gradle now resolves to `9.5.0` instead of `9.6.0-M1`, and sbt resolves to `1.12.10` instead of `2.0.0-M5`. No regressions: every curated recipe with `tag_prefix` resolves to the same version it did before this change.

## Reviewer Notes

- Audit was run against all 24 curated recipes that use `tag_prefix`. One required attention: jq's tag scheme (`jq-1.8.2rc1`) is non-SemVer-compliant — there is no hyphen between the version and the `rc` marker. The strict-SemVer-only design would have admitted that as stable; the non-SemVer fallback layer is the implementation refinement that handles this case. The design doc's Solution Architecture and Implementation Approach were updated to document the two-layered shape and the audit finding.
- The `nonSemverUnstableMarkers` list (`alpha`, `beta`, `rc`, `preview`, `snapshot`, `nightly`, `dev`) is the same content as the old keyword list minus `dev`. It only fires when the version has no hyphen at all, so it cannot regress hyphenated SemVer prereleases.
- Default qualifier list contents are at `internal/version/provider_github.go:13`.
- Recipe authors of new tools usually do nothing; they only need `stable_qualifiers` when the upstream uses an exotic qualifier outside the default set.

## Test Plan

- [x] New table-driven tests in `internal/version/provider_github_test.go` cover plain semver, SemVer prereleases, milestone tags, default qualifiers, recipe overrides, build metadata, and non-SemVer markers.
- [x] `go test ./...` passes (full suite).
- [x] `tsuku eval --recipe <gradle-test>.toml` returns 9.5.0 (not 9.6.0-M1).
- [x] `tsuku eval --recipe <sbt-test>.toml` returns 1.12.10 (not 2.0.0-M5).
- [x] All 24 curated recipes with `tag_prefix` continue to resolve to plain semver versions matching their main-branch behavior.

Closes #2325