### PR TITLE
fix(update): use reporter for outcome lines so TTY spinner replaces in-place

### DIFF
--- a/cmd/tsuku/install_deps.go
+++ b/cmd/tsuku/install_deps.go
@@ -154,6 +154,15 @@ func runInstallWithTelemetry(toolName, reqVersion, versionConstraint string, isE
 	return installWithDependencies(toolName, reqVersion, versionConstraint, isExplicit, parent, make(map[string]bool), client, reporter)
 }
 
+// runInstallWithExternalReporter runs the install flow using a caller-provided
+// reporter. The caller owns the reporter lifecycle (Stop/FlushDeferred). Use
+// this when the caller needs to emit a permanent outcome line via the same
+// reporter after the install completes, so TTY spinner replacement works
+// correctly without mixing output streams.
+func runInstallWithExternalReporter(toolName, reqVersion, versionConstraint string, isExplicit bool, parent string, client *telemetry.Client, reporter progress.Reporter) error {
+	return installWithDependencies(toolName, reqVersion, versionConstraint, isExplicit, parent, make(map[string]bool), client, reporter)
+}
+
 func installWithDependencies(toolName, reqVersion, versionConstraint string, isExplicit bool, parent string, visited map[string]bool, telemetryClient *telemetry.Client, reporter progress.Reporter) error {
 	// Initialize manager for state updates
 	cfg, err := config.DefaultConfig()

--- a/cmd/tsuku/update.go
+++ b/cmd/tsuku/update.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/tsukumogami/tsuku/internal/config"
 	"github.com/tsukumogami/tsuku/internal/install"
+	"github.com/tsukumogami/tsuku/internal/progress"
 	"github.com/tsukumogami/tsuku/internal/telemetry"
 )
 
@@ -124,13 +125,15 @@ Examples:
 			}
 		}
 
-		// Don't print "Updating <tool>..." here — the install
-		// reporter's spinner shows the tool and phase as transient
-		// status, replaced on completion by either "✅ <name>@<version>"
-		// (the install's own permanent line) or, for the no-op case,
-		// the line emitted below by updateOutcomeMessage. See #2280
-		// for the single-line-per-package pattern.
-		if err := runInstallWithTelemetry(toolName, reqVersion, "", true, "", telemetryClient); err != nil {
+		// Create a reporter here so that both the install progress and the
+		// outcome line share the same stream (stderr). This lets the TTY
+		// spinner be replaced in-place by the permanent outcome line via
+		// reporter.Log, rather than the spinner being cleared on stderr and
+		// the outcome appearing on a separate stdout line. See #2280/#2359.
+		reporter := progress.NewTTYReporter(os.Stderr)
+
+		if err := runInstallWithExternalReporter(toolName, reqVersion, "", true, "", telemetryClient, reporter); err != nil {
+			reporter.Stop()
 			if telemetryClient != nil {
 				telemetryClient.SendUpdateOutcome(telemetry.NewUpdateOutcomeFailureEvent(
 					toolName, reqVersion, telemetry.ClassifyError(err), "manual"))
@@ -151,14 +154,14 @@ Examples:
 			}
 		}
 
-		// Surface the outcome so the user sees something after "Updating
-		// <tool>...". The install machinery's "is already installed"
-		// progress message is a transient TTY status that gets cleared on
-		// command exit; without this line, an up-to-date tool produces no
-		// visible output. See #2356.
-		if msg := updateOutcomeMessage(toolName, previousVersion, newVersion); msg != "" {
-			printInfo(msg)
+		// Emit the no-op outcome via the reporter so the TTY spinner is
+		// replaced in-place. The update outcome (new version) is already
+		// handled by the install reporter's "✅ <name>@<version>" line.
+		if msg := updateOutcomeMessage(toolName, previousVersion, newVersion); msg != "" && !quietFlag {
+			reporter.Log("%s", msg)
 		}
+		reporter.Stop()
+		reporter.FlushDeferred()
 
 		// Lifecycle-aware stale cleanup: delete files the old version created
 		// that the new version no longer needs (e.g., shell.d scripts for a
@@ -317,11 +320,14 @@ func runUpdateAll(cmd *cobra.Command) {
 		}
 
 		previousVersion := tool.Version
-		// "Updating <tool>..." is intentionally not printed here for
-		// the same reason as the single-tool path above (#2280): the
-		// install reporter's spinner already shows the tool and phase.
-		if err := runInstallWithTelemetry(tool.Name, requested, "", true, "", telemetryClient); err != nil {
-			fmt.Fprintf(os.Stderr, "  Failed to update %s: %v\n", tool.Name, err)
+
+		// Per-tool reporter so the spinner is replaced in-place by the
+		// outcome line, consistent with the single-tool path.
+		toolReporter := progress.NewTTYReporter(os.Stderr)
+
+		if err := runInstallWithExternalReporter(tool.Name, requested, "", true, "", telemetryClient, toolReporter); err != nil {
+			toolReporter.Log("failed to update %s: %v", tool.Name, err)
+			toolReporter.Stop()
 			if telemetryClient != nil {
 				telemetryClient.SendUpdateOutcome(telemetry.NewUpdateOutcomeFailureEvent(
 					tool.Name, requested, telemetry.ClassifyError(err), "manual-batch"))
@@ -348,15 +354,19 @@ func runUpdateAll(cmd *cobra.Command) {
 				}
 			}
 		}
-		// Print the no-op line only. Real updates already get a
-		// permanent "✅ <name>@<version>" line from the install
-		// reporter (see #2280); a second line here would duplicate it.
+		// Emit the no-op outcome via the reporter so the TTY spinner is
+		// replaced in-place. Real updates already get a permanent
+		// "✅ <name>@<version>" line from the install reporter (#2280).
 		if newVersion == previousVersion {
-			printInfof("  %s is already at the latest version (%s).\n", tool.Name, newVersion)
+			if !quietFlag {
+				toolReporter.Log("%s is already at the latest version (%s).", tool.Name, newVersion)
+			}
 			upToDate++
 		} else {
 			updated++
 		}
+		toolReporter.Stop()
+		toolReporter.FlushDeferred()
 	}
 
 	if updateDryRun {

--- a/recipes/b/btop.toml
+++ b/recipes/b/btop.toml
@@ -14,8 +14,8 @@ supported_os = ["linux"]
 action = "github_archive"
 when = { os = ["linux"], libc = ["glibc", "musl"] }
 repo = "aristocratos/btop"
-asset_pattern = "btop-{arch}-unknown-linux-musl.tbz"
-archive_format = "tbz"
+asset_pattern = "btop-{arch}-unknown-linux-musl.tar.gz"
+archive_format = "tar.gz"
 arch_mapping = { amd64 = "x86_64", arm64 = "aarch64" }
 strip_dirs = 0
 binaries = ["btop/bin/btop"]

--- a/recipes/b/btop.toml
+++ b/recipes/b/btop.toml
@@ -15,7 +15,6 @@ action = "github_archive"
 when = { os = ["linux"], libc = ["glibc", "musl"] }
 repo = "aristocratos/btop"
 asset_pattern = "btop-{arch}-unknown-linux-musl.tar.gz"
-archive_format = "tar.gz"
 arch_mapping = { amd64 = "x86_64", arm64 = "aarch64" }
 strip_dirs = 0
 binaries = ["btop/bin/btop"]


### PR DESCRIPTION
`update.go` emitted the no-op outcome ("already at the latest version") via `printInfo` (stdout) while the install reporter used stderr for both spinner status and the update outcome ("✅ tool@v"). On a TTY this broke the replace-in-place behavior: the spinner cleared on stderr, then the outcome appeared on a separate stdout stream instead of replacing the spinner line.

`install_deps.go` gains `runInstallWithExternalReporter`, which takes a caller-provided reporter so the caller can emit its own permanent line via the same reporter after the install returns. `update.go` creates a `progress.NewTTYReporter` before calling install, passes it through `runInstallWithExternalReporter`, and emits the no-op outcome via `reporter.Log`. The `--all` path applies the same pattern per-tool. `quietFlag` is checked explicitly before `reporter.Log` to preserve `--quiet` behavior. The error path in `--all` is also changed from `fmt.Fprintf` to `toolReporter.Log` for consistent spinner handling.

---

Fixes #2360

## Root cause

`printInfo` writes to stdout; `reporter.Log` writes to stderr. The spinner lives on stderr. Mixing streams means `Stop()` clears the spinner on stderr but the outcome line then appears on stdout — not a replacement, just a subsequent independent line.

## Test plan

- `tsuku update nodejs` (no-op) → "nodejs is already at the latest version (25.9.0)." on stderr, nothing on stdout
- `tsuku update nodejs --quiet` → no output
- `tsuku update --all` (all at latest) → per-tool lines on stderr, summary on stdout
- `go test ./cmd/tsuku/` passes