### PR TITLE
fix(recipe): gate unguarded-glibc check on glibc-reachable steps

### DIFF
--- a/internal/recipe/coverage.go
+++ b/internal/recipe/coverage.go
@@ -78,7 +78,12 @@ func AnalyzeRecipeCoverage(r *Recipe) CoverageReport {
 			if hasMuslLibcWhenClause(step) {
 				hasMuslPath = true
 			}
-			if isGlibcBoundAction(step.Action) && !hasLibcWhenClause(step) {
+			// stepMatchesGlibc gates this on the step actually being
+			// reachable from a glibc Linux target. Darwin-only steps
+			// can't carry a libc clause (the schema forbids it on
+			// non-linux), so without this guard they would falsely
+			// trigger "no libc clause" warnings.
+			if isGlibcBoundAction(step.Action) && !hasLibcWhenClause(step) && stepMatchesGlibc(step.When) {
 				hasUnguardedGlibcAction = true
 			}
 		}

--- a/internal/recipe/coverage_test.go
+++ b/internal/recipe/coverage_test.go
@@ -618,6 +618,35 @@ func TestAnalyzeRecipeCoverage_UnguardedHomebrewNoApkInstall(t *testing.T) {
 	}
 }
 
+func TestAnalyzeRecipeCoverage_DarwinOnlyHomebrewSkipsMuslWarning(t *testing.T) {
+	// A homebrew step gated to darwin (`when = { os = ["darwin"] }`)
+	// is not glibc-bound at runtime — the schema even forbids a libc
+	// clause on non-linux. Without considering the step's OS, the
+	// musl-coverage check would falsely flag any recipe with a
+	// darwin homebrew step.
+	r := &Recipe{
+		Metadata: MetadataSection{Name: "darwin-only-tool", SupportedLibc: []string{"glibc"}},
+		Steps: []Step{
+			{
+				Action: "homebrew",
+				When:   &WhenClause{OS: []string{"linux"}, Libc: []string{"glibc"}},
+			},
+			{
+				Action: "homebrew",
+				When:   &WhenClause{OS: []string{"darwin"}},
+			},
+		},
+	}
+
+	report := AnalyzeRecipeCoverage(r)
+
+	for _, w := range report.Warnings {
+		if w == "recipe 'darwin-only-tool' has platform-specific actions without libc when clauses and no musl fallback" {
+			t.Errorf("unexpected musl coverage warning for darwin-only homebrew step: %v", report.Warnings)
+		}
+	}
+}
+
 func TestIsGlibcBoundAction(t *testing.T) {
 	tests := []struct {
 		action   string


### PR DESCRIPTION
Update the libc-coverage validator's "platform-specific actions without libc when clauses and no musl fallback" check to gate on `stepMatchesGlibc(step.When)`. The bare `isGlibcBoundAction(step.Action) && !hasLibcWhenClause(step)` condition fired for darwin-only homebrew steps even though they cannot carry a libc clause (the recipe schema forbids `libc = [...]` on non-linux when clauses).

---

## What This Fixes

The validator was generating a spurious musl coverage warning for any recipe that paired a darwin-only homebrew step with a glibc-only step. Since the schema disallows libc clauses on darwin steps, the validator's check could never have been satisfied for those steps, but it kept treating them as "unguarded glibc-bound actions" and emitting a warning even when the recipe had a complete musl story (or correctly opted out via `supported_libc`).

Surfaced while authoring a curated bazel recipe (#2330) — the recipe pairs a glibc-only homebrew step with a darwin homebrew step, which is the exact shape that triggers the false positive.

## Changes

- `internal/recipe/coverage.go`: gate the unguarded-glibc check on `stepMatchesGlibc(step.When)` so darwin-only steps no longer satisfy it
- `internal/recipe/coverage_test.go`: add `TestAnalyzeRecipeCoverage_DarwinOnlyHomebrewSkipsMuslWarning` covering the recipe shape that triggered the false positive