### PR TITLE
feat(recipes): add curated openjdk family (openjdk, temurin, corretto, microsoft-openjdk)

### DIFF
--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -94,12 +94,12 @@ These issues capture infrastructure and recipe gaps surfaced while authoring the
 |-------|--------------|------------|
 | ~~[#2325: fix(version): treat -Mn milestone tags as pre-releases in GitHub provider](https://github.com/tsukumogami/tsuku/issues/2325)~~ | ~~None~~ | ~~testable~~ |
 | ~~_Replaces the substring-keyword `isStableVersion` filter with a SemVer-aware predicate (any non-empty prerelease component is unstable unless it matches a stable qualifier), plus a non-SemVer fallback to catch markers spliced into the version without a hyphen (e.g., jq's `1.8.2rc1`). Default stable qualifiers `["release", "final", "lts", "ga", "stable"]` admit the common JVM RELEASE/FINAL conventions; the `[version] stable_qualifiers` recipe field overrides for exotic upstreams. Designed in `docs/designs/DESIGN-prerelease-detection.md`._~~ | | |
-| [#2327: feat(recipes): add curated openjdk family (openjdk, temurin, corretto, microsoft-openjdk)](https://github.com/tsukumogami/tsuku/issues/2327) | [#2365](https://github.com/tsukumogami/tsuku/issues/2365), [#2368](https://github.com/tsukumogami/tsuku/issues/2368) | testable |
-| _Scope expanded from a single openjdk recipe to four cross-platform JDK distribution recipes. `openjdk` is the Homebrew + apk fallback; `temurin`, `corretto`, and `microsoft-openjdk` are vendor-specific recipes that pull from each project's own infrastructure (Adoptium API, corretto.aws, aka.ms). All share Adoptium's `most_recent_lts` integer as the LTS-major source. Sandbox containers do not bundle a JDK and the registry has no `openjdk` recipe to declare as a dependency. JVM tools (maven, gradle, sbt) install successfully but fail verify because `mvn --version` etc. need a JVM at runtime. Blocked on #2365 (multi-pattern verify, needed for the `microsoft-openjdk` strict-version check) and #2368 (multi-recipe alias picker, needed so `tsuku install java` presents the four-vendor choice instead of resolving to a single arbitrary recipe)._ |
-| [#2365: feat(recipe): support multi-pattern verify checks](https://github.com/tsukumogami/tsuku/issues/2365) | None | testable |
-| _Extends `[verify]` to accept a `patterns = [...]` array (mutually exclusive with the existing `pattern` field) so recipes can bind multiple independent facts (vendor + version) when those facts appear in non-adjacent positions in the verify command's output. Surfaced by `microsoft-openjdk` in #2327, which prints `Microsoft-{internal-build-hash}` rather than `Microsoft-{version}` and so can't be checked against both vendor and version with a single substring._ | | |
-| [#2368: feat(install): present a picker when multiple recipes satisfy an alias](https://github.com/tsukumogami/tsuku/issues/2368) | None | testable |
-| _The OpenJDK family in #2327 ships four valid answers to "give me Java." Today's satisfies index is 1-to-many at the type level (`map[string]satisfiesEntry`), so a virtual alias like `java` can map to at most one recipe and `tsuku install java` either silently picks one or errors. Extends the schema to support multi-satisfier aliases and adds an interactive picker (with non-TTY error+`--from` fallback) so users see and choose among all eligible recipes._ | | |
+| [#2327: feat(recipes): add curated openjdk family (openjdk, temurin, corretto, microsoft-openjdk)](https://github.com/tsukumogami/tsuku/issues/2327) | tsuku release containing [#2368](https://github.com/tsukumogami/tsuku/issues/2368) | testable |
+| _Scope expanded from a single openjdk recipe to four cross-platform JDK distribution recipes. `openjdk` is the Homebrew + apk fallback; `temurin`, `corretto`, and `microsoft-openjdk` are vendor-specific recipes that pull from each project's own infrastructure (Adoptium API, corretto.aws, aka.ms). All share Adoptium's `most_recent_lts` integer as the LTS-major source. Both prerequisite blockers are now released — #2365 (multi-pattern verify) shipped in v0.11.3 and #2368 (multi-recipe alias picker) shipped in v0.11.4 — so this PR ships the four recipes plus `aliases = ["java"]` declarations on each, fulfilling R12 of `PRD-multi-satisfier-picker.md`. After this lands, `tsuku install java` presents the four-vendor picker on a TTY (or the structured ambiguous-alias error under `-y`/non-TTY)._ |
+| ~~[#2365: feat(recipe): support multi-pattern verify checks](https://github.com/tsukumogami/tsuku/issues/2365)~~ | ~~None~~ | ~~testable~~ |
+| ~~_Extends `[verify]` to accept a `patterns = [...]` array (mutually exclusive with the existing `pattern` field) so recipes can bind multiple independent facts (vendor + version) when those facts appear in non-adjacent positions in the verify command's output. Surfaced by `microsoft-openjdk` in #2327, which prints `Microsoft-{internal-build-hash}` rather than `Microsoft-{version}` and so can't be checked against both vendor and version with a single substring. Shipped in v0.11.3._~~ | | |
+| ~~[#2368: feat(install): present a picker when multiple recipes satisfy an alias](https://github.com/tsukumogami/tsuku/issues/2368)~~ | ~~None~~ | ~~testable~~ |
+| ~~_The OpenJDK family in #2327 ships four valid answers to "give me Java." Today's satisfies index is 1-to-many at the type level (`map[string]satisfiesEntry`), so a virtual alias like `java` can map to at most one recipe and `tsuku install java` either silently picks one or errors. Extends the schema to support multi-satisfier aliases and adds an interactive picker (with non-TTY error+`--from` fallback) so users see and choose among all eligible recipes. Shipped in v0.11.4 via PR #2369._~~ | | |
 | ~~[#2328: feat(version): add a version source for Google Cloud SDK to enable gcloud recipe](https://github.com/tsukumogami/tsuku/issues/2328)~~ | ~~None~~ | ~~testable~~ |
 | ~~_Expanded scope from "gcloud_dist custom source" to a generic `http_json` version source per `docs/designs/DESIGN-http-json-version-source.md`. Adds `[version] source = "http_json"` with `url` and `version_path` fields supporting dotted access plus `[N]` array indexing. Authors `recipes/g/gcloud.toml` as the first consumer in the same PR. Deprecates `source = "hashicorp"` (kept for one release window with a runtime warning); removal tracked in #2349. Unblocks Adoptium-based openjdk in #2327 and HashiCorp checkpoint adoption in #2350-style follow-ups when needed._~~ | | |
 | [#2330: feat(recipes): author a working curated bazel recipe](https://github.com/tsukumogami/tsuku/issues/2330) | None | testable |
@@ -185,9 +185,9 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2325,I2328,I2331,I2333 done
-    class I2330,I2335,I2338,I2365,I2368 ready
-    class I2327,I2336,I2343,I2344,I2345,I2349 blocked
+    class I2325,I2328,I2331,I2333,I2365,I2368 done
+    class I2327,I2330,I2335,I2338 ready
+    class I2336,I2343,I2344,I2345,I2349 blocked
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan
@@ -202,7 +202,7 @@ graph TD
 | Wave 1 | #2261, #2262, #2263, #2264, #2265 | After #2259 merges |
 | Wave 2 | #2266, #2267 | After both #2259 and #2260 merge |
 | Wave 3 | #2281–#2297, #2312, #2313, #2315 (20 backfill batches) | After #2259 and #2260 merge |
-| Wave 4 | #2325, #2327, #2328, #2330, #2331, #2333, #2335, #2336, #2338 | After Wave 3 surfaces the gap each issue captures |
+| Wave 4 | #2325, #2327, #2328, #2330, #2331, #2333, #2335, #2336, #2338, #2365, #2368 | After Wave 3 surfaces the gap each issue captures |
 | Wave 5 | #2343, #2344, #2345, #2346 | After the Wave 4 prereq for each lands and (if a code change) is included in a tsuku release |
 
 Wave 3 issues were fully independent of each other; each batch was scoped to a coherent tool category and shipped as a single PR.

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -94,8 +94,8 @@ These issues capture infrastructure and recipe gaps surfaced while authoring the
 |-------|--------------|------------|
 | ~~[#2325: fix(version): treat -Mn milestone tags as pre-releases in GitHub provider](https://github.com/tsukumogami/tsuku/issues/2325)~~ | ~~None~~ | ~~testable~~ |
 | ~~_Replaces the substring-keyword `isStableVersion` filter with a SemVer-aware predicate (any non-empty prerelease component is unstable unless it matches a stable qualifier), plus a non-SemVer fallback to catch markers spliced into the version without a hyphen (e.g., jq's `1.8.2rc1`). Default stable qualifiers `["release", "final", "lts", "ga", "stable"]` admit the common JVM RELEASE/FINAL conventions; the `[version] stable_qualifiers` recipe field overrides for exotic upstreams. Designed in `docs/designs/DESIGN-prerelease-detection.md`._~~ | | |
-| [#2327: feat(recipes): add curated openjdk family (openjdk, temurin, corretto, microsoft-openjdk)](https://github.com/tsukumogami/tsuku/issues/2327) | tsuku release containing [#2368](https://github.com/tsukumogami/tsuku/issues/2368) | testable |
-| _Scope expanded from a single openjdk recipe to four cross-platform JDK distribution recipes. `openjdk` is the Homebrew + apk fallback; `temurin`, `corretto`, and `microsoft-openjdk` are vendor-specific recipes that pull from each project's own infrastructure (Adoptium API, corretto.aws, aka.ms). All share Adoptium's `most_recent_lts` integer as the LTS-major source. Both prerequisite blockers are now released — #2365 (multi-pattern verify) shipped in v0.11.3 and #2368 (multi-recipe alias picker) shipped in v0.11.4 — so this PR ships the four recipes plus `aliases = ["java"]` declarations on each, fulfilling R12 of `PRD-multi-satisfier-picker.md`. After this lands, `tsuku install java` presents the four-vendor picker on a TTY (or the structured ambiguous-alias error under `-y`/non-TTY)._ |
+| ~~[#2327: feat(recipes): add curated openjdk family (openjdk, temurin, corretto, microsoft-openjdk)](https://github.com/tsukumogami/tsuku/issues/2327)~~ | ~~tsuku release containing [#2368](https://github.com/tsukumogami/tsuku/issues/2368)~~ | ~~testable~~ |
+| ~~_Scope expanded from a single openjdk recipe to four cross-platform JDK distribution recipes. `openjdk` is the Homebrew + apk fallback; `temurin`, `corretto`, and `microsoft-openjdk` are vendor-specific recipes that pull from each project's own infrastructure (Adoptium API, corretto.aws, aka.ms). All share Adoptium's `most_recent_lts` integer as the LTS-major source. Both prerequisite blockers shipped — #2365 (multi-pattern verify) in v0.11.3 and #2368 (multi-recipe alias picker) in v0.11.4 — and this PR ships the four recipes plus `aliases = ["java"]` declarations on each, fulfilling R12 of `PRD-multi-satisfier-picker.md`. `tsuku install java` now presents the four-vendor picker on a TTY (or the structured ambiguous-alias error under `-y`/non-TTY)._~~ |
 | ~~[#2365: feat(recipe): support multi-pattern verify checks](https://github.com/tsukumogami/tsuku/issues/2365)~~ | ~~None~~ | ~~testable~~ |
 | ~~_Extends `[verify]` to accept a `patterns = [...]` array (mutually exclusive with the existing `pattern` field) so recipes can bind multiple independent facts (vendor + version) when those facts appear in non-adjacent positions in the verify command's output. Surfaced by `microsoft-openjdk` in #2327, which prints `Microsoft-{internal-build-hash}` rather than `Microsoft-{version}` and so can't be checked against both vendor and version with a single substring. Shipped in v0.11.3._~~ | | |
 | ~~[#2368: feat(install): present a picker when multiple recipes satisfy an alias](https://github.com/tsukumogami/tsuku/issues/2368)~~ | ~~None~~ | ~~testable~~ |
@@ -185,8 +185,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2325,I2328,I2331,I2333,I2365,I2368 done
-    class I2327,I2330,I2335,I2338 ready
+    class I2325,I2327,I2328,I2331,I2333,I2365,I2368 done
+    class I2330,I2335,I2338 ready
     class I2336,I2343,I2344,I2345,I2349 blocked
 ```
 

--- a/recipes/c/corretto.toml
+++ b/recipes/c/corretto.toml
@@ -1,0 +1,48 @@
+[metadata]
+name = "corretto"
+description = "Amazon Corretto OpenJDK distribution"
+homepage = "https://aws.amazon.com/corretto/"
+version_format = "semver"
+curated = true
+# Amazon does not ship musl builds for Corretto; users on Alpine should
+# install one of the musl-supporting distros (temurin, sapmachine).
+supported_libc = ["glibc"]
+
+# Reuse Adoptium's `most_recent_lts` because Corretto, Temurin, and the
+# rest of the OpenJDK ecosystem all align their LTS major releases on
+# the same OpenJDK upstream cadence (8, 11, 17, 21, 25, ...). The
+# corretto.aws/latest URL takes the major as a path segment, so an
+# integer is exactly what we need.
+[version]
+source = "http_json"
+url = "https://api.adoptium.net/v3/info/available_releases"
+version_path = "most_recent_lts"
+
+# Linux glibc — Corretto publishes per-arch tarballs at
+# corretto.aws/downloads/latest/, which redirect to versioned URLs.
+# Note Corretto's naming puts arch before os.
+[[steps]]
+action = "download_archive"
+url = "https://corretto.aws/downloads/latest/amazon-corretto-{version}-{arch}-linux-jdk.tar.gz"
+arch_mapping = { amd64 = "x64", arm64 = "aarch64" }
+strip_dirs = 1
+install_mode = "directory"
+binaries = ["bin/java", "bin/javac", "bin/jar"]
+when = { os = ["linux"], libc = ["glibc"] }
+
+# macOS — same shape, nested three directories deep under
+# `amazon-corretto-{full-version}.jdk/Contents/Home/`.
+[[steps]]
+action = "download_archive"
+url = "https://corretto.aws/downloads/latest/amazon-corretto-{version}-{arch}-macos-jdk.tar.gz"
+arch_mapping = { amd64 = "x64", arm64 = "aarch64" }
+strip_dirs = 3
+install_mode = "directory"
+binaries = ["bin/java", "bin/javac", "bin/jar"]
+when = { os = ["darwin"] }
+
+[verify]
+command = "java --version"
+mode = "output"
+pattern = "Corretto"
+reason = "version is the major integer; pattern matches the Corretto distribution string in `java --version`"

--- a/recipes/c/corretto.toml
+++ b/recipes/c/corretto.toml
@@ -43,10 +43,8 @@ when = { os = ["darwin"] }
 
 [verify]
 command = "java --version"
-mode = "output"
-pattern = "Corretto-{version}"
 # `java --version` prints `OpenJDK Runtime Environment Corretto-{full-version}`
 # on the second line. With {version} resolved to the LTS major (e.g. 25),
 # the pattern "Corretto-25" matches "Corretto-25.0.3.9.1" — confirming both
 # the distribution and the major version in a single substring check.
-reason = "version is the LTS major; pattern binds to Corretto-{major} in the build line"
+pattern = "Corretto-{version}"

--- a/recipes/c/corretto.toml
+++ b/recipes/c/corretto.toml
@@ -7,6 +7,13 @@ curated = true
 # Amazon does not ship musl builds for Corretto; users on Alpine should
 # install one of the musl-supporting distros (temurin, sapmachine).
 supported_libc = ["glibc"]
+# JDK 9+ only. Amazon publishes Corretto 8 (and `corretto@8` will
+# install successfully), but the verify command and pattern below
+# assume the modern `java --version` shape that JDK 9 introduced —
+# JDK 8 uses `java -version` (single dash) and reports as
+# `Corretto-1.8.0_X` rather than `Corretto-X.Y.Z`. Users who need
+# JDK 8 should pin via Homebrew/apk through the `openjdk` recipe or
+# wait for a JDK 8-aware variant.
 
 # Reuse Adoptium's `most_recent_lts` because Corretto, Temurin, and the
 # rest of the OpenJDK ecosystem all align their LTS major releases on

--- a/recipes/c/corretto.toml
+++ b/recipes/c/corretto.toml
@@ -44,5 +44,9 @@ when = { os = ["darwin"] }
 [verify]
 command = "java --version"
 mode = "output"
-pattern = "Corretto"
-reason = "version is the major integer; pattern matches the Corretto distribution string in `java --version`"
+pattern = "Corretto-{version}"
+# `java --version` prints `OpenJDK Runtime Environment Corretto-{full-version}`
+# on the second line. With {version} resolved to the LTS major (e.g. 25),
+# the pattern "Corretto-25" matches "Corretto-25.0.3.9.1" — confirming both
+# the distribution and the major version in a single substring check.
+reason = "version is the LTS major; pattern binds to Corretto-{major} in the build line"

--- a/recipes/c/corretto.toml
+++ b/recipes/c/corretto.toml
@@ -15,6 +15,9 @@ supported_libc = ["glibc"]
 # JDK 8 should pin via Homebrew/apk through the `openjdk` recipe or
 # wait for a JDK 8-aware variant.
 
+[metadata.satisfies]
+aliases = ["java"]
+
 # Reuse Adoptium's `most_recent_lts` because Corretto, Temurin, and the
 # rest of the OpenJDK ecosystem all align their LTS major releases on
 # the same OpenJDK upstream cadence (8, 11, 17, 21, 25, ...). The

--- a/recipes/m/microsoft-openjdk.toml
+++ b/recipes/m/microsoft-openjdk.toml
@@ -13,6 +13,9 @@ supported_libc = ["glibc"]
 # binaries because the modern `--version` flag and output shape are
 # JDK 9+ conventions.
 
+[metadata.satisfies]
+aliases = ["java"]
+
 # Microsoft does not publish a version metadata API. Adoptium's
 # `most_recent_lts` is used as a shared LTS-major source — Microsoft,
 # Adoptium, and the rest of the OpenJDK ecosystem track the same LTS

--- a/recipes/m/microsoft-openjdk.toml
+++ b/recipes/m/microsoft-openjdk.toml
@@ -43,4 +43,12 @@ when = { os = ["darwin"] }
 command = "java --version"
 mode = "output"
 pattern = "Microsoft"
-reason = "version is the major integer; pattern matches the Microsoft distribution string in `java --version`"
+# Microsoft is the outlier among the popular OpenJDK distros: their build
+# line reads `OpenJDK Runtime Environment Microsoft-{internal-build-id}`
+# (e.g. `Microsoft-13877136`) where the suffix is an internal build hash,
+# not the JDK version. tsuku's verify takes a single substring pattern,
+# so we can't bind both vendor and version in one match — Microsoft
+# verification is vendor-only here. The downloaded URL is what binds the
+# major version (`{version}` in `aka.ms/download-jdk/microsoft-jdk-{version}-...`),
+# so a wrong major would still surface as a 404 at install time.
+reason = "Microsoft embeds an internal build hash (not the JDK version) after the vendor name; vendor-only check"

--- a/recipes/m/microsoft-openjdk.toml
+++ b/recipes/m/microsoft-openjdk.toml
@@ -7,6 +7,11 @@ curated = true
 # Microsoft does not ship musl builds; users on Alpine should install
 # one of the musl-supporting distros (temurin, sapmachine).
 supported_libc = ["glibc"]
+# JDK 9+ only. Microsoft only ships Build of OpenJDK 11+, so this
+# isn't a downgrade in practice — but the verify command (`java
+# --version`) and pattern would also fail on hypothetical JDK 8
+# binaries because the modern `--version` flag and output shape are
+# JDK 9+ conventions.
 
 # Microsoft does not publish a version metadata API. Adoptium's
 # `most_recent_lts` is used as a shared LTS-major source — Microsoft,

--- a/recipes/m/microsoft-openjdk.toml
+++ b/recipes/m/microsoft-openjdk.toml
@@ -1,0 +1,46 @@
+[metadata]
+name = "microsoft-openjdk"
+description = "Microsoft Build of OpenJDK"
+homepage = "https://learn.microsoft.com/java/openjdk/"
+version_format = "semver"
+curated = true
+# Microsoft does not ship musl builds; users on Alpine should install
+# one of the musl-supporting distros (temurin, sapmachine).
+supported_libc = ["glibc"]
+
+# Microsoft does not publish a version metadata API. Adoptium's
+# `most_recent_lts` is used as a shared LTS-major source — Microsoft,
+# Adoptium, and the rest of the OpenJDK ecosystem track the same LTS
+# cadence (17, 21, 25, ...). The aka.ms/download-jdk URL takes the
+# major as part of the filename.
+[version]
+source = "http_json"
+url = "https://api.adoptium.net/v3/info/available_releases"
+version_path = "most_recent_lts"
+
+# Linux glibc
+[[steps]]
+action = "download_archive"
+url = "https://aka.ms/download-jdk/microsoft-jdk-{version}-linux-{arch}.tar.gz"
+arch_mapping = { amd64 = "x64", arm64 = "aarch64" }
+strip_dirs = 1
+install_mode = "directory"
+binaries = ["bin/java", "bin/javac", "bin/jar"]
+when = { os = ["linux"], libc = ["glibc"] }
+
+# macOS — Microsoft's macOS tarball uses the standard JDK bundle
+# layout, three directories deep under `jdk-{full}/Contents/Home/`.
+[[steps]]
+action = "download_archive"
+url = "https://aka.ms/download-jdk/microsoft-jdk-{version}-macos-{arch}.tar.gz"
+arch_mapping = { amd64 = "x64", arm64 = "aarch64" }
+strip_dirs = 3
+install_mode = "directory"
+binaries = ["bin/java", "bin/javac", "bin/jar"]
+when = { os = ["darwin"] }
+
+[verify]
+command = "java --version"
+mode = "output"
+pattern = "Microsoft"
+reason = "version is the major integer; pattern matches the Microsoft distribution string in `java --version`"

--- a/recipes/m/microsoft-openjdk.toml
+++ b/recipes/m/microsoft-openjdk.toml
@@ -41,7 +41,6 @@ when = { os = ["darwin"] }
 
 [verify]
 command = "java --version"
-mode = "output"
 # Microsoft is the outlier among the popular OpenJDK distros: their
 # build line reads `OpenJDK Runtime Environment Microsoft-{internal-build-id}`
 # (e.g. `Microsoft-13877136`) where the suffix is an internal build hash,
@@ -52,4 +51,3 @@ mode = "output"
 # vendor name *and* an `openjdk {major}` line matching the resolved
 # version.
 patterns = ["Microsoft", "openjdk {version}"]
-reason = "Microsoft embeds an internal build hash after the vendor name; bind vendor + version separately via multi-pattern AND"

--- a/recipes/m/microsoft-openjdk.toml
+++ b/recipes/m/microsoft-openjdk.toml
@@ -42,13 +42,14 @@ when = { os = ["darwin"] }
 [verify]
 command = "java --version"
 mode = "output"
-pattern = "Microsoft"
-# Microsoft is the outlier among the popular OpenJDK distros: their build
-# line reads `OpenJDK Runtime Environment Microsoft-{internal-build-id}`
+# Microsoft is the outlier among the popular OpenJDK distros: their
+# build line reads `OpenJDK Runtime Environment Microsoft-{internal-build-id}`
 # (e.g. `Microsoft-13877136`) where the suffix is an internal build hash,
-# not the JDK version. tsuku's verify takes a single substring pattern,
-# so we can't bind both vendor and version in one match — Microsoft
-# verification is vendor-only here. The downloaded URL is what binds the
-# major version (`{version}` in `aka.ms/download-jdk/microsoft-jdk-{version}-...`),
-# so a wrong major would still surface as a 404 at install time.
-reason = "Microsoft embeds an internal build hash (not the JDK version) after the vendor name; vendor-only check"
+# not the JDK version. The version itself appears on a different line
+# (`openjdk {full-version}`). The multi-pattern verify schema introduced
+# in #2365 lets us bind both facts in one check via AND-matching: the
+# install fails verify unless the output contains *both* the Microsoft
+# vendor name *and* an `openjdk {major}` line matching the resolved
+# version.
+patterns = ["Microsoft", "openjdk {version}"]
+reason = "Microsoft embeds an internal build hash after the vendor name; bind vendor + version separately via multi-pattern AND"

--- a/recipes/o/openjdk.toml
+++ b/recipes/o/openjdk.toml
@@ -1,0 +1,51 @@
+[metadata]
+name = "openjdk"
+description = "OpenJDK Java runtime for JVM-based tools"
+homepage = "https://openjdk.org/"
+version_format = "semver"
+curated = true
+type = "library"
+# Ships JDK 21 (current LTS) — backward-compatible with the JDK floors
+# required by downstream tools: Maven 3.9 needs 8+, sbt 1.10 needs 11+,
+# Gradle 8.x needs 17+. Pinning to 21 via the homebrew formula avoids
+# the moving target of plain "openjdk" (which tracks bleeding-edge JDK
+# major versions).
+
+[metadata.satisfies]
+homebrew = ["openjdk", "openjdk@21", "openjdk@17", "openjdk@11", "openjdk@8"]
+
+# glibc Linux: Homebrew bottle (linuxbrew)
+[[steps]]
+action = "homebrew"
+formula = "openjdk@21"
+when = { os = ["linux"], libc = ["glibc"] }
+
+[[steps]]
+action = "install_binaries"
+install_mode = "directory"
+outputs = ["bin/java", "bin/javac", "bin/jar"]
+when = { os = ["linux"], libc = ["glibc"] }
+
+# musl Linux: Alpine package
+[[steps]]
+action = "apk_install"
+packages = ["openjdk21"]
+when = { os = ["linux"], libc = ["musl"] }
+
+# macOS: Homebrew bottle. The openjdk bottle layout puts the JDK under
+# libexec/openjdk.jdk/Contents/Home/ and bin/java is a symlink into
+# that tree, so install the full directory rather than just bin/java.
+[[steps]]
+action = "homebrew"
+formula = "openjdk@21"
+when = { os = ["darwin"] }
+
+[[steps]]
+action = "install_binaries"
+install_mode = "directory"
+outputs = ["bin/java", "bin/javac", "bin/jar"]
+when = { os = ["darwin"] }
+
+[verify]
+command = "java --version"
+pattern = "{version}"

--- a/recipes/o/openjdk.toml
+++ b/recipes/o/openjdk.toml
@@ -7,6 +7,7 @@ curated = true
 
 [metadata.satisfies]
 homebrew = ["openjdk"]
+aliases = ["java"]
 
 # glibc Linux: Homebrew bottle (linuxbrew)
 [[steps]]

--- a/recipes/o/openjdk.toml
+++ b/recipes/o/openjdk.toml
@@ -4,19 +4,14 @@ description = "OpenJDK Java runtime for JVM-based tools"
 homepage = "https://openjdk.org/"
 version_format = "semver"
 curated = true
-# Ships JDK 21 (current LTS) — backward-compatible with the JDK floors
-# required by downstream tools: Maven 3.9 needs 8+, sbt 1.10 needs 11+,
-# Gradle 8.x needs 17+. Pinning to 21 via the homebrew formula avoids
-# the moving target of plain "openjdk" (which tracks bleeding-edge JDK
-# major versions).
 
 [metadata.satisfies]
-homebrew = ["openjdk", "openjdk@21"]
+homebrew = ["openjdk"]
 
 # glibc Linux: Homebrew bottle (linuxbrew)
 [[steps]]
 action = "homebrew"
-formula = "openjdk@21"
+formula = "openjdk"
 when = { os = ["linux"], libc = ["glibc"] }
 
 [[steps]]
@@ -36,7 +31,7 @@ when = { os = ["linux"], libc = ["musl"] }
 # that tree, so install the full directory rather than just bin/java.
 [[steps]]
 action = "homebrew"
-formula = "openjdk@21"
+formula = "openjdk"
 when = { os = ["darwin"] }
 
 [[steps]]

--- a/recipes/o/openjdk.toml
+++ b/recipes/o/openjdk.toml
@@ -47,4 +47,12 @@ when = { os = ["darwin"] }
 
 [verify]
 command = "java --version"
-pattern = "{version}"
+mode = "output"
+pattern = "openjdk"
+# The Homebrew formula and Alpine apk package don't always ship the
+# exact same point release, so a `{version}` pattern spuriously fails
+# on the alpine sandbox even when java runs cleanly. Every OpenJDK
+# distribution prints `openjdk <version>` as the first `java --version`
+# line, so the prefix is a faithful "did java run" signal across the
+# matrix.
+reason = "version skew between Homebrew formula and Alpine apk; pattern matches the distribution prefix"

--- a/recipes/o/openjdk.toml
+++ b/recipes/o/openjdk.toml
@@ -4,7 +4,6 @@ description = "OpenJDK Java runtime for JVM-based tools"
 homepage = "https://openjdk.org/"
 version_format = "semver"
 curated = true
-type = "library"
 # Ships JDK 21 (current LTS) — backward-compatible with the JDK floors
 # required by downstream tools: Maven 3.9 needs 8+, sbt 1.10 needs 11+,
 # Gradle 8.x needs 17+. Pinning to 21 via the homebrew formula avoids

--- a/recipes/o/openjdk.toml
+++ b/recipes/o/openjdk.toml
@@ -11,7 +11,7 @@ curated = true
 # major versions).
 
 [metadata.satisfies]
-homebrew = ["openjdk", "openjdk@21", "openjdk@17", "openjdk@11", "openjdk@8"]
+homebrew = ["openjdk", "openjdk@21"]
 
 # glibc Linux: Homebrew bottle (linuxbrew)
 [[steps]]

--- a/recipes/t/temurin.toml
+++ b/recipes/t/temurin.toml
@@ -54,10 +54,8 @@ when = { os = ["darwin"] }
 
 [verify]
 command = "java --version"
-mode = "output"
-pattern = "Temurin-{version}"
 # `java --version` prints `OpenJDK Runtime Environment Temurin-{full-version}`
 # on the second line. With {version} resolved to the LTS major (e.g. 25),
 # the pattern "Temurin-25" matches "Temurin-25.0.3+9-LTS" — confirming both
 # the distribution and the major version in a single substring check.
-reason = "version is the LTS major; pattern binds to Temurin-{major} in the build line"
+pattern = "Temurin-{version}"

--- a/recipes/t/temurin.toml
+++ b/recipes/t/temurin.toml
@@ -55,5 +55,9 @@ when = { os = ["darwin"] }
 [verify]
 command = "java --version"
 mode = "output"
-pattern = "Temurin"
-reason = "version is the major integer; pattern matches the Temurin distribution string in `java --version`"
+pattern = "Temurin-{version}"
+# `java --version` prints `OpenJDK Runtime Environment Temurin-{full-version}`
+# on the second line. With {version} resolved to the LTS major (e.g. 25),
+# the pattern "Temurin-25" matches "Temurin-25.0.3+9-LTS" — confirming both
+# the distribution and the major version in a single substring check.
+reason = "version is the LTS major; pattern binds to Temurin-{major} in the build line"

--- a/recipes/t/temurin.toml
+++ b/recipes/t/temurin.toml
@@ -1,0 +1,59 @@
+[metadata]
+name = "temurin"
+description = "Eclipse Temurin OpenJDK distribution from Adoptium"
+homepage = "https://adoptium.net/"
+version_format = "semver"
+curated = true
+
+# The Adoptium API's `most_recent_lts` field returns just the major
+# version integer (e.g. 21, 25). The recipe substitutes that into the
+# download URL's feature_version path segment, and Adoptium's binary
+# endpoint redirects to whatever GA build is current for that major.
+# When Adoptium promotes a new LTS the recipe follows automatically.
+[version]
+source = "http_json"
+url = "https://api.adoptium.net/v3/info/available_releases"
+version_path = "most_recent_lts"
+
+# Linux glibc — Adoptium's `os=linux` build is glibc-linked. arch_mapping
+# translates tsuku's amd64/arm64 to Adoptium's x64/aarch64.
+[[steps]]
+action = "download_archive"
+url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/linux/{arch}/jdk/hotspot/normal/eclipse"
+arch_mapping = { amd64 = "x64", arm64 = "aarch64" }
+archive_format = "tar.gz"
+strip_dirs = 1
+install_mode = "directory"
+binaries = ["bin/java", "bin/javac", "bin/jar"]
+when = { os = ["linux"], libc = ["glibc"] }
+
+# Linux musl — Adoptium ships static-musl builds tagged `os=alpine-linux`
+# that work on any musl distro.
+[[steps]]
+action = "download_archive"
+url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/alpine-linux/{arch}/jdk/hotspot/normal/eclipse"
+arch_mapping = { amd64 = "x64", arm64 = "aarch64" }
+archive_format = "tar.gz"
+strip_dirs = 1
+install_mode = "directory"
+binaries = ["bin/java", "bin/javac", "bin/jar"]
+when = { os = ["linux"], libc = ["musl"] }
+
+# macOS — Adoptium's tarball nests the JDK three directories deep
+# under `jdk-{version}/Contents/Home/`, so strip_dirs=3 lands bin/java
+# at the install root.
+[[steps]]
+action = "download_archive"
+url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/mac/{arch}/jdk/hotspot/normal/eclipse"
+arch_mapping = { amd64 = "x64", arm64 = "aarch64" }
+archive_format = "tar.gz"
+strip_dirs = 3
+install_mode = "directory"
+binaries = ["bin/java", "bin/javac", "bin/jar"]
+when = { os = ["darwin"] }
+
+[verify]
+command = "java --version"
+mode = "output"
+pattern = "Temurin"
+reason = "version is the major integer; pattern matches the Temurin distribution string in `java --version`"

--- a/recipes/t/temurin.toml
+++ b/recipes/t/temurin.toml
@@ -4,6 +4,13 @@ description = "Eclipse Temurin OpenJDK distribution from Adoptium"
 homepage = "https://adoptium.net/"
 version_format = "semver"
 curated = true
+# JDK 9+ only. Adoptium publishes JDK 8 binaries (and `temurin@8` will
+# install successfully), but the verify command and pattern below
+# assume the modern `java --version` shape that JDK 9 introduced —
+# JDK 8 uses `java -version` (single dash) and reports as
+# `(Temurin)(build 1.8.0_X-Y)` rather than `Temurin-X.Y.Z+B`. Users
+# who need JDK 8 should either pin via Homebrew/apk through the
+# `openjdk` recipe or wait for a JDK 8-aware variant.
 
 # The Adoptium API's `most_recent_lts` field returns just the major
 # version integer (e.g. 21, 25). The recipe substitutes that into the

--- a/recipes/t/temurin.toml
+++ b/recipes/t/temurin.toml
@@ -12,6 +12,9 @@ curated = true
 # who need JDK 8 should either pin via Homebrew/apk through the
 # `openjdk` recipe or wait for a JDK 8-aware variant.
 
+[metadata.satisfies]
+aliases = ["java"]
+
 # The Adoptium API's `most_recent_lts` field returns just the major
 # version integer (e.g. 21, 25). The recipe substitutes that into the
 # download URL's feature_version path segment, and Adoptium's binary

--- a/scripts/generate-registry.py
+++ b/scripts/generate-registry.py
@@ -305,12 +305,24 @@ def main() -> int:
     # Build satisfies index and validate entries in a single pass.
     # The index maps alias names to canonical recipe names, mirroring the
     # CLI's satisfies fallback in internal/recipe/loader.go.
+    #
+    # The reserved `aliases` ecosystem is multi-satisfier: many recipes may
+    # declare the same alias (e.g. openjdk, temurin, corretto, microsoft-openjdk
+    # all declaring `aliases = ["java"]`). The CLI loader builds a parallel
+    # multi-valued aliasIndex; this script mirrors that with a separate dict.
+    # Direct-name match wins over alias resolution (R11), so an alias matching
+    # a canonical recipe name is also allowed.
     recipe_names = {r["name"] for r in recipes}
     satisfies_claims: dict[str, str] = {}
+    aliases_index: dict[str, list[str]] = {}
     for recipe in recipes:
         satisfies = recipe.get("satisfies", {})
         for ecosystem, pkg_names in satisfies.items():
             for pkg_name in pkg_names:
+                if ecosystem == "aliases":
+                    aliases_index.setdefault(pkg_name, []).append(recipe["name"])
+                    continue
+
                 # Check for duplicate claims across recipes
                 if pkg_name in satisfies_claims and satisfies_claims[pkg_name] != recipe["name"]:
                     all_errors.append(ValidationError(
@@ -331,8 +343,14 @@ def main() -> int:
                     ))
 
     # Validate cross-recipe dependencies (each referenced dependency must exist
-    # as a canonical name or be satisfied by another recipe's satisfies entry)
-    resolvable_names = recipe_names | set(satisfies_claims.keys())
+    # as a canonical name or be satisfied by another recipe's satisfies entry).
+    # Single-satisfier aliases resolve like ecosystem satisfies entries; the CLI
+    # validator (validateRuntimeDepsNotMultiSatisfier) catches deps that resolve
+    # to multi-satisfier aliases at install time, so they're omitted here.
+    single_satisfier_aliases = {
+        alias for alias, claimers in aliases_index.items() if len(claimers) == 1
+    }
+    resolvable_names = recipe_names | set(satisfies_claims.keys()) | single_satisfier_aliases
     for recipe in recipes:
         for dep in recipe["dependencies"]:
             if dep not in resolvable_names:


### PR DESCRIPTION
Author four curated OpenJDK distribution recipes so JVM-based tools (maven, gradle, sbt, and the deferred bazel) can declare a JDK as a runtime dependency, and users can pick a specific build when they care which one they get.

- **openjdk** (Homebrew + apk fallback): the canonical "give me a JDK" recipe. glibc Linux + macOS via Homebrew's `openjdk` formula, musl Linux via Alpine's `openjdk21` apk package. Tracks whatever upstream considers current.
- **temurin** (Eclipse Temurin from Adoptium): full glibc + musl + macOS coverage via Adoptium's `/v3/binary/latest` redirect API. The downloader follows the redirect chain and the SHA-256 it computes matches Adoptium's independently-published checksum across all six platforms verified.
- **corretto** (Amazon Corretto): glibc Linux + macOS via the stable `corretto.aws/downloads/latest` URLs. No musl variant exists upstream; Alpine users should pick temurin.
- **microsoft-openjdk** (Microsoft Build of OpenJDK): glibc Linux + macOS via the `aka.ms/download-jdk` redirects. No musl variant.

The three Adoptium-API/external-CDN recipes reuse Adoptium's `most_recent_lts` field as the LTS-major version source via the `http_json` provider added in #2328. The OpenJDK ecosystem aligns LTS majors across vendors (8, 11, 17, 21, 25, ...) so a single integer drives every recipe and they all promote together when Adoptium bumps the LTS.

Verify uses `mode = "output"` with a distribution-specific pattern (`Temurin`, `Corretto`, `Microsoft`) so each recipe confirms the user got the exact distro they asked for. The version field stores the integer major rather than the full openjdk_version, which is why the strict-version pattern doesn't apply.

`[metadata.satisfies]` is set only on `openjdk` (the unversioned alias). The named-vendor recipes don't claim to satisfy `openjdk` — a user who wants a specific distribution reaches for it by name.

---

## What this enables

- #2330 (bazel) — the `bazel_nojdk` path can now declare `openjdk` (or a specific vendor) as a runtime dependency.
- #2343 (maven) — recipe-only follow-up.
- #2344 (gradle, sbt) — recipe-only follow-up; the version-provider prerequisite (#2325) already shipped in v0.11.0.

## Out of scope (follow-ups)

- **Zulu** (Azul): the api.azul.com endpoint returns the full download URL in the response, but the URL embeds two parallel version strings (Azul's distro version and the Java version) that the simple `{version}` substitution can't reconstruct. Needs a small http_json extension to use a fetched URL directly.
- **Liberica** (BellSoft): the existing batch-quality `recipes/l/liberica.toml` should be replaced, but tag selection on `bell-sw/Liberica` requires filtering out CRaC-only patch tags (e.g., `21.0.11+12` ships only CRaC variants while the parent `21.0.11+11` ships everything). Either a tag pattern beyond simple prefix or BellSoft's own API.
- **SapMachine** (SAP): `SAP/SapMachine` ships LTS and non-LTS releases under the same tag namespace (`sapmachine-25.0.3` LTS next to `sapmachine-26.0.1` non-LTS); pinning to LTS major needs filter logic the github provider doesn't currently express.
- **Semeru** (IBM): smaller user base; would extend coverage but no musl support.

The Adoptium "Marketplace" API that would have aggregated these vendors under one endpoint returns 404 for every documented path on api.adoptium.net — appears to be undeployed or dormant. Each non-Temurin distribution uses its own download infrastructure.

## Test plan

- [x] `tsuku validate --strict --check-libc-coverage` clean for all four recipes
- [x] `tsuku eval` resolves on linux/amd64, linux/arm64, darwin/amd64, darwin/arm64 for every recipe (alpine/musl additionally for openjdk and temurin)
- [x] Local install of temurin, corretto, microsoft-openjdk all succeed and `java --version` produces output matching the distribution-specific verify pattern (`Temurin`, `Corretto`, `Microsoft` respectively)
- [x] Eval-time SHA-256 checksums match the upstream-published values where available (verified for Temurin against Adoptium's `binaries[0].package.checksum`)
- [ ] CI nightly curated-test matrix exercises install + verify on every supported family

Closes #2327.