### PR TITLE
feat(recipes): add curated temurin recipe

### DIFF
--- a/recipes/t/temurin.toml
+++ b/recipes/t/temurin.toml
@@ -17,68 +17,43 @@ source = "http_json"
 url = "https://api.adoptium.net/v3/info/available_releases"
 version_path = "most_recent_lts"
 
-# Linux glibc amd64
+# Linux glibc — Adoptium publishes a single tarball per arch under
+# `os=linux`. The arch_mapping translates tsuku's amd64/arm64 to
+# Adoptium's x64/aarch64.
 [[steps]]
 action = "download_archive"
-url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/linux/x64/jdk/hotspot/normal/eclipse"
+url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/linux/{arch}/jdk/hotspot/normal/eclipse"
+arch_mapping = { amd64 = "x64", arm64 = "aarch64" }
 archive_format = "tar.gz"
 strip_dirs = 1
 install_mode = "directory"
 binaries = ["bin/java", "bin/javac", "bin/jar"]
-when = { platform = ["linux/amd64"], libc = ["glibc"] }
+when = { os = ["linux"], libc = ["glibc"] }
 
-# Linux glibc arm64
+# Linux musl — Adoptium ships static-musl builds tagged `os=alpine-linux`
+# that work on any musl distro. Same arch transformation as glibc.
 [[steps]]
 action = "download_archive"
-url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/linux/aarch64/jdk/hotspot/normal/eclipse"
+url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/alpine-linux/{arch}/jdk/hotspot/normal/eclipse"
+arch_mapping = { amd64 = "x64", arm64 = "aarch64" }
 archive_format = "tar.gz"
 strip_dirs = 1
 install_mode = "directory"
 binaries = ["bin/java", "bin/javac", "bin/jar"]
-when = { platform = ["linux/arm64"], libc = ["glibc"] }
+when = { os = ["linux"], libc = ["musl"] }
 
-# Linux musl amd64 (Alpine)
+# macOS — Adoptium's tarball nests the JDK three directories deep
+# under `jdk-{version}/Contents/Home/`, so strip_dirs=3 lands bin/java
+# at the install root. The Adoptium os name for macOS is `mac`.
 [[steps]]
 action = "download_archive"
-url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/alpine-linux/x64/jdk/hotspot/normal/eclipse"
-archive_format = "tar.gz"
-strip_dirs = 1
-install_mode = "directory"
-binaries = ["bin/java", "bin/javac", "bin/jar"]
-when = { platform = ["linux/amd64"], libc = ["musl"] }
-
-# Linux musl arm64 (Alpine)
-[[steps]]
-action = "download_archive"
-url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/alpine-linux/aarch64/jdk/hotspot/normal/eclipse"
-archive_format = "tar.gz"
-strip_dirs = 1
-install_mode = "directory"
-binaries = ["bin/java", "bin/javac", "bin/jar"]
-when = { platform = ["linux/arm64"], libc = ["musl"] }
-
-# Darwin amd64
-# Adoptium's macOS tarball nests the JDK under Contents/Home/, so two
-# levels of stripping land bin/java at the install root rather than at
-# Contents/Home/bin/java.
-[[steps]]
-action = "download_archive"
-url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/mac/x64/jdk/hotspot/normal/eclipse"
+url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/mac/{arch}/jdk/hotspot/normal/eclipse"
+arch_mapping = { amd64 = "x64", arm64 = "aarch64" }
 archive_format = "tar.gz"
 strip_dirs = 3
 install_mode = "directory"
 binaries = ["bin/java", "bin/javac", "bin/jar"]
-when = { platform = ["darwin/amd64"] }
-
-# Darwin arm64
-[[steps]]
-action = "download_archive"
-url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/mac/aarch64/jdk/hotspot/normal/eclipse"
-archive_format = "tar.gz"
-strip_dirs = 3
-install_mode = "directory"
-binaries = ["bin/java", "bin/javac", "bin/jar"]
-when = { platform = ["darwin/arm64"] }
+when = { os = ["darwin"] }
 
 [verify]
 command = "java --version"
@@ -86,7 +61,7 @@ mode = "output"
 pattern = "Temurin"
 # Match the distribution name rather than the version. The version
 # field is the integer major (e.g. "25"), and `java --version`'s
-# build line includes the substring "Temurin" on every Adoptium-
-# published JDK, so this is a precise distribution check that works
+# build line embeds "Temurin-{version}" on every Adoptium-published
+# JDK, so this is a precise distribution check that doesn't drift
 # across LTS bumps.
 reason = "version is the major integer; pattern matches the Temurin distribution string"

--- a/recipes/t/temurin.toml
+++ b/recipes/t/temurin.toml
@@ -1,0 +1,92 @@
+[metadata]
+name = "temurin"
+description = "Eclipse Temurin OpenJDK distribution"
+homepage = "https://adoptium.net/"
+version_format = "semver"
+curated = true
+
+# The Adoptium API's `most_recent_lts` field returns just the major
+# version integer (e.g. 21, 25). The recipe substitutes that into the
+# download URL's feature_version path segment, and Adoptium's binary
+# endpoint redirects to whatever GA build is current for that major.
+# When Adoptium promotes a new LTS the recipe follows automatically;
+# the trade-off is that the displayed "version" is the integer major,
+# not the full openjdk_version string.
+[version]
+source = "http_json"
+url = "https://api.adoptium.net/v3/info/available_releases"
+version_path = "most_recent_lts"
+
+# Linux glibc amd64
+[[steps]]
+action = "download_archive"
+url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/linux/x64/jdk/hotspot/normal/eclipse"
+archive_format = "tar.gz"
+strip_dirs = 1
+install_mode = "directory"
+binaries = ["bin/java", "bin/javac", "bin/jar"]
+when = { platform = ["linux/amd64"], libc = ["glibc"] }
+
+# Linux glibc arm64
+[[steps]]
+action = "download_archive"
+url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/linux/aarch64/jdk/hotspot/normal/eclipse"
+archive_format = "tar.gz"
+strip_dirs = 1
+install_mode = "directory"
+binaries = ["bin/java", "bin/javac", "bin/jar"]
+when = { platform = ["linux/arm64"], libc = ["glibc"] }
+
+# Linux musl amd64 (Alpine)
+[[steps]]
+action = "download_archive"
+url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/alpine-linux/x64/jdk/hotspot/normal/eclipse"
+archive_format = "tar.gz"
+strip_dirs = 1
+install_mode = "directory"
+binaries = ["bin/java", "bin/javac", "bin/jar"]
+when = { platform = ["linux/amd64"], libc = ["musl"] }
+
+# Linux musl arm64 (Alpine)
+[[steps]]
+action = "download_archive"
+url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/alpine-linux/aarch64/jdk/hotspot/normal/eclipse"
+archive_format = "tar.gz"
+strip_dirs = 1
+install_mode = "directory"
+binaries = ["bin/java", "bin/javac", "bin/jar"]
+when = { platform = ["linux/arm64"], libc = ["musl"] }
+
+# Darwin amd64
+# Adoptium's macOS tarball nests the JDK under Contents/Home/, so two
+# levels of stripping land bin/java at the install root rather than at
+# Contents/Home/bin/java.
+[[steps]]
+action = "download_archive"
+url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/mac/x64/jdk/hotspot/normal/eclipse"
+archive_format = "tar.gz"
+strip_dirs = 3
+install_mode = "directory"
+binaries = ["bin/java", "bin/javac", "bin/jar"]
+when = { platform = ["darwin/amd64"] }
+
+# Darwin arm64
+[[steps]]
+action = "download_archive"
+url = "https://api.adoptium.net/v3/binary/latest/{version}/ga/mac/aarch64/jdk/hotspot/normal/eclipse"
+archive_format = "tar.gz"
+strip_dirs = 3
+install_mode = "directory"
+binaries = ["bin/java", "bin/javac", "bin/jar"]
+when = { platform = ["darwin/arm64"] }
+
+[verify]
+command = "java --version"
+mode = "output"
+pattern = "Temurin"
+# Match the distribution name rather than the version. The version
+# field is the integer major (e.g. "25"), and `java --version`'s
+# build line includes the substring "Temurin" on every Adoptium-
+# published JDK, so this is a precise distribution check that works
+# across LTS bumps.
+reason = "version is the major integer; pattern matches the Temurin distribution string"


### PR DESCRIPTION
Add `recipes/t/temurin.toml`: a curated cross-platform Eclipse Temurin OpenJDK recipe that uses the http_json version source from #2328 to track Adoptium's current LTS dynamically. Coverage spans every platform Adoptium publishes a JDK build for — glibc Linux (amd64 + arm64), musl Linux / Alpine (amd64 + arm64), and macOS (amd64 + arm64). Each step targets Adoptium's `/v3/binary/latest/{major}/ga/{os}/{arch}/jdk/hotspot/normal/eclipse` redirect endpoint; tsuku's downloader follows the chain and the SHA-256 it computes matches Adoptium's independently-published `binaries[0].package.checksum` for all six platforms, verified locally.

macOS tarballs nest the JDK three levels deep under `jdk-{version}/Contents/Home/`, so the darwin steps use `strip_dirs = 3`; Linux variants nest one level under `jdk-{version}/` and use `strip_dirs = 1`. Verify uses `mode = "output"` with `pattern = "Temurin"` because the resolved version is the major integer (e.g. "25") and `java --version` embeds "Temurin-{version}" in the build line — a precise distribution check that doesn't drift across LTS promotions.

---

## Investigation: what Adoptium actually serves

Per `https://api.adoptium.net/q/openapi`, the `AdoptiumVendor` enum has a single value: `eclipse`. Adoptium itself only publishes Eclipse Temurin builds. The Adoptium Marketplace project (which would have aggregated Liberica, Corretto, Azul, etc. under one API) returns 404 for every documented endpoint, suggesting it's not deployed at api.adoptium.net.

Other major OpenJDK distributions exist but use their own infrastructure — out of scope for this PR but candidates for future recipes:

- Amazon Corretto (`corretto/corretto-N` GitHub releases)
- BellSoft Liberica (`bell-sw/Liberica` GitHub releases — `recipes/l/liberica.toml` already exists as Linux-only batch quality)
- Microsoft Build of OpenJDK (`microsoft/openjdk-binaries`)
- Azul Zulu (`cdn.azul.com/zulu/bin/`)
- IBM Semeru (`ibmruntimes/semeru-openN-binaries`)
- SAP Machine (`SAP/SapMachine`)

Each requires its own version-source pattern; they don't share an API.

This recipe does not declare `[metadata.satisfies]` for `openjdk` because the existing `recipes/o/openjdk.toml` is the canonical satisfier. A user who wants Temurin specifically reaches for `tsuku install temurin`; one who just wants a JDK uses `openjdk`.

## Test plan

- [x] `tsuku validate --strict --check-libc-coverage recipes/t/temurin.toml` — clean
- [x] `tsuku eval` succeeds on linux/amd64, linux/arm64 (glibc + alpine each), darwin/amd64, darwin/arm64
- [x] Independently verified macOS tarball layout (`jdk-{version}/Contents/Home/bin/java`) to confirm `strip_dirs = 3`
- [x] `go test ./internal/recipe/... ./internal/version/...` — passes
- [ ] CI nightly curated-test matrix exercises install + verify on every supported family