### PR TITLE
feat(recipes): author a curated bazel recipe

### DIFF
--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -98,8 +98,8 @@ These issues capture infrastructure and recipe gaps surfaced while authoring the
 | _Sandbox containers do not bundle a JDK and the registry has no `openjdk` recipe to declare as a dependency. JVM tools (maven, gradle, sbt) install successfully but fail verify because `mvn --version` etc. need a JVM at runtime._ | | |
 | ~~[#2328: feat(version): add a version source for Google Cloud SDK to enable gcloud recipe](https://github.com/tsukumogami/tsuku/issues/2328)~~ | ~~None~~ | ~~testable~~ |
 | ~~_Expanded scope from "gcloud_dist custom source" to a generic `http_json` version source per `docs/designs/DESIGN-http-json-version-source.md`. Adds `[version] source = "http_json"` with `url` and `version_path` fields supporting dotted access plus `[N]` array indexing. Authors `recipes/g/gcloud.toml` as the first consumer in the same PR. Deprecates `source = "hashicorp"` (kept for one release window with a runtime warning); removal tracked in #2349. Unblocks Adoptium-based openjdk in #2327 and HashiCorp checkpoint adoption in #2350-style follow-ups when needed._~~ | | |
-| [#2330: feat(recipes): author a working curated bazel recipe](https://github.com/tsukumogami/tsuku/issues/2330) | None | testable |
-| _The bare `bazel-{version}-{os}-{arch}` binary self-extracts an embedded JDK and spawns a long-lived server on first run; verify exits non-zero on glibc Linux (~55s) and macOS (~3s) in the sandbox. Needs an installer-script or Homebrew approach._ | | |
+| ~~[#2330: feat(recipes): author a working curated bazel recipe](https://github.com/tsukumogami/tsuku/issues/2330)~~ | ~~None~~ | ~~testable~~ |
+| ~~_Authored `recipes/b/bazel.toml` using the homebrew bottle for both glibc Linux and macOS — homebrew handles the embedded-JDK self-extraction layout that broke in the bare-binary attempt. Restricted to glibc via `supported_libc = ["glibc"]` (Alpine cannot run the embedded JDK). Also fixed a pre-existing libc-coverage validator false positive that flagged darwin-only homebrew steps as "no libc clause" even though the schema forbids `libc` on non-linux when clauses._~~ | | |
 | ~~[#2331: feat(recipes): allow pipx_install recipes to pin a PyPI version constraint](https://github.com/tsukumogami/tsuku/issues/2331)~~ | ~~None~~ | ~~testable~~ |
 | ~~_Resolved with a different mechanism than the title suggests. Recipes do not declare PyPI version constraints; instead, `PyPIProvider.ResolveLatest` filters by per-release `requires_python` against the bundled `python-standalone` major.minor. Auto-resolution picks the newest stable, non-yanked, Python-compatible release. Lands `recipes/a/ansible.toml` as the proof point. azure-cli is deferred — its eval already succeeds and its post-install failure is a separate transitive C-extension ABI issue. See `docs/designs/current/DESIGN-pipx-pypi-version-pinning.md`._~~ | | |
 | ~~[#2333: fix(homebrew): resolve revision-suffixed bottles so libevent darwin can be installed](https://github.com/tsukumogami/tsuku/issues/2333)~~ | ~~None~~ | ~~testable~~ |
@@ -177,8 +177,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2325,I2328,I2331,I2333 done
-    class I2327,I2330,I2335,I2338 ready
+    class I2325,I2328,I2330,I2331,I2333 done
+    class I2327,I2335,I2338 ready
     class I2336,I2343,I2344,I2345,I2349 blocked
 ```
 

--- a/internal/recipe/coverage.go
+++ b/internal/recipe/coverage.go
@@ -78,7 +78,12 @@ func AnalyzeRecipeCoverage(r *Recipe) CoverageReport {
 			if hasMuslLibcWhenClause(step) {
 				hasMuslPath = true
 			}
-			if isGlibcBoundAction(step.Action) && !hasLibcWhenClause(step) {
+			// stepMatchesGlibc gates this on the step actually being
+			// reachable from a glibc Linux target. Darwin-only steps
+			// can't carry a libc clause (the schema forbids it on
+			// non-linux), so without this guard they would falsely
+			// trigger "no libc clause" warnings.
+			if isGlibcBoundAction(step.Action) && !hasLibcWhenClause(step) && stepMatchesGlibc(step.When) {
 				hasUnguardedGlibcAction = true
 			}
 		}

--- a/internal/recipe/coverage_test.go
+++ b/internal/recipe/coverage_test.go
@@ -618,6 +618,35 @@ func TestAnalyzeRecipeCoverage_UnguardedHomebrewNoApkInstall(t *testing.T) {
 	}
 }
 
+func TestAnalyzeRecipeCoverage_DarwinOnlyHomebrewSkipsMuslWarning(t *testing.T) {
+	// A homebrew step gated to darwin (`when = { os = ["darwin"] }`)
+	// is not glibc-bound at runtime — the schema even forbids a libc
+	// clause on non-linux. Without considering the step's OS, the
+	// musl-coverage check would falsely flag any recipe with a
+	// darwin homebrew step.
+	r := &Recipe{
+		Metadata: MetadataSection{Name: "darwin-only-tool", SupportedLibc: []string{"glibc"}},
+		Steps: []Step{
+			{
+				Action: "homebrew",
+				When:   &WhenClause{OS: []string{"linux"}, Libc: []string{"glibc"}},
+			},
+			{
+				Action: "homebrew",
+				When:   &WhenClause{OS: []string{"darwin"}},
+			},
+		},
+	}
+
+	report := AnalyzeRecipeCoverage(r)
+
+	for _, w := range report.Warnings {
+		if w == "recipe 'darwin-only-tool' has platform-specific actions without libc when clauses and no musl fallback" {
+			t.Errorf("unexpected musl coverage warning for darwin-only homebrew step: %v", report.Warnings)
+		}
+	}
+}
+
 func TestIsGlibcBoundAction(t *testing.T) {
 	tests := []struct {
 		action   string

--- a/recipes/b/bazel.toml
+++ b/recipes/b/bazel.toml
@@ -21,8 +21,13 @@ formula = "bazel"
 when = { os = ["linux"], libc = ["glibc"] }
 
 [[steps]]
+# Bazel's homebrew wrapper at bin/bazel is a shell script that execs
+# libexec/bin/bazel (the bazel-real binary plus embedded JDK). Install
+# the entire bottle as a directory so the wrapper's libexec reference
+# resolves; only bin/bazel needs PATH exposure.
 action = "install_binaries"
-binaries = ["bin/bazel"]
+install_mode = "directory"
+outputs = ["bin/bazel"]
 when = { os = ["linux"], libc = ["glibc"] }
 
 # macOS: Homebrew bottle.
@@ -32,8 +37,13 @@ formula = "bazel"
 when = { os = ["darwin"] }
 
 [[steps]]
+# Bazel's homebrew wrapper at bin/bazel is a shell script that execs
+# libexec/bin/bazel (the bazel-real binary plus embedded JDK). Install
+# the entire bottle as a directory so the wrapper's libexec reference
+# resolves; only bin/bazel needs PATH exposure.
 action = "install_binaries"
-binaries = ["bin/bazel"]
+install_mode = "directory"
+outputs = ["bin/bazel"]
 when = { os = ["darwin"] }
 
 [verify]

--- a/recipes/b/bazel.toml
+++ b/recipes/b/bazel.toml
@@ -1,35 +1,41 @@
 [metadata]
-  name = "bazel"
-  description = "Google's own build tool"
-  homepage = "https://bazel.build/"
-  version_format = ""
-  requires_sudo = false
-  unsupported_platforms = ["darwin/arm64", "darwin/amd64"]
-  tier = 0
-  type = ""
-  llm_validation = "skipped"
+name = "bazel"
+description = "Google's own build tool"
+homepage = "https://bazel.build/"
+version_format = "semver"
+curated = true
+# Bazel ships a self-extracting JDK with each release, glibc-linked.
+# Alpine (musl) cannot run the embedded interpreter, so the recipe is
+# scoped to glibc Linux + macOS. Homebrew bottles handle the
+# self-extraction layout correctly across both, where the bare GitHub
+# binary failed in the test-recipe sandbox (#2330).
+supported_libc = ["glibc"]
 
-[version]
-  source = ""
-  github_repo = ""
-  tag_prefix = ""
-  module = ""
-  formula = ""
-  cask = ""
-  tap = ""
-  fossil_repo = ""
-  project_name = ""
-  version_separator = ""
-  timeline_tag = ""
+[metadata.satisfies]
+homebrew = ["bazel"]
+
+# glibc Linux: Homebrew bottle.
+[[steps]]
+action = "homebrew"
+formula = "bazel"
+when = { os = ["linux"], libc = ["glibc"] }
 
 [[steps]]
-  action = "homebrew"
-  formula = "bazel"
+action = "install_binaries"
+binaries = ["bin/bazel"]
+when = { os = ["linux"], libc = ["glibc"] }
+
+# macOS: Homebrew bottle.
+[[steps]]
+action = "homebrew"
+formula = "bazel"
+when = { os = ["darwin"] }
 
 [[steps]]
-  action = "install_binaries"
-  binaries = ["bin/bazel", "bin/bazel-9.0.0"]
+action = "install_binaries"
+binaries = ["bin/bazel"]
+when = { os = ["darwin"] }
 
 [verify]
-  command = "bazel --version"
-  pattern = ""
+command = "bazel --version"
+pattern = "{version}"


### PR DESCRIPTION
Replace the batch-generated `recipes/b/bazel.toml` with a clean curated recipe that uses the Homebrew bottle on both glibc Linux and macOS. The previous direct-binary approach failed in the test-recipe sandbox because bazel self-extracts an embedded JDK on first run; the homebrew bottle handles that layout correctly. The recipe declares `supported_libc = ["glibc"]` (Alpine cannot run the embedded JDK), gates the linux step on `libc = ["glibc"]`, and verifies via the real `bazel --version`.

Also corrects a pre-existing false positive in the libc-coverage validator at `internal/recipe/coverage.go:81`. The structural check flagged any `homebrew` step without a `libc` when clause as an "unguarded glibc-bound action" — but the schema forbids `libc` on non-linux when clauses, so a darwin-only homebrew step had no way to satisfy both checks. Adding the existing `stepMatchesGlibc` gate so darwin-only steps are excluded from the unguarded-glibc count. New test `TestAnalyzeRecipeCoverage_DarwinOnlyHomebrewSkipsMuslWarning`.

`docs/plans/PLAN-curated-recipes.md`: marks #2330 done (strikethrough + node class moved from `ready` to `done`).

---

Fixes #2330

## Test plan

- [x] `tsuku validate --strict --check-libc-coverage recipes/b/bazel.toml` passes
- [x] `tsuku eval --recipe recipes/b/bazel.toml` resolves cleanly on linux/amd64, linux/arm64, darwin/amd64, darwin/arm64 (bazel 9.1.0, real GHCR bottle blob URLs)
- [x] `go test ./internal/recipe/...` passes including the new darwin-only homebrew coverage test
- [x] `go vet ./...` and `gofmt -l .` clean
- [ ] Sandbox install + verify on every supported family — gated by the test-recipe nightly matrix