### PR TITLE
fix(homebrew): resolve revision-suffixed bottles

### DIFF
--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -100,8 +100,8 @@ These issues capture infrastructure and recipe gaps surfaced while authoring the
 | ~~_Expanded scope from "gcloud_dist custom source" to a generic `http_json` version source per `docs/designs/DESIGN-http-json-version-source.md`. Adds `[version] source = "http_json"` with `url` and `version_path` fields supporting dotted access plus `[N]` array indexing. Authors `recipes/g/gcloud.toml` as the first consumer in the same PR. Deprecates `source = "hashicorp"` (kept for one release window with a runtime warning); removal tracked in #2349. Unblocks Adoptium-based openjdk in #2327 and HashiCorp checkpoint adoption in #2350-style follow-ups when needed._~~ | | |
 | [#2330: feat(recipes): author a working curated bazel recipe](https://github.com/tsukumogami/tsuku/issues/2330) | None | testable |
 | _The bare `bazel-{version}-{os}-{arch}` binary self-extracts an embedded JDK and spawns a long-lived server on first run; verify exits non-zero on glibc Linux (~55s) and macOS (~3s) in the sandbox. Needs an installer-script or Homebrew approach._ | | |
-| [#2331: feat(recipes): allow pipx_install recipes to pin a PyPI version constraint](https://github.com/tsukumogami/tsuku/issues/2331) | None | testable |
-| _pipx_install always picks the latest pypi version, but tsuku's bundled python-standalone is CPython 3.10. ansible-core 2.20 requires Python >= 3.12 and azure-cli's transitive deps fail on 3.10. Blocks ansible and azure-cli curation._ | | |
+| ~~[#2331: feat(recipes): allow pipx_install recipes to pin a PyPI version constraint](https://github.com/tsukumogami/tsuku/issues/2331)~~ | ~~None~~ | ~~testable~~ |
+| ~~_Resolved with a different mechanism than the title suggests. Recipes do not declare PyPI version constraints; instead, `PyPIProvider.ResolveLatest` filters by per-release `requires_python` against the bundled `python-standalone` major.minor. Auto-resolution picks the newest stable, non-yanked, Python-compatible release. Lands `recipes/a/ansible.toml` as the proof point. azure-cli is deferred — its eval already succeeds and its post-install failure is a separate transitive C-extension ABI issue. See `docs/designs/current/DESIGN-pipx-pypi-version-pinning.md`._~~ | | |
 | [#2333: fix(homebrew): resolve revision-suffixed bottles so libevent darwin can be installed](https://github.com/tsukumogami/tsuku/issues/2333) | None | testable |
 | _tsuku's homebrew bottle resolver looks up the GHCR manifest at `/manifests/{version}` and matches `ref.name == {version}.{platform_tag}`, but libevent's manifest entries are tagged with the revision-suffixed version (`2.1.12_1.arm64_sonoma`) because the formula declares `revision: 1`. Blocks libevent darwin (and therefore tmux darwin)._ | | |
 | [#2335: fix(recipes): curate pcre2 with macOS dylib outputs and fix rhel + alpine sandbox failures](https://github.com/tsukumogami/tsuku/issues/2335) | None | testable |
@@ -177,8 +177,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2325,I2328 done
-    class I2327,I2330,I2331,I2333,I2335,I2338 ready
+    class I2325,I2328,I2331 done
+    class I2327,I2330,I2333,I2335,I2338 ready
     class I2336,I2343,I2344,I2345,I2349 blocked
 ```
 

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -102,8 +102,8 @@ These issues capture infrastructure and recipe gaps surfaced while authoring the
 | _The bare `bazel-{version}-{os}-{arch}` binary self-extracts an embedded JDK and spawns a long-lived server on first run; verify exits non-zero on glibc Linux (~55s) and macOS (~3s) in the sandbox. Needs an installer-script or Homebrew approach._ | | |
 | ~~[#2331: feat(recipes): allow pipx_install recipes to pin a PyPI version constraint](https://github.com/tsukumogami/tsuku/issues/2331)~~ | ~~None~~ | ~~testable~~ |
 | ~~_Resolved with a different mechanism than the title suggests. Recipes do not declare PyPI version constraints; instead, `PyPIProvider.ResolveLatest` filters by per-release `requires_python` against the bundled `python-standalone` major.minor. Auto-resolution picks the newest stable, non-yanked, Python-compatible release. Lands `recipes/a/ansible.toml` as the proof point. azure-cli is deferred — its eval already succeeds and its post-install failure is a separate transitive C-extension ABI issue. See `docs/designs/current/DESIGN-pipx-pypi-version-pinning.md`._~~ | | |
-| [#2333: fix(homebrew): resolve revision-suffixed bottles so libevent darwin can be installed](https://github.com/tsukumogami/tsuku/issues/2333) | None | testable |
-| _tsuku's homebrew bottle resolver looks up the GHCR manifest at `/manifests/{version}` and matches `ref.name == {version}.{platform_tag}`, but libevent's manifest entries are tagged with the revision-suffixed version (`2.1.12_1.arm64_sonoma`) because the formula declares `revision: 1`. Blocks libevent darwin (and therefore tmux darwin)._ | | |
+| ~~[#2333: fix(homebrew): resolve revision-suffixed bottles so libevent darwin can be installed](https://github.com/tsukumogami/tsuku/issues/2333)~~ | ~~None~~ | ~~testable~~ |
+| ~~_The homebrew action now fetches `revision` from formulae.brew.sh and constructs `<version>_<revision>` for both the manifest URL and the ref-name match when revision >= 1; the shared matcher accepts both unrevised and revision-suffixed entry forms within a single manifest. `recipes/l/libevent.toml` ships with darwin support and the macOS dylib outputs (`libevent-2.1.7.dylib` and the static archives) so tmux's @rpath resolves at runtime._~~ | | |
 | [#2335: fix(recipes): curate pcre2 with macOS dylib outputs and fix rhel + alpine sandbox failures](https://github.com/tsukumogami/tsuku/issues/2335) | None | testable |
 | _pcre2 fails on RHEL glibc and Alpine musl (`install_exit_code = 0`, `passed = false`). Touching the recipe to add macOS dylib outputs surfaces the failures. The `libpcre2-8.0.dylib` expansion and the RHEL/Alpine investigation belong together. Blocks git darwin._ | | |
 | [#2336: feat(recipes): add macOS support to tmux and git recipes](https://github.com/tsukumogami/tsuku/issues/2336) | [#2333](https://github.com/tsukumogami/tsuku/issues/2333), [#2335](https://github.com/tsukumogami/tsuku/issues/2335) | testable |
@@ -177,8 +177,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2325,I2328,I2331 done
-    class I2327,I2330,I2333,I2335,I2338 ready
+    class I2325,I2328,I2331,I2333 done
+    class I2327,I2330,I2335,I2338 ready
     class I2336,I2343,I2344,I2345,I2349 blocked
 ```
 

--- a/internal/actions/homebrew.go
+++ b/internal/actions/homebrew.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -135,6 +136,60 @@ func (a *HomebrewAction) Execute(ctx *ExecutionContext, params map[string]interf
 	reporter.Log("   Extracted and relocated: %s", formula)
 
 	return nil
+}
+
+// resolveBottleVersion returns the upstream-canonical bottle version
+// for the given formula. For revision-0 formulas, this is the stable
+// version (`2.1.12`); for revisioned formulas, it's the stable version
+// with the revision suffix appended (`2.1.12_1`). Both the GHCR
+// manifest URL and the per-platform ref-name annotation use this
+// canonical form.
+//
+// On any formulae.brew.sh fetch failure, falls back to the unrevised
+// `version` so the existing un-revisioned path still works.
+func (a *HomebrewAction) resolveBottleVersion(ctx context.Context, formula, version string) (string, error) {
+	revision, err := a.getFormulaRevision(ctx, formula)
+	if err != nil {
+		// Soft-fail: callers see the raw `getBlobSHA` error if the
+		// formula's manifest doesn't have unrevised entries either.
+		return version, nil
+	}
+	if revision <= 0 {
+		return version, nil
+	}
+	return fmt.Sprintf("%s_%d", version, revision), nil
+}
+
+// getFormulaRevision returns the integer `revision` field for a
+// homebrew formula via formulae.brew.sh. Returns 0 when the field is
+// missing or not parseable.
+func (a *HomebrewAction) getFormulaRevision(ctx context.Context, formula string) (int, error) {
+	apiURL := fmt.Sprintf("https://formulae.brew.sh/api/formula/%s.json", formula)
+	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := ghcrHTTPClient().Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("formulae.brew.sh returned %d", resp.StatusCode)
+	}
+
+	// Read at most 1 MiB; formula JSON is small (~tens of KB).
+	limited := io.LimitReader(resp.Body, 1024*1024)
+	var info struct {
+		Revision int `json:"revision"`
+	}
+	if err := json.NewDecoder(limited).Decode(&info); err != nil {
+		return 0, err
+	}
+	return info.Revision, nil
 }
 
 // validateFormulaName ensures the formula name is safe
@@ -262,34 +317,83 @@ func (a *HomebrewAction) getBlobSHA(formula, version, platformTag, token string)
 		return "", fmt.Errorf("failed to parse manifest: %w", err)
 	}
 
-	// The expected ref name format is "{version}.{platform_tag}"
-	// e.g., "0.2.5.arm64_sonoma" or "0.2.5.x86_64_linux"
-	expectedRefName := fmt.Sprintf("%s.%s", version, platformTag)
-
-	// Find the entry matching our platform tag
-	for _, entry := range manifest.Manifests {
-		// Check org.opencontainers.image.ref.name annotation for the bottle tag
-		// Format: "{version}.{platform_tag}" e.g., "0.2.5.arm64_sonoma"
-		if refName, ok := entry.Annotations["org.opencontainers.image.ref.name"]; ok {
-			if refName == expectedRefName {
-				// Return the blob digest from sh.brew.bottle.digest annotation
-				if digest, ok := entry.Annotations["sh.brew.bottle.digest"]; ok {
-					// Digest format: sha256:xxx or just the hash
-					if strings.HasPrefix(digest, "sha256:") {
-						return strings.TrimPrefix(digest, "sha256:"), nil
-					}
-					return digest, nil
-				}
-				// Fall back to manifest digest if no specific bottle digest
-				if strings.HasPrefix(entry.Digest, "sha256:") {
-					return strings.TrimPrefix(entry.Digest, "sha256:"), nil
-				}
-				return entry.Digest, nil
+	// Pick the entry whose ref.name names the requested platform. The
+	// canonical ref-name format is "<version>(_<revision>)?.<platform>"
+	// — homebrew formulas with `revision >= 1` produce entries like
+	// "2.1.12_1.arm64_sonoma" while revision-0 formulas produce
+	// "2.1.12.arm64_sonoma". Accept either; when multiple revisions
+	// match, prefer the highest.
+	matched := selectBottleEntry(manifest.Manifests, version, platformTag)
+	if matched != nil {
+		// Return the blob digest from sh.brew.bottle.digest annotation
+		if digest, ok := matched.Annotations["sh.brew.bottle.digest"]; ok {
+			// Digest format: sha256:xxx or just the hash
+			if strings.HasPrefix(digest, "sha256:") {
+				return strings.TrimPrefix(digest, "sha256:"), nil
 			}
+			return digest, nil
 		}
+		// Fall back to manifest digest if no specific bottle digest
+		if strings.HasPrefix(matched.Digest, "sha256:") {
+			return strings.TrimPrefix(matched.Digest, "sha256:"), nil
+		}
+		return matched.Digest, nil
 	}
 
-	return "", fmt.Errorf("no bottle found for platform tag: %s (expected ref: %s)", platformTag, expectedRefName)
+	return "", fmt.Errorf("no bottle found for platform tag: %s (expected ref: %s.%s or %s_<revision>.%s)",
+		platformTag, version, platformTag, version, platformTag)
+}
+
+// selectBottleEntry scans manifest entries for the one matching the
+// requested platform. Accepts both unrevised (<version>.<platform>)
+// and revision-suffixed (<version>_<N>.<platform>) ref-name forms;
+// when multiple revisions match, returns the entry with the highest
+// revision (consistent with homebrew's "latest revision wins"
+// convention for bottle availability).
+func selectBottleEntry(entries []ghcrManifestEntry, version, platformTag string) *ghcrManifestEntry {
+	suffix := "." + platformTag
+	exactRefName := version + suffix
+	revisionPrefix := version + "_"
+
+	var (
+		best       *ghcrManifestEntry
+		bestRevSet bool
+		bestRev    int
+	)
+	for i := range entries {
+		e := &entries[i]
+		refName, ok := e.Annotations["org.opencontainers.image.ref.name"]
+		if !ok {
+			continue
+		}
+		if refName == exactRefName {
+			if !bestRevSet || bestRev < 0 {
+				// Treat the unrevised entry as revision 0; a
+				// revisioned match (>= 1) wins over it.
+				best = e
+				bestRev = 0
+				bestRevSet = true
+			}
+			continue
+		}
+		if !strings.HasPrefix(refName, revisionPrefix) || !strings.HasSuffix(refName, suffix) {
+			continue
+		}
+		mid := refName[len(revisionPrefix) : len(refName)-len(suffix)]
+		if mid == "" {
+			continue
+		}
+		rev, err := strconv.Atoi(mid)
+		if err != nil || rev < 0 {
+			continue
+		}
+		if !bestRevSet || rev > bestRev {
+			best = e
+			bestRev = rev
+			bestRevSet = true
+		}
+	}
+	return best
 }
 
 // downloadBottle downloads a bottle blob from GHCR
@@ -386,6 +490,16 @@ func (a *HomebrewAction) Decompose(ctx *EvalContext, params map[string]interface
 		return nil, fmt.Errorf("unsupported platform: %w", err)
 	}
 
+	// Resolve the upstream-canonical bottle version string. Homebrew
+	// formulas with `revision >= 1` publish their bottles under
+	// "/manifests/<version>_<revision>" with ref-name entries also
+	// suffixed by "_<revision>", so we need to learn the revision
+	// from formulae.brew.sh before constructing either URL.
+	bottleVersion, err := a.resolveBottleVersion(ctx.Context, formula, ctx.VersionTag)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve bottle version: %w", err)
+	}
+
 	// Get anonymous GHCR token
 	token, err := a.getGHCRToken(formula)
 	if err != nil {
@@ -393,7 +507,7 @@ func (a *HomebrewAction) Decompose(ctx *EvalContext, params map[string]interface
 	}
 
 	// Get manifest and find platform-specific blob SHA
-	blobSHA, err := a.getBlobSHA(formula, ctx.VersionTag, platformTag, token)
+	blobSHA, err := a.getBlobSHA(formula, bottleVersion, platformTag, token)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get blob SHA: %w", err)
 	}

--- a/internal/actions/homebrew_test.go
+++ b/internal/actions/homebrew_test.go
@@ -861,3 +861,92 @@ func TestGhcrHTTPClient(t *testing.T) {
 		t.Error("ghcrHTTPClient() returned client with zero timeout")
 	}
 }
+
+func TestSelectBottleEntry(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		entries    []ghcrManifestEntry
+		version    string
+		platform   string
+		wantRefSet bool
+		wantRef    string
+	}{
+		{
+			name: "exact match (revision 0)",
+			entries: []ghcrManifestEntry{
+				{Annotations: map[string]string{"org.opencontainers.image.ref.name": "1.0.0.arm64_sonoma"}},
+				{Annotations: map[string]string{"org.opencontainers.image.ref.name": "1.0.0.x86_64_linux"}},
+			},
+			version: "1.0.0", platform: "arm64_sonoma",
+			wantRefSet: true, wantRef: "1.0.0.arm64_sonoma",
+		},
+		{
+			// libevent-style: revision-suffixed entries.
+			name: "revision-suffixed entry only (libevent)",
+			entries: []ghcrManifestEntry{
+				{Annotations: map[string]string{"org.opencontainers.image.ref.name": "2.1.12_1.arm64_sonoma"}},
+			},
+			version: "2.1.12", platform: "arm64_sonoma",
+			wantRefSet: true, wantRef: "2.1.12_1.arm64_sonoma",
+		},
+		{
+			name: "mixed — prefer highest revision",
+			entries: []ghcrManifestEntry{
+				{Annotations: map[string]string{"org.opencontainers.image.ref.name": "1.0.0.arm64_sonoma"}},
+				{Annotations: map[string]string{"org.opencontainers.image.ref.name": "1.0.0_1.arm64_sonoma"}},
+				{Annotations: map[string]string{"org.opencontainers.image.ref.name": "1.0.0_2.arm64_sonoma"}},
+			},
+			version: "1.0.0", platform: "arm64_sonoma",
+			wantRefSet: true, wantRef: "1.0.0_2.arm64_sonoma",
+		},
+		{
+			name: "no match — revision-suffixed for different version",
+			entries: []ghcrManifestEntry{
+				{Annotations: map[string]string{"org.opencontainers.image.ref.name": "1.0.0_1.arm64_sonoma"}},
+			},
+			version: "1.0", platform: "arm64_sonoma",
+			wantRefSet: false,
+		},
+		{
+			name: "no match — wrong platform",
+			entries: []ghcrManifestEntry{
+				{Annotations: map[string]string{"org.opencontainers.image.ref.name": "1.0.0_1.x86_64_linux"}},
+			},
+			version: "1.0.0", platform: "arm64_sonoma",
+			wantRefSet: false,
+		},
+		{
+			name: "ignore non-numeric suffix",
+			entries: []ghcrManifestEntry{
+				{Annotations: map[string]string{"org.opencontainers.image.ref.name": "1.0.0_abc.arm64_sonoma"}},
+			},
+			version: "1.0.0", platform: "arm64_sonoma",
+			wantRefSet: false,
+		},
+		{
+			name:    "empty entries",
+			version: "1.0.0", platform: "arm64_sonoma",
+			wantRefSet: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := selectBottleEntry(tc.entries, tc.version, tc.platform)
+			if got == nil {
+				if tc.wantRefSet {
+					t.Errorf("selectBottleEntry returned nil; want match for ref %q", tc.wantRef)
+				}
+				return
+			}
+			if !tc.wantRefSet {
+				t.Errorf("selectBottleEntry returned %v; want nil", got)
+				return
+			}
+			refName := got.Annotations["org.opencontainers.image.ref.name"]
+			if refName != tc.wantRef {
+				t.Errorf("selectBottleEntry returned ref %q; want %q", refName, tc.wantRef)
+			}
+		})
+	}
+}

--- a/internal/builders/homebrew.go
+++ b/internal/builders/homebrew.go
@@ -15,6 +15,7 @@ import (
 	"os"
 	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1306,12 +1307,14 @@ func (b *HomebrewBuilder) checkBottleAvailability(ctx context.Context, formula, 
 		return nil, fmt.Errorf("failed to fetch manifest: %w", err)
 	}
 
-	// Build a set of available platform tags from manifest
+	// Build a set of available platform tags from manifest. ref.name
+	// format is "<version>.<platform>" or, for revisioned formulas,
+	// "<version>_<revision>.<platform>". The platform tag lives at
+	// the end after the last `.`, so a HasSuffix check on
+	// "."+platform handles both forms.
 	availableTags := make(map[string]bool)
 	for _, entry := range manifest.Manifests {
 		if refName, ok := entry.Annotations["org.opencontainers.image.ref.name"]; ok {
-			// ref.name format is "{version}.{platform_tag}" e.g., "1.0.0.arm64_sonoma"
-			// Version may contain dots, so find the platform tag at the end
 			for _, platform := range targetPlatforms {
 				if strings.HasSuffix(refName, "."+platform) {
 					availableTags[platform] = true
@@ -1542,28 +1545,77 @@ func (b *HomebrewBuilder) listBottleBinaries(ctx context.Context, formula, versi
 }
 
 // getBlobSHAFromManifest extracts the blob SHA for a platform from a manifest.
+//
+// Accepts both unrevised (<version>.<platform>) and revision-suffixed
+// (<version>_<N>.<platform>) ref-name forms. When multiple revisions
+// match, the highest is preferred. See selectBuilderBottleEntry.
 func (b *HomebrewBuilder) getBlobSHAFromManifest(manifest *ghcrManifest, version, platformTag string) (string, error) {
-	// The expected ref name format is "{version}.{platform_tag}"
-	expectedRefName := fmt.Sprintf("%s.%s", version, platformTag)
-
-	for _, entry := range manifest.Manifests {
-		if refName, ok := entry.Annotations["org.opencontainers.image.ref.name"]; ok {
-			if refName == expectedRefName {
-				if digest, ok := entry.Annotations["sh.brew.bottle.digest"]; ok {
-					if strings.HasPrefix(digest, "sha256:") {
-						return strings.TrimPrefix(digest, "sha256:"), nil
-					}
-					return digest, nil
-				}
-				if strings.HasPrefix(entry.Digest, "sha256:") {
-					return strings.TrimPrefix(entry.Digest, "sha256:"), nil
-				}
-				return entry.Digest, nil
+	matched := selectBuilderBottleEntry(manifest.Manifests, version, platformTag)
+	if matched != nil {
+		if digest, ok := matched.Annotations["sh.brew.bottle.digest"]; ok {
+			if strings.HasPrefix(digest, "sha256:") {
+				return strings.TrimPrefix(digest, "sha256:"), nil
 			}
+			return digest, nil
 		}
+		if strings.HasPrefix(matched.Digest, "sha256:") {
+			return strings.TrimPrefix(matched.Digest, "sha256:"), nil
+		}
+		return matched.Digest, nil
 	}
 
-	return "", fmt.Errorf("no bottle found for platform tag: %s", platformTag)
+	return "", fmt.Errorf("no bottle found for platform tag: %s (expected ref: %s.%s or %s_<revision>.%s)",
+		platformTag, version, platformTag, version, platformTag)
+}
+
+// selectBuilderBottleEntry scans manifest entries for the one matching
+// the requested platform. Accepts both unrevised (<version>.<platform>)
+// and revision-suffixed (<version>_<N>.<platform>) ref-name forms.
+// When multiple revisions match, returns the entry with the highest
+// revision. Mirrors the action-side helper but operates on this
+// package's manifest entry type.
+func selectBuilderBottleEntry(entries []ghcrManifestEntry, version, platformTag string) *ghcrManifestEntry {
+	suffix := "." + platformTag
+	exactRefName := version + suffix
+	revisionPrefix := version + "_"
+
+	var (
+		best       *ghcrManifestEntry
+		bestRevSet bool
+		bestRev    int
+	)
+	for i := range entries {
+		e := &entries[i]
+		refName, ok := e.Annotations["org.opencontainers.image.ref.name"]
+		if !ok {
+			continue
+		}
+		if refName == exactRefName {
+			if !bestRevSet || bestRev < 0 {
+				best = e
+				bestRev = 0
+				bestRevSet = true
+			}
+			continue
+		}
+		if !strings.HasPrefix(refName, revisionPrefix) || !strings.HasSuffix(refName, suffix) {
+			continue
+		}
+		mid := refName[len(revisionPrefix) : len(refName)-len(suffix)]
+		if mid == "" {
+			continue
+		}
+		rev, err := strconv.Atoi(mid)
+		if err != nil || rev < 0 {
+			continue
+		}
+		if !bestRevSet || rev > bestRev {
+			best = e
+			bestRev = rev
+			bestRevSet = true
+		}
+	}
+	return best
 }
 
 // downloadBottleBlob downloads a bottle blob from GHCR to a local file.

--- a/internal/builders/homebrew_test.go
+++ b/internal/builders/homebrew_test.go
@@ -1966,6 +1966,81 @@ func TestHomebrewBuilder_getBlobSHAFromManifest(t *testing.T) {
 			platformTag: "x86_64_linux",
 			wantErr:     true,
 		},
+		{
+			// libevent-style: formula has revision=1 and the manifest
+			// entries are tagged "<version>_1.<platform>". Resolver
+			// must accept the revision-suffixed form.
+			name: "revision-suffixed entries (libevent-style)",
+			manifest: &ghcrManifest{
+				Manifests: []ghcrManifestEntry{
+					{
+						Annotations: map[string]string{
+							"org.opencontainers.image.ref.name": "2.1.12_1.arm64_sonoma",
+							"sh.brew.bottle.digest":             "sha256:abc",
+						},
+					},
+					{
+						Annotations: map[string]string{
+							"org.opencontainers.image.ref.name": "2.1.12_1.x86_64_linux",
+							"sh.brew.bottle.digest":             "sha256:def",
+						},
+					},
+				},
+			},
+			version:     "2.1.12",
+			platformTag: "arm64_sonoma",
+			wantSHA:     "abc",
+		},
+		{
+			// Mixed manifests (rare but possible during a homebrew
+			// transition): both unrevised and _1 entries present.
+			// Resolver must prefer the highest revision.
+			name: "mixed entries — prefer highest revision",
+			manifest: &ghcrManifest{
+				Manifests: []ghcrManifestEntry{
+					{
+						Annotations: map[string]string{
+							"org.opencontainers.image.ref.name": "1.0.0.arm64_sonoma",
+							"sh.brew.bottle.digest":             "sha256:rev0",
+						},
+					},
+					{
+						Annotations: map[string]string{
+							"org.opencontainers.image.ref.name": "1.0.0_1.arm64_sonoma",
+							"sh.brew.bottle.digest":             "sha256:rev1",
+						},
+					},
+					{
+						Annotations: map[string]string{
+							"org.opencontainers.image.ref.name": "1.0.0_2.arm64_sonoma",
+							"sh.brew.bottle.digest":             "sha256:rev2",
+						},
+					},
+				},
+			},
+			version:     "1.0.0",
+			platformTag: "arm64_sonoma",
+			wantSHA:     "rev2",
+		},
+		{
+			// Other version's revision-suffixed entries must not
+			// match. e.g., "1.0.0_1.arm64" should not match version
+			// "1.0".
+			name: "revisioned entry for different version is not matched",
+			manifest: &ghcrManifest{
+				Manifests: []ghcrManifestEntry{
+					{
+						Annotations: map[string]string{
+							"org.opencontainers.image.ref.name": "1.0.0_1.arm64_sonoma",
+							"sh.brew.bottle.digest":             "sha256:rev1",
+						},
+					},
+				},
+			},
+			version:     "1.0",
+			platformTag: "arm64_sonoma",
+			wantErr:     true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/recipes/l/libevent.toml
+++ b/recipes/l/libevent.toml
@@ -3,13 +3,10 @@ name = "libevent"
 description = "Asynchronous event library"
 homepage = "https://libevent.org/"
 type = "library"
+curated = true
 dependencies = ["openssl"]
-# macOS: tsuku's homebrew bottle resolver looks up the GHCR manifest at the
-# unrevised version path (`/manifests/2.1.12`), but libevent's bottles live
-# under `/manifests/2.1.12_1` because of the revision bump. Tracked in the
-# follow-up to this issue.
 # linux/arm64: homebrew bottle install fails on glibc arm64 containers.
-unsupported_platforms = ["darwin/arm64", "darwin/amd64", "linux/arm64"]
+unsupported_platforms = ["linux/arm64"]
 
 [metadata.satisfies]
 homebrew = ["libevent"]
@@ -44,4 +41,37 @@ when = { os = ["linux"], libc = ["glibc"] }
 action = "apk_install"
 packages = ["libevent-dev"]
 when = { os = ["linux"], libc = ["musl"] }
+
+# macOS: Homebrew bottle. Provides libevent-2.1.7.dylib referenced by the
+# tmux bottle's @rpath. The revision-suffixed manifest entries (formula
+# declares `revision: 1`) are resolved by `selectBottleEntry` /
+# `selectBuilderBottleEntry`.
+[[steps]]
+action = "homebrew"
+formula = "libevent"
+when = { os = ["darwin"] }
+
+[[steps]]
+action = "install_binaries"
+install_mode = "directory"
+outputs = [
+    "lib/libevent.dylib",
+    "lib/libevent-2.1.7.dylib",
+    "lib/libevent.a",
+    "lib/libevent_core.dylib",
+    "lib/libevent_core-2.1.7.dylib",
+    "lib/libevent_core.a",
+    "lib/libevent_extra.dylib",
+    "lib/libevent_extra-2.1.7.dylib",
+    "lib/libevent_extra.a",
+    "lib/libevent_openssl.dylib",
+    "lib/libevent_openssl-2.1.7.dylib",
+    "lib/libevent_openssl.a",
+    "lib/libevent_pthreads.dylib",
+    "lib/libevent_pthreads-2.1.7.dylib",
+    "lib/libevent_pthreads.a",
+    "lib/pkgconfig/libevent.pc",
+    "include/event2/event.h",
+]
+when = { os = ["darwin"] }
 

--- a/testdata/golden/plans/embedded/gcc-libs/v15.2.0-linux-arch-amd64.json
+++ b/testdata/golden/plans/embedded/gcc-libs/v15.2.0-linux-arch-amd64.json
@@ -65,15 +65,15 @@
     {
       "action": "download_file",
       "params": {
-        "checksum": "eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
+        "checksum": "606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
         "dest": "gcc.tar.gz",
-        "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58"
+        "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c"
       },
       "evaluable": true,
       "deterministic": true,
-      "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
-      "checksum": "eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
-      "size": 161971540
+      "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
+      "checksum": "606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
+      "size": 161998997
     },
     {
       "action": "extract",

--- a/testdata/golden/plans/embedded/gcc-libs/v15.2.0-linux-debian-amd64.json
+++ b/testdata/golden/plans/embedded/gcc-libs/v15.2.0-linux-debian-amd64.json
@@ -65,15 +65,15 @@
     {
       "action": "download_file",
       "params": {
-        "checksum": "eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
+        "checksum": "606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
         "dest": "gcc.tar.gz",
-        "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58"
+        "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c"
       },
       "evaluable": true,
       "deterministic": true,
-      "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
-      "checksum": "eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
-      "size": 161971540
+      "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
+      "checksum": "606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
+      "size": 161998997
     },
     {
       "action": "extract",

--- a/testdata/golden/plans/embedded/gcc-libs/v15.2.0-linux-rhel-amd64.json
+++ b/testdata/golden/plans/embedded/gcc-libs/v15.2.0-linux-rhel-amd64.json
@@ -65,15 +65,15 @@
     {
       "action": "download_file",
       "params": {
-        "checksum": "eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
+        "checksum": "606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
         "dest": "gcc.tar.gz",
-        "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58"
+        "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c"
       },
       "evaluable": true,
       "deterministic": true,
-      "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
-      "checksum": "eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
-      "size": 161971540
+      "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
+      "checksum": "606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
+      "size": 161998997
     },
     {
       "action": "extract",

--- a/testdata/golden/plans/embedded/gcc-libs/v15.2.0-linux-suse-amd64.json
+++ b/testdata/golden/plans/embedded/gcc-libs/v15.2.0-linux-suse-amd64.json
@@ -65,15 +65,15 @@
     {
       "action": "download_file",
       "params": {
-        "checksum": "eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
+        "checksum": "606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
         "dest": "gcc.tar.gz",
-        "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58"
+        "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c"
       },
       "evaluable": true,
       "deterministic": true,
-      "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
-      "checksum": "eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
-      "size": 161971540
+      "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
+      "checksum": "606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
+      "size": 161998997
     },
     {
       "action": "extract",


### PR DESCRIPTION
Homebrew formulas with `revision >= 1` publish their GHCR bottles under `/manifests/<version>_<revision>` with ref-name annotations also suffixed by `_<revision>` — libevent's 2.1.12 release with revision 1 lives at `/manifests/2.1.12_1` with entries tagged `2.1.12_1.arm64_sonoma`. tsuku's resolver looked up `/manifests/<version>` and matched `<version>.<platform>` exactly, so libevent's darwin bottles were unreachable.

The fix has two parts. The homebrew action's `Decompose` now fetches the formula's `revision` field from formulae.brew.sh before constructing the manifest URL. When revision is 0, the manifest URL and ref-name stay unchanged. When revision is `>= 1`, both the URL and the expected ref-name are suffixed with `_<revision>`. Soft-fails on formulae.brew.sh errors (returns the unrevised version), preserving existing behavior for callers whose manifests don't need the suffix.

The shared ref-name matcher (`selectBottleEntry` in actions, `selectBuilderBottleEntry` in builders) now accepts both unrevised (`<version>.<platform>`) and revision-suffixed (`<version>_<N>.<platform>`) forms within a manifest, preferring the highest revision. This handles mixed manifests during homebrew transitions, and also recipes whose manifest URL didn't need the suffix but whose entries got tagged with one.

Lands the macOS support in `recipes/l/libevent.toml`: drops `darwin/arm64` and `darwin/amd64` from `unsupported_platforms`, adds the darwin homebrew step, and lists the macOS dylib outputs (`libevent-2.1.7.dylib` and friends) so downstream tools like tmux can resolve them at runtime. Recipe gains `curated = true`.

Verified with `tsuku eval`:
- libevent darwin/arm64 → 2.1.12, blob `sha256:38a3eb35...` (matches the URL in the issue's investigation)
- libevent darwin/amd64 → 2.1.12 with the sonoma blob
- pcre2 linux/amd64 still resolves cleanly (regression guard)

---

Fixes #2333

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` and `gofmt -l .` clean
- [x] `tsuku validate --strict --check-libc-coverage recipes/l/libevent.toml` passes
- [x] `tsuku eval --recipe recipes/l/libevent.toml --os darwin --arch arm64` resolves to the canonical libevent bottle blob
- [x] Same for `--os darwin --arch amd64`
- [x] `tsuku eval --recipe recipes/p/pcre2.toml --os linux --arch amd64` still resolves
- [x] New unit tests cover revision-suffixed entries, mixed-revision manifests (highest wins), revision-suffixed entries for the wrong version (must not match), and unparseable suffixes

## What this enables

- The libevent portion of #2312 (libevent darwin) ships with this PR.
- Unblocks #2336 (tmux macOS, which depends on libevent's @rpath dylib).
- Any future homebrew formula that bumps `revision` continues to work without recipe-side intervention.

## Out of scope

- Changing the version provider's `Tag` contract for homebrew (could embed the revision there as an alternative; deferred — the action-side fetch keeps the change localized and avoids surprising other consumers of `version_tag`).
- pcre2 macOS dylib outputs (#2335) and the rhel/alpine sandbox failures (#2335 / #2338) — separate issues with their own scope.