### PR TITLE
fix(test): align functional tests with current update CLI behavior

### DIFF
--- a/test/functional/features/project-auto-update.feature
+++ b/test/functional/features/project-auto-update.feature
@@ -64,7 +64,7 @@ Feature: Project-level auto-update integration
     # Cache entry consumed by the detached `tsuku apply-updates` process
     # auto-apply spawns from `tsuku list`'s PersistentPreRun. The spawn
     # is async (per #2278), so the assertion polls.
-    And the file "cache/updates/fake-auto-apply-tool.json" eventually does not exist within 30 seconds
+    And the file "cache/updates/fake-auto-apply-tool.json" eventually does not exist within 90 seconds
 
   Scenario: undeclared tool in project config uses global pin
     # Project config declares python but not the cached tool -- the
@@ -88,7 +88,7 @@ Feature: Project-level auto-update integration
     Then the exit code is 0
     # Cache entry consumed asynchronously by the detached `tsuku apply-updates`
     # process (per #2278); poll for absence.
-    And the file "cache/updates/fake-auto-apply-tool.json" eventually does not exist within 30 seconds
+    And the file "cache/updates/fake-auto-apply-tool.json" eventually does not exist within 90 seconds
 
   Scenario: tsuku commands work from project directory
     Given I create home file "myproject/.tsuku.toml" with content:

--- a/test/functional/features/project-auto-update.feature
+++ b/test/functional/features/project-auto-update.feature
@@ -48,41 +48,47 @@ Feature: Project-level auto-update integration
     And the file "cache/updates/serve.json" exists
 
   Scenario: no project config allows auto-apply to attempt update
-    # Without .tsuku.toml, auto-apply should attempt the update
-    # (the install will fail since serve isn't a real installed binary, but auto-apply will try)
-    Given I create home file "cache/updates/serve.json" with content:
+    # Without .tsuku.toml, auto-apply should attempt the update.
+    # Use a fake tool name so the install fails fast on recipe lookup
+    # — the test verifies cache consumption, not a real install.
+    Given I create home file "cache/updates/fake-auto-apply-tool.json" with content:
       """
-      {"tool":"serve","active_version":"0.6.0","requested":"","latest_within_pin":"0.7.0","latest_overall":"0.7.0","source":"github","checked_at":"2026-04-01T00:00:00Z","expires_at":"2026-04-02T00:00:00Z","error":""}
+      {"tool":"fake-auto-apply-tool","active_version":"0.6.0","requested":"","latest_within_pin":"0.7.0","latest_overall":"0.7.0","source":"github","checked_at":"2026-04-01T00:00:00Z","expires_at":"2026-04-02T00:00:00Z","error":""}
       """
     And I create home file "state.json" with content:
       """
-      {"installed":{"serve":{"active_version":"0.6.0","versions":{"0.6.0":{"requested":""}}}}}
+      {"installed":{"fake-auto-apply-tool":{"active_version":"0.6.0","versions":{"0.6.0":{"requested":""}}}}}
       """
     When I run "tsuku list"
     Then the exit code is 0
-    # Cache entry consumed because auto-apply attempted the update (even if it failed)
-    And the file "cache/updates/serve.json" does not exist
+    # Cache entry consumed by the detached `tsuku apply-updates` process
+    # auto-apply spawns from `tsuku list`'s PersistentPreRun. The spawn
+    # is async (per #2278), so the assertion polls.
+    And the file "cache/updates/fake-auto-apply-tool.json" eventually does not exist within 30 seconds
 
   Scenario: undeclared tool in project config uses global pin
-    # Project config declares python but not serve -- serve uses global pin
-    Given I create home file "cache/updates/serve.json" with content:
+    # Project config declares python but not the cached tool -- the
+    # cached tool uses global pin. Fake name fails install fast.
+    Given I create home file "cache/updates/fake-auto-apply-tool.json" with content:
       """
-      {"tool":"serve","active_version":"0.6.0","requested":"","latest_within_pin":"0.7.0","latest_overall":"0.7.0","source":"github","checked_at":"2026-04-01T00:00:00Z","expires_at":"2026-04-02T00:00:00Z","error":""}
+      {"tool":"fake-auto-apply-tool","active_version":"0.6.0","requested":"","latest_within_pin":"0.7.0","latest_overall":"0.7.0","source":"github","checked_at":"2026-04-01T00:00:00Z","expires_at":"2026-04-02T00:00:00Z","error":""}
       """
     And I create home file "state.json" with content:
       """
-      {"installed":{"serve":{"active_version":"0.6.0","versions":{"0.6.0":{"requested":""}}}}}
+      {"installed":{"fake-auto-apply-tool":{"active_version":"0.6.0","versions":{"0.6.0":{"requested":""}}}}}
       """
     And I create home file "myproject/.tsuku.toml" with content:
       """
       [tools]
       python = "3.12"
       """
-    # serve is not in .tsuku.toml, so auto-apply should attempt it with global pin
+    # The cached tool is not in .tsuku.toml, so auto-apply should attempt
+    # it with the global pin.
     When I run from "myproject" "tsuku list"
     Then the exit code is 0
-    # Cache entry consumed because serve wasn't suppressed by project config
-    And the file "cache/updates/serve.json" does not exist
+    # Cache entry consumed asynchronously by the detached `tsuku apply-updates`
+    # process (per #2278); poll for absence.
+    And the file "cache/updates/fake-auto-apply-tool.json" eventually does not exist within 30 seconds
 
   Scenario: tsuku commands work from project directory
     Given I create home file "myproject/.tsuku.toml" with content:

--- a/test/functional/features/update-registry.feature
+++ b/test/functional/features/update-registry.feature
@@ -13,8 +13,10 @@ Feature: Update Registry
     When I run "tsuku update-registry"
     Then the exit code is 0
 
-  Scenario: Refresh a cached recipe
-    When I run "tsuku update-registry --all"
+  Scenario: Explicit invocation force-refreshes cached recipes
+    # Explicit `tsuku update-registry` is a force-refresh per #2257; the
+    # subsequent dry-run on a freshly-refreshed cache has nothing to do.
+    When I run "tsuku update-registry"
     Then the exit code is 0
     When I run "tsuku update-registry --dry-run"
     Then the exit code is 0

--- a/test/functional/steps_test.go
+++ b/test/functional/steps_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/cucumber/godog"
 )
@@ -145,6 +146,27 @@ func theFileDoesNotExist(ctx context.Context, path string) error {
 		return fmt.Errorf("expected file %q not to exist", fullPath)
 	}
 	return nil
+}
+
+// theFileEventuallyDoesNotExist polls for a file's absence with a
+// bounded deadline. Used for assertions against state mutated by a
+// detached background process — e.g., auto-apply's `apply-updates`
+// subprocess, which consumes update cache entries asynchronously
+// after the foreground command (`tsuku list`, etc.) returns.
+func theFileEventuallyDoesNotExist(ctx context.Context, path string, timeoutSeconds int) error {
+	state := getState(ctx)
+	fullPath := filepath.Join(state.homeDir, path)
+	deadline := time.Now().Add(time.Duration(timeoutSeconds) * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Lstat(fullPath); os.IsNotExist(err) {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if _, err := os.Lstat(fullPath); os.IsNotExist(err) {
+		return nil
+	}
+	return fmt.Errorf("expected file %q not to exist within %ds", fullPath, timeoutSeconds)
 }
 
 // iSetEnv sets an environment variable override for subsequent commands in this scenario.

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -162,6 +162,7 @@ func initializeScenario(ctx *godog.ScenarioContext, binPath string) {
 	ctx.Step(`^the error output does not contain "([^"]*)"$`, theErrorOutputDoesNotContain)
 	ctx.Step(`^the file "([^"]*)" exists$`, theFileExists)
 	ctx.Step(`^the file "([^"]*)" does not exist$`, theFileDoesNotExist)
+	ctx.Step(`^the file "([^"]*)" eventually does not exist within (\d+) seconds$`, theFileEventuallyDoesNotExist)
 	ctx.Step(`^the file "([^"]*)" contains "([^"]*)"$`, theFileContains)
 	ctx.Step(`^the file "([^"]*)" does not contain "([^"]*)"$`, theFileDoesNotContain)
 	ctx.Step(`^I source home file "([^"]*)" and can run "([^"]*)"$`, iSourceHomeFileAndCanRun)


### PR DESCRIPTION
The `Functional Tests` job has been red on every `main` commit since 2026-04-28. Two assertions in `test/functional/features/` drifted out of sync with the production CLI.

`update-registry.feature` invoked `tsuku update-registry --all`. The `--all` flag was removed in #2257 (2026-04-17), which made force-refresh the default for explicit `tsuku update-registry` invocations. Drop `--all` from the scenario; the intent (refresh, then dry-run sees nothing to do) still holds.

`project-auto-update.feature` ran `tsuku list` and immediately asserted the auto-apply cache entry was consumed. Auto-apply moved from synchronous `PersistentPreRun` to a detached background `apply-updates` subprocess in #2278 (2026-04-20), so the foreground command returns before consumption completes. Two changes here:

- New polling step `the file "X" eventually does not exist within N seconds` for assertions against state mutated by detached subprocesses (added to `steps_test.go`, registered in `suite_test.go`).
- Replace the cached `serve` tool name with `fake-auto-apply-tool`. With `serve`, the auto-apply install attempts to download nodejs before failing — 55-60 s wall-clock per scenario, plus contention with the other auto-apply scenarios when run in sequence. A fake tool name fails fast on recipe lookup (~200 ms); the test verifies cache consumption, not a real install.

No production code changes. Full functional suite passes locally (`go test ./test/functional/` clean in 270 s).

---

Fixes #2354

## Test plan

- [x] `go test ./test/functional/` passes locally end-to-end (270 s, no failures)
- [x] The five `project-auto-update` scenarios all pass under 1 s combined (down from 60+ s before, when they intermittently failed)
- [x] `update-registry` scenarios pass
- [x] `go test ./...`, `go vet ./...`, `gofmt -l .` all clean