### PR TITLE
feat(recipe): support multi-pattern verify checks

### DIFF
--- a/cmd/tsuku/verify.go
+++ b/cmd/tsuku/verify.go
@@ -189,6 +189,44 @@ func RunToolVerification(r *recipe.Recipe, toolName string, toolState *install.T
 // makeVerifyEnv creates an environment for verification commands with proper PATH setup.
 // It filters out existing PATH entries and prepends the install directories to ensure
 // the installed tool's binaries are found before system binaries.
+// substitutedVerifyPatterns returns the verify section's pattern(s)
+// with {version} and {install_dir} substituted, normalized into a
+// slice. Returns nil if neither Pattern nor Patterns is set.
+//
+// The validator enforces mutual exclusion between Pattern and
+// Patterns, so at runtime exactly one of them is populated when set.
+func substitutedVerifyPatterns(v *recipe.VerifySection, version, installDir string) []string {
+	subst := func(p string) string {
+		p = strings.ReplaceAll(p, "{version}", version)
+		p = strings.ReplaceAll(p, "{install_dir}", installDir)
+		return p
+	}
+	if len(v.Patterns) > 0 {
+		out := make([]string, len(v.Patterns))
+		for i, p := range v.Patterns {
+			out[i] = subst(p)
+		}
+		return out
+	}
+	if v.Pattern != "" {
+		return []string{subst(v.Pattern)}
+	}
+	return nil
+}
+
+// matchVerifyPatterns returns the patterns that did NOT appear as
+// substrings in output. Empty return = all patterns matched (or no
+// patterns to match — treated as success).
+func matchVerifyPatterns(patterns []string, output string) []string {
+	var missing []string
+	for _, p := range patterns {
+		if !strings.Contains(output, p) {
+			missing = append(missing, p)
+		}
+	}
+	return missing
+}
+
 func makeVerifyEnv(installDir string, cfg *config.Config) []string {
 	// Filter out existing PATH to avoid duplicate entries
 	env := make([]string, 0)
@@ -218,9 +256,7 @@ func runHiddenToolVerification(r *recipe.Recipe, toolName, version, installDir s
 	command = strings.ReplaceAll(command, "{version}", version)
 	command = strings.ReplaceAll(command, "{install_dir}", installDir)
 
-	pattern := r.Verify.Pattern
-	pattern = strings.ReplaceAll(pattern, "{version}", version)
-	pattern = strings.ReplaceAll(pattern, "{install_dir}", installDir)
+	patterns := substitutedVerifyPatterns(r.Verify, version, installDir)
 
 	if opts.Verbose {
 		printInfof("  Running: %s\n", command)
@@ -239,13 +275,11 @@ func runHiddenToolVerification(r *recipe.Recipe, toolName, version, installDir s
 		printInfof("  Output: %s\n", outputStr)
 	}
 
-	if pattern != "" {
-		if !strings.Contains(outputStr, pattern) {
-			return fmt.Errorf("output does not match expected pattern\n  Expected: %s\n  Got: %s", pattern, outputStr)
-		}
-		if opts.Verbose {
-			printInfof("  Pattern matched: %s\n", pattern)
-		}
+	if missing := matchVerifyPatterns(patterns, outputStr); len(missing) > 0 {
+		return fmt.Errorf("output does not match expected pattern(s)\n  Missing: %s\n  Got: %s", strings.Join(missing, ", "), outputStr)
+	}
+	if opts.Verbose && len(patterns) > 0 {
+		printInfof("  Pattern(s) matched: %s\n", strings.Join(patterns, ", "))
 	}
 
 	// Binary integrity verification
@@ -295,7 +329,6 @@ func runVisibleToolVerification(r *recipe.Recipe, toolName string, toolState *in
 	}
 
 	command := r.Verify.Command
-	pattern := r.Verify.Pattern
 
 	version := toolState.Version
 	if toolState.ActiveVersion != "" {
@@ -303,8 +336,7 @@ func runVisibleToolVerification(r *recipe.Recipe, toolName string, toolState *in
 	}
 	command = strings.ReplaceAll(command, "{version}", version)
 	command = strings.ReplaceAll(command, "{install_dir}", installDir)
-	pattern = strings.ReplaceAll(pattern, "{version}", version)
-	pattern = strings.ReplaceAll(pattern, "{install_dir}", installDir)
+	patterns := substitutedVerifyPatterns(r.Verify, version, installDir)
 
 	if opts.Verbose {
 		printInfof("    Running: %s\n", command)
@@ -321,8 +353,8 @@ func runVisibleToolVerification(r *recipe.Recipe, toolName string, toolState *in
 		printInfof("    Output: %s\n", outputStr)
 	}
 
-	if pattern != "" && !strings.Contains(outputStr, pattern) {
-		return fmt.Errorf("pattern mismatch\n  Expected: %s\n  Got: %s", pattern, outputStr)
+	if missing := matchVerifyPatterns(patterns, outputStr); len(missing) > 0 {
+		return fmt.Errorf("pattern mismatch\n  Missing: %s\n  Got: %s", strings.Join(missing, ", "), outputStr)
 	}
 	if opts.Verbose {
 		printInfo("    Installation verified\n")

--- a/cmd/tsuku/verify.go
+++ b/cmd/tsuku/verify.go
@@ -186,9 +186,6 @@ func RunToolVerification(r *recipe.Recipe, toolName string, toolState *install.T
 	return runVisibleToolVerification(r, toolName, toolState, versionState, installDir, cfg, state, opts)
 }
 
-// makeVerifyEnv creates an environment for verification commands with proper PATH setup.
-// It filters out existing PATH entries and prepends the install directories to ensure
-// the installed tool's binaries are found before system binaries.
 // substitutedVerifyPatterns returns the verify section's pattern(s)
 // with {version} and {install_dir} substituted, normalized into a
 // slice. Returns nil if neither Pattern nor Patterns is set.
@@ -227,6 +224,10 @@ func matchVerifyPatterns(patterns []string, output string) []string {
 	return missing
 }
 
+// makeVerifyEnv creates an environment for verification commands with
+// proper PATH setup. It filters out existing PATH entries and prepends
+// the install directories to ensure the installed tool's binaries are
+// found before system binaries.
 func makeVerifyEnv(installDir string, cfg *config.Config) []string {
 	// Filter out existing PATH to avoid duplicate entries
 	env := make([]string, 0)

--- a/cmd/tsuku/verify_test.go
+++ b/cmd/tsuku/verify_test.go
@@ -3,11 +3,109 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/tsukumogami/tsuku/internal/install"
+	"github.com/tsukumogami/tsuku/internal/recipe"
 	"github.com/tsukumogami/tsuku/internal/verify"
 )
+
+func TestSubstitutedVerifyPatterns(t *testing.T) {
+	cases := []struct {
+		name    string
+		verify  recipe.VerifySection
+		version string
+		want    []string
+	}{
+		{
+			name:    "single pattern with version placeholder",
+			verify:  recipe.VerifySection{Pattern: "openjdk {version}"},
+			version: "25.0.3",
+			want:    []string{"openjdk 25.0.3"},
+		},
+		{
+			name:    "multi-pattern with version placeholder in one entry",
+			verify:  recipe.VerifySection{Patterns: []string{"Microsoft", "openjdk {version}"}},
+			version: "25.0.3",
+			want:    []string{"Microsoft", "openjdk 25.0.3"},
+		},
+		{
+			name:    "neither pattern nor patterns",
+			verify:  recipe.VerifySection{},
+			version: "1.0",
+			want:    nil,
+		},
+		{
+			name:    "patterns takes precedence over pattern when somehow both set (validator rejects this)",
+			verify:  recipe.VerifySection{Pattern: "ignored", Patterns: []string{"a", "b"}},
+			version: "9",
+			want:    []string{"a", "b"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := substitutedVerifyPatterns(&tc.verify, tc.version, "/tmp/install")
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("substitutedVerifyPatterns: got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchVerifyPatterns(t *testing.T) {
+	cases := []struct {
+		name        string
+		patterns    []string
+		output      string
+		wantMissing []string
+	}{
+		{
+			name:        "no patterns matches anything",
+			patterns:    nil,
+			output:      "anything",
+			wantMissing: nil,
+		},
+		{
+			name:        "single pattern matched",
+			patterns:    []string{"Temurin-25"},
+			output:      "OpenJDK Runtime Environment Temurin-25.0.3+9 (build ...)",
+			wantMissing: nil,
+		},
+		{
+			name:        "single pattern missed",
+			patterns:    []string{"Temurin-26"},
+			output:      "OpenJDK Runtime Environment Temurin-25.0.3+9 (build ...)",
+			wantMissing: []string{"Temurin-26"},
+		},
+		{
+			name:        "all patterns matched",
+			patterns:    []string{"Microsoft", "openjdk 25"},
+			output:      "openjdk 25.0.3 ...\nOpenJDK Runtime Environment Microsoft-13877136 (build 25.0.3+9-LTS)",
+			wantMissing: nil,
+		},
+		{
+			name:        "one pattern missed reports only that one",
+			patterns:    []string{"Microsoft", "openjdk 26"},
+			output:      "openjdk 25.0.3 ...\nOpenJDK Runtime Environment Microsoft-13877136 (build 25.0.3+9-LTS)",
+			wantMissing: []string{"openjdk 26"},
+		},
+		{
+			name:        "all patterns missed",
+			patterns:    []string{"Corretto", "openjdk 8"},
+			output:      "OpenJDK Runtime Environment Temurin-25.0.3+9",
+			wantMissing: []string{"Corretto", "openjdk 8"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := matchVerifyPatterns(tc.patterns, tc.output)
+			if !reflect.DeepEqual(got, tc.wantMissing) {
+				t.Errorf("matchVerifyPatterns: got %v, want %v", got, tc.wantMissing)
+			}
+		})
+	}
+}
 
 func TestIsSharedLibrary(t *testing.T) {
 	tests := []struct {

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -94,8 +94,10 @@ These issues capture infrastructure and recipe gaps surfaced while authoring the
 |-------|--------------|------------|
 | ~~[#2325: fix(version): treat -Mn milestone tags as pre-releases in GitHub provider](https://github.com/tsukumogami/tsuku/issues/2325)~~ | ~~None~~ | ~~testable~~ |
 | ~~_Replaces the substring-keyword `isStableVersion` filter with a SemVer-aware predicate (any non-empty prerelease component is unstable unless it matches a stable qualifier), plus a non-SemVer fallback to catch markers spliced into the version without a hyphen (e.g., jq's `1.8.2rc1`). Default stable qualifiers `["release", "final", "lts", "ga", "stable"]` admit the common JVM RELEASE/FINAL conventions; the `[version] stable_qualifiers` recipe field overrides for exotic upstreams. Designed in `docs/designs/DESIGN-prerelease-detection.md`._~~ | | |
-| [#2327: feat(recipes): add openjdk recipe to enable JVM tool verification](https://github.com/tsukumogami/tsuku/issues/2327) | None | testable |
-| _Sandbox containers do not bundle a JDK and the registry has no `openjdk` recipe to declare as a dependency. JVM tools (maven, gradle, sbt) install successfully but fail verify because `mvn --version` etc. need a JVM at runtime._ | | |
+| [#2327: feat(recipes): add curated openjdk family (openjdk, temurin, corretto, microsoft-openjdk)](https://github.com/tsukumogami/tsuku/issues/2327) | [#2365](https://github.com/tsukumogami/tsuku/issues/2365) | testable |
+| _Scope expanded from a single openjdk recipe to four cross-platform JDK distribution recipes. `openjdk` is the Homebrew + apk fallback; `temurin`, `corretto`, and `microsoft-openjdk` are vendor-specific recipes that pull from each project's own infrastructure (Adoptium API, corretto.aws, aka.ms). All share Adoptium's `most_recent_lts` integer as the LTS-major source. Sandbox containers do not bundle a JDK and the registry has no `openjdk` recipe to declare as a dependency. JVM tools (maven, gradle, sbt) install successfully but fail verify because `mvn --version` etc. need a JVM at runtime. Blocked on #2365 — `microsoft-openjdk` cannot bind verify to both vendor and version with the current single-pattern verify schema (Microsoft suffixes the vendor name with an internal build hash, not the JDK version)._ |
+| [#2365: feat(recipe): support multi-pattern verify checks](https://github.com/tsukumogami/tsuku/issues/2365) | None | testable |
+| _Extends `[verify]` to accept a `patterns = [...]` array (mutually exclusive with the existing `pattern` field) so recipes can bind multiple independent facts (vendor + version) when those facts appear in non-adjacent positions in the verify command's output. Surfaced by `microsoft-openjdk` in #2327, which prints `Microsoft-{internal-build-hash}` rather than `Microsoft-{version}` and so can't be checked against both vendor and version with a single substring._ | | |
 | ~~[#2328: feat(version): add a version source for Google Cloud SDK to enable gcloud recipe](https://github.com/tsukumogami/tsuku/issues/2328)~~ | ~~None~~ | ~~testable~~ |
 | ~~_Expanded scope from "gcloud_dist custom source" to a generic `http_json` version source per `docs/designs/DESIGN-http-json-version-source.md`. Adds `[version] source = "http_json"` with `url` and `version_path` fields supporting dotted access plus `[N]` array indexing. Authors `recipes/g/gcloud.toml` as the first consumer in the same PR. Deprecates `source = "hashicorp"` (kept for one release window with a runtime warning); removal tracked in #2349. Unblocks Adoptium-based openjdk in #2327 and HashiCorp checkpoint adoption in #2350-style follow-ups when needed._~~ | | |
 | [#2330: feat(recipes): author a working curated bazel recipe](https://github.com/tsukumogami/tsuku/issues/2330) | None | testable |
@@ -141,7 +143,7 @@ authoring they unblock.
 graph TD
     subgraph wave4 ["Wave 4: Follow-ups from milestone work"]
         I2325["#2325: -Mn milestone tags in github provider"]
-        I2327["#2327: openjdk recipe for JVM verify"]
+        I2327["#2327: curated openjdk family (openjdk + temurin + corretto + microsoft-openjdk)"]
         I2328["#2328: http_json source + gcloud recipe"]
         I2330["#2330: working bazel recipe"]
         I2331["#2331: pipx PyPI version constraint"]
@@ -150,6 +152,7 @@ graph TD
         I2336["#2336: tmux + git macOS support"]
         I2338["#2338: curl macOS + rhel sandbox failure"]
         I2349["#2349: remove deprecated hashicorp source"]
+        I2365["#2365: multi-pattern verify (blocks #2327 microsoft-openjdk)"]
     end
 
     subgraph wave5 ["Wave 5: Recipe authoring after Wave 4"]
@@ -161,6 +164,7 @@ graph TD
     I2333 --> I2336
     I2335 --> I2336
 
+    I2365 --> I2327
     I2327 --> I2343
     I2325 --> I2344
     I2327 --> I2344
@@ -178,8 +182,8 @@ graph TD
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
     class I2325,I2328,I2331,I2333 done
-    class I2327,I2330,I2335,I2338 ready
-    class I2336,I2343,I2344,I2345,I2349 blocked
+    class I2330,I2335,I2338,I2365 ready
+    class I2327,I2336,I2343,I2344,I2345,I2349 blocked
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -472,15 +472,17 @@ func (e *Executor) ExecutePlan(ctx context.Context, plan *InstallationPlan) erro
 		// Add verify info if available
 		if plan.Verify != nil && plan.Verify.Command != "" {
 			recipeForContext.Verify = &recipe.VerifySection{
-				Command: plan.Verify.Command,
-				Pattern: plan.Verify.Pattern,
+				Command:  plan.Verify.Command,
+				Pattern:  plan.Verify.Pattern,
+				Patterns: plan.Verify.Patterns,
 			}
 		}
 	} else if (recipeForContext.Verify == nil || recipeForContext.Verify.Command == "") && plan.Verify != nil && plan.Verify.Command != "" {
 		// Recipe exists but has no verify, add from plan
 		recipeForContext.Verify = &recipe.VerifySection{
-			Command: plan.Verify.Command,
-			Pattern: plan.Verify.Pattern,
+			Command:  plan.Verify.Command,
+			Pattern:  plan.Verify.Pattern,
+			Patterns: plan.Verify.Patterns,
 		}
 	}
 
@@ -812,8 +814,9 @@ func (e *Executor) installSingleDependency(ctx context.Context, dep *DependencyP
 	}
 	if dep.Verify != nil {
 		depRecipe.Verify = &recipe.VerifySection{
-			Command: dep.Verify.Command,
-			Pattern: dep.Verify.Pattern,
+			Command:  dep.Verify.Command,
+			Pattern:  dep.Verify.Pattern,
+			Patterns: dep.Verify.Patterns,
 		}
 	}
 

--- a/internal/executor/plan.go
+++ b/internal/executor/plan.go
@@ -79,10 +79,16 @@ type DependencyPlan struct {
 }
 
 // PlanVerify captures verification information from the recipe.
+//
+// Pattern and Patterns mirror VerifySection: Pattern is the legacy
+// single-substring form, Patterns is the multi-substring AND-list.
+// Recipes set one or the other (the validator rejects both), so the
+// plan also carries one or the other.
 type PlanVerify struct {
-	Command  string `json:"command,omitempty"`
-	Pattern  string `json:"pattern,omitempty"`
-	ExitCode *int   `json:"exit_code,omitempty"` // Expected exit code (default: 0)
+	Command  string   `json:"command,omitempty"`
+	Pattern  string   `json:"pattern,omitempty"`
+	Patterns []string `json:"patterns,omitempty"`
+	ExitCode *int     `json:"exit_code,omitempty"` // Expected exit code (default: 0)
 }
 
 // Platform identifies the target operating system and architecture.

--- a/internal/executor/plan_cache.go
+++ b/internal/executor/plan_cache.go
@@ -143,9 +143,10 @@ type depForHashing struct {
 
 // verifyForHash is a normalized PlanVerify for hashing.
 type verifyForHash struct {
-	Command  string `json:"command,omitempty"`
-	ExitCode *int   `json:"exit_code,omitempty"`
-	Pattern  string `json:"pattern,omitempty"`
+	Command  string   `json:"command,omitempty"`
+	ExitCode *int     `json:"exit_code,omitempty"`
+	Pattern  string   `json:"pattern,omitempty"`
+	Patterns []string `json:"patterns,omitempty"`
 }
 
 // planContentForHashing converts an InstallationPlan to a normalized
@@ -188,6 +189,7 @@ func planContentForHashing(plan *InstallationPlan) planForHashing {
 			Command:  plan.Verify.Command,
 			ExitCode: plan.Verify.ExitCode,
 			Pattern:  plan.Verify.Pattern,
+			Patterns: plan.Verify.Patterns,
 		}
 	}
 
@@ -228,6 +230,7 @@ func convertDepsForHashing(deps []DependencyPlan) []depForHashing {
 				Command:  dep.Verify.Command,
 				ExitCode: dep.Verify.ExitCode,
 				Pattern:  dep.Verify.Pattern,
+				Patterns: dep.Verify.Patterns,
 			}
 		}
 	}

--- a/internal/executor/plan_generator.go
+++ b/internal/executor/plan_generator.go
@@ -280,6 +280,7 @@ func (e *Executor) GeneratePlan(ctx context.Context, cfg PlanConfig) (*Installat
 		verify = &PlanVerify{
 			Command:  e.recipe.Verify.Command,
 			Pattern:  e.recipe.Verify.Pattern,
+			Patterns: e.recipe.Verify.Patterns,
 			ExitCode: e.recipe.Verify.ExitCode,
 		}
 	}
@@ -799,6 +800,7 @@ func generateSingleDependencyPlan(
 		verify = &PlanVerify{
 			Command:  depRecipe.Verify.Command,
 			Pattern:  depRecipe.Verify.Pattern,
+			Patterns: depRecipe.Verify.Patterns,
 			ExitCode: depRecipe.Verify.ExitCode,
 		}
 	}

--- a/internal/executor/plan_verify.go
+++ b/internal/executor/plan_verify.go
@@ -4,26 +4,34 @@ import "strings"
 
 // CheckPlanVerification evaluates verify results against expectations.
 // It checks the verify command's exit code against the expected exit code,
-// then checks whether the expected pattern appears in the combined output.
+// then checks whether every entry in patterns appears as a substring in
+// the combined output (AND-semantics, matching VerifySection's two-field
+// schema where pattern and patterns are mutually exclusive but both feed
+// the same matcher here).
 //
 // Returns true when:
-//   - Exit code matches expectedExitCode AND pattern is empty
-//   - Exit code matches expectedExitCode AND pattern is found in output
+//   - Exit code matches expectedExitCode AND patterns is empty
+//   - Exit code matches expectedExitCode AND every entry in patterns
+//     is found in output
 //
 // Returns false when:
 //   - Exit code does not match expectedExitCode
-//   - Exit code matches but pattern is not found in output
+//   - Exit code matches but at least one pattern is not found in output
 //
 // Used by both the sandbox and validate packages to ensure consistent
 // verification behavior.
-func CheckPlanVerification(verifyExitCode int, output string, expectedExitCode int, pattern string) bool {
+func CheckPlanVerification(verifyExitCode int, output string, expectedExitCode int, patterns []string) bool {
 	if verifyExitCode != expectedExitCode {
 		return false
 	}
 
-	if pattern == "" {
-		return true
+	for _, p := range patterns {
+		if p == "" {
+			continue
+		}
+		if !strings.Contains(output, p) {
+			return false
+		}
 	}
-
-	return strings.Contains(output, pattern)
+	return true
 }

--- a/internal/executor/plan_verify_test.go
+++ b/internal/executor/plan_verify_test.go
@@ -5,15 +5,15 @@ import "testing"
 func TestCheckPlanVerification_ExitCodeMatch_EmptyPattern(t *testing.T) {
 	t.Parallel()
 
-	if !CheckPlanVerification(0, "some output", 0, "") {
-		t.Error("Expected true when exit code matches and pattern is empty")
+	if !CheckPlanVerification(0, "some output", 0, nil) {
+		t.Error("Expected true when exit code matches and patterns is empty")
 	}
 }
 
 func TestCheckPlanVerification_ExitCodeMismatch(t *testing.T) {
 	t.Parallel()
 
-	if CheckPlanVerification(1, "some output", 0, "") {
+	if CheckPlanVerification(1, "some output", 0, nil) {
 		t.Error("Expected false when exit code does not match")
 	}
 }
@@ -21,7 +21,7 @@ func TestCheckPlanVerification_ExitCodeMismatch(t *testing.T) {
 func TestCheckPlanVerification_PatternMatch(t *testing.T) {
 	t.Parallel()
 
-	if !CheckPlanVerification(0, "ruff 0.4.1", 0, "ruff") {
+	if !CheckPlanVerification(0, "ruff 0.4.1", 0, []string{"ruff"}) {
 		t.Error("Expected true when exit code matches and pattern found in output")
 	}
 }
@@ -29,7 +29,7 @@ func TestCheckPlanVerification_PatternMatch(t *testing.T) {
 func TestCheckPlanVerification_PatternMismatch(t *testing.T) {
 	t.Parallel()
 
-	if CheckPlanVerification(0, "some other output", 0, "ruff") {
+	if CheckPlanVerification(0, "some other output", 0, []string{"ruff"}) {
 		t.Error("Expected false when exit code matches but pattern not found")
 	}
 }
@@ -38,13 +38,32 @@ func TestCheckPlanVerification_NonDefaultExpectedExitCode(t *testing.T) {
 	t.Parallel()
 
 	// Verify command that intentionally exits with code 2
-	if !CheckPlanVerification(2, "expected output", 2, "expected") {
+	if !CheckPlanVerification(2, "expected output", 2, []string{"expected"}) {
 		t.Error("Expected true when non-default exit code matches and pattern found")
 	}
 
 	// Wrong exit code when expecting non-default
-	if CheckPlanVerification(0, "expected output", 2, "expected") {
+	if CheckPlanVerification(0, "expected output", 2, []string{"expected"}) {
 		t.Error("Expected false when exit code 0 does not match expected 2")
+	}
+}
+
+func TestCheckPlanVerification_MultiPatternAllMatch(t *testing.T) {
+	t.Parallel()
+
+	output := "openjdk 25.0.3\nOpenJDK Runtime Environment Microsoft-13877136 (build 25.0.3+9-LTS)"
+	if !CheckPlanVerification(0, output, 0, []string{"Microsoft", "openjdk 25"}) {
+		t.Error("Expected true when both vendor and version patterns match")
+	}
+}
+
+func TestCheckPlanVerification_MultiPatternOneMissing(t *testing.T) {
+	t.Parallel()
+
+	output := "openjdk 25.0.3\nOpenJDK Runtime Environment Microsoft-13877136"
+	// Wrong major — should fail.
+	if CheckPlanVerification(0, output, 0, []string{"Microsoft", "openjdk 26"}) {
+		t.Error("Expected false when one of multiple patterns is missing")
 	}
 }
 
@@ -56,15 +75,15 @@ func TestCheckPlanVerification_TableDriven(t *testing.T) {
 		verifyExitCode   int
 		output           string
 		expectedExitCode int
-		pattern          string
+		patterns         []string
 		want             bool
 	}{
 		{
-			name:             "exit code 0, no pattern",
+			name:             "exit code 0, no patterns",
 			verifyExitCode:   0,
 			output:           "",
 			expectedExitCode: 0,
-			pattern:          "",
+			patterns:         nil,
 			want:             true,
 		},
 		{
@@ -72,7 +91,7 @@ func TestCheckPlanVerification_TableDriven(t *testing.T) {
 			verifyExitCode:   0,
 			output:           "tool v1.2.3",
 			expectedExitCode: 0,
-			pattern:          "v1.2.3",
+			patterns:         []string{"v1.2.3"},
 			want:             true,
 		},
 		{
@@ -80,15 +99,15 @@ func TestCheckPlanVerification_TableDriven(t *testing.T) {
 			verifyExitCode:   0,
 			output:           "tool v1.2.3",
 			expectedExitCode: 0,
-			pattern:          "v2.0.0",
+			patterns:         []string{"v2.0.0"},
 			want:             false,
 		},
 		{
-			name:             "exit code mismatch, no pattern",
+			name:             "exit code mismatch, no patterns",
 			verifyExitCode:   1,
 			output:           "",
 			expectedExitCode: 0,
-			pattern:          "",
+			patterns:         nil,
 			want:             false,
 		},
 		{
@@ -96,7 +115,7 @@ func TestCheckPlanVerification_TableDriven(t *testing.T) {
 			verifyExitCode:   1,
 			output:           "tool v1.2.3",
 			expectedExitCode: 0,
-			pattern:          "v1.2.3",
+			patterns:         []string{"v1.2.3"},
 			want:             false,
 		},
 		{
@@ -104,7 +123,7 @@ func TestCheckPlanVerification_TableDriven(t *testing.T) {
 			verifyExitCode:   42,
 			output:           "some output",
 			expectedExitCode: 42,
-			pattern:          "some",
+			patterns:         []string{"some"},
 			want:             true,
 		},
 		{
@@ -112,18 +131,34 @@ func TestCheckPlanVerification_TableDriven(t *testing.T) {
 			verifyExitCode:   0,
 			output:           "line1\nline2\ntool v1.0\nline4",
 			expectedExitCode: 0,
-			pattern:          "tool v1.0",
+			patterns:         []string{"tool v1.0"},
 			want:             true,
+		},
+		{
+			name:             "two patterns both match",
+			verifyExitCode:   0,
+			output:           "vendor X version 1.0",
+			expectedExitCode: 0,
+			patterns:         []string{"vendor X", "version 1.0"},
+			want:             true,
+		},
+		{
+			name:             "two patterns, second missing",
+			verifyExitCode:   0,
+			output:           "vendor X version 1.0",
+			expectedExitCode: 0,
+			patterns:         []string{"vendor X", "version 2.0"},
+			want:             false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := CheckPlanVerification(tt.verifyExitCode, tt.output, tt.expectedExitCode, tt.pattern)
+			got := CheckPlanVerification(tt.verifyExitCode, tt.output, tt.expectedExitCode, tt.patterns)
 			if got != tt.want {
-				t.Errorf("CheckPlanVerification(%d, %q, %d, %q) = %v, want %v",
-					tt.verifyExitCode, tt.output, tt.expectedExitCode, tt.pattern, got, tt.want)
+				t.Errorf("CheckPlanVerification(%d, %q, %d, %v) = %v, want %v",
+					tt.verifyExitCode, tt.output, tt.expectedExitCode, tt.patterns, got, tt.want)
 			}
 		})
 	}

--- a/internal/recipe/types.go
+++ b/internal/recipe/types.go
@@ -144,6 +144,16 @@ func (r *Recipe) ToTOML() ([]byte, error) {
 		if r.Verify.Pattern != "" {
 			buf.WriteString(fmt.Sprintf("pattern = %q\n", r.Verify.Pattern))
 		}
+		if len(r.Verify.Patterns) > 0 {
+			buf.WriteString("patterns = [")
+			for i, p := range r.Verify.Patterns {
+				if i > 0 {
+					buf.WriteString(", ")
+				}
+				buf.WriteString(fmt.Sprintf("%q", p))
+			}
+			buf.WriteString("]\n")
+		}
 	}
 
 	return []byte(buf.String()), nil
@@ -807,10 +817,18 @@ const (
 	VersionFormatStripV = "strip_v"
 )
 
-// VerifySection defines how to verify the installation
+// VerifySection defines how to verify the installation.
+//
+// Pattern and Patterns are mutually exclusive: set one or the other.
+// Pattern (single substring) covers the common case where one match
+// confirms the install. Patterns (substring AND-list) is for tools
+// whose `--version` output prints multiple independent identifying
+// strings in non-adjacent positions — e.g., a vendor name on one line
+// and the version on another — where one substring can't bind both.
 type VerifySection struct {
 	Command       string             `toml:"command"`
 	Pattern       string             `toml:"pattern"`
+	Patterns      []string           `toml:"patterns,omitempty"`
 	Mode          string             `toml:"mode,omitempty"`
 	VersionFormat string             `toml:"version_format,omitempty"`
 	Reason        string             `toml:"reason,omitempty"`

--- a/internal/recipe/validator.go
+++ b/internal/recipe/validator.go
@@ -513,6 +513,20 @@ func validateVerify(result *ValidationResult, r *Recipe) {
 		return
 	}
 
+	// pattern and patterns are mutually exclusive — pick one shape per recipe.
+	if r.Verify.Pattern != "" && len(r.Verify.Patterns) > 0 {
+		result.addError("verify.patterns", "pattern and patterns cannot both be set; pick one")
+	}
+	// patterns, when present, must have at least one entry — an empty list
+	// would silently match every output and defeat verify.
+	if len(r.Verify.Patterns) > 0 {
+		for i, p := range r.Verify.Patterns {
+			if p == "" {
+				result.addError(fmt.Sprintf("verify.patterns[%d]", i), "pattern entry is empty")
+			}
+		}
+	}
+
 	// Check for dangerous patterns in verify command
 	validateDangerousPatterns(result, r.Verify.Command)
 
@@ -579,10 +593,23 @@ func validateVerifyMode(result *ValidationResult, r *Recipe) {
 
 	switch mode {
 	case VerifyModeVersion:
-		// Version mode should have {version} in pattern for proper verification
-		// This is a warning because version_format transforms can normalize versions
+		// Version mode should have {version} somewhere in the pattern(s)
+		// for proper verification. This is a warning because version_format
+		// transforms can normalize versions.
 		if r.Verify.Pattern != "" && !strings.Contains(r.Verify.Pattern, "{version}") {
 			result.addWarning("verify.pattern", "version mode pattern should include {version} for proper verification")
+		}
+		if len(r.Verify.Patterns) > 0 {
+			anyHasVersion := false
+			for _, p := range r.Verify.Patterns {
+				if strings.Contains(p, "{version}") {
+					anyHasVersion = true
+					break
+				}
+			}
+			if !anyHasVersion {
+				result.addWarning("verify.patterns", "version mode patterns should include {version} in at least one entry for proper verification")
+			}
 		}
 
 	case VerifyModeOutput:

--- a/internal/recipe/validator.go
+++ b/internal/recipe/validator.go
@@ -517,8 +517,15 @@ func validateVerify(result *ValidationResult, r *Recipe) {
 	if r.Verify.Pattern != "" && len(r.Verify.Patterns) > 0 {
 		result.addError("verify.patterns", "pattern and patterns cannot both be set; pick one")
 	}
-	// patterns, when present, must have at least one entry — an empty list
-	// would silently match every output and defeat verify.
+	// `patterns = []` is just as wrong as forgetting to set anything — it
+	// would collapse to "no patterns" at runtime and silently pass any
+	// output. The TOML decoder distinguishes a missing field (Patterns
+	// stays nil) from an explicit empty array (non-nil, length zero).
+	if r.Verify.Patterns != nil && len(r.Verify.Patterns) == 0 {
+		result.addError("verify.patterns", "patterns is set but empty; remove the field or add at least one entry")
+	}
+	// Each entry must be non-empty too — same reasoning, on a per-entry
+	// basis. An empty string substring matches every output.
 	if len(r.Verify.Patterns) > 0 {
 		for i, p := range r.Verify.Patterns {
 			if p == "" {

--- a/internal/recipe/validator_test.go
+++ b/internal/recipe/validator_test.go
@@ -285,6 +285,97 @@ command = "test"
 	}
 }
 
+func TestValidateBytes_VerifyPatternsMutex(t *testing.T) {
+	// Both pattern and patterns set — must be rejected.
+	recipe := `
+[metadata]
+name = "test"
+
+[[steps]]
+action = "download"
+url = "https://example.com/test.tar.gz"
+
+[verify]
+command = "test --version"
+mode = "output"
+pattern = "test"
+patterns = ["test", "version"]
+reason = "test"
+`
+	result := ValidateBytes([]byte(recipe))
+	if result.Valid {
+		t.Fatal("expected invalid recipe when both pattern and patterns are set")
+	}
+	if !hasError(result, "verify.patterns", "cannot both be set") {
+		t.Errorf("expected mutex error, got errors: %+v", result.Errors)
+	}
+}
+
+func TestValidateBytes_VerifyPatternsEmptyEntry(t *testing.T) {
+	recipe := `
+[metadata]
+name = "test"
+
+[[steps]]
+action = "download"
+url = "https://example.com/test.tar.gz"
+
+[verify]
+command = "test --version"
+mode = "output"
+patterns = ["valid", ""]
+reason = "test"
+`
+	result := ValidateBytes([]byte(recipe))
+	if result.Valid {
+		t.Fatal("expected invalid recipe when patterns has an empty entry")
+	}
+	if !hasError(result, "verify.patterns[1]", "empty") {
+		t.Errorf("expected empty-entry error, got errors: %+v", result.Errors)
+	}
+}
+
+func TestValidateBytes_VerifyPatternsVersionModeWarning(t *testing.T) {
+	// version mode (default) without {version} in any patterns entry
+	// should warn the same way single-pattern mode does today.
+	recipe := `
+[metadata]
+name = "test"
+
+[[steps]]
+action = "download"
+url = "https://example.com/test.tar.gz"
+
+[verify]
+command = "test --version"
+patterns = ["Vendor", "release"]
+`
+	result := ValidateBytes([]byte(recipe))
+	if !hasWarning(result, "verify.patterns", "{version}") {
+		t.Errorf("expected version-mode warning, got warnings: %+v", result.Warnings)
+	}
+}
+
+func TestValidateBytes_VerifyPatternsVersionModeNoWarning(t *testing.T) {
+	// At least one entry has {version} — no warning.
+	recipe := `
+[metadata]
+name = "test"
+
+[[steps]]
+action = "download"
+url = "https://example.com/test.tar.gz"
+
+[verify]
+command = "test --version"
+patterns = ["Vendor", "build {version}"]
+`
+	result := ValidateBytes([]byte(recipe))
+	if hasWarning(result, "verify.patterns", "{version}") {
+		t.Errorf("did not expect version-mode warning when one entry has {version}; warnings: %+v", result.Warnings)
+	}
+}
+
 func TestValidateBytes_MissingVerifyCommand(t *testing.T) {
 	recipe := `
 [metadata]

--- a/internal/recipe/validator_test.go
+++ b/internal/recipe/validator_test.go
@@ -311,6 +311,32 @@ reason = "test"
 	}
 }
 
+func TestValidateBytes_VerifyPatternsEmptyArray(t *testing.T) {
+	// `patterns = []` must be rejected — a non-nil empty list collapses
+	// to "no patterns" at runtime and would silently pass any output.
+	recipe := `
+[metadata]
+name = "test"
+
+[[steps]]
+action = "download"
+url = "https://example.com/test.tar.gz"
+
+[verify]
+command = "test --version"
+mode = "output"
+patterns = []
+reason = "test"
+`
+	result := ValidateBytes([]byte(recipe))
+	if result.Valid {
+		t.Fatal("expected invalid recipe when patterns is set to an empty array")
+	}
+	if !hasError(result, "verify.patterns", "set but empty") {
+		t.Errorf("expected empty-array error, got errors: %+v", result.Errors)
+	}
+}
+
 func TestValidateBytes_VerifyPatternsEmptyEntry(t *testing.T) {
 	recipe := `
 [metadata]

--- a/internal/sandbox/executor.go
+++ b/internal/sandbox/executor.go
@@ -480,12 +480,32 @@ func (e *Executor) readVerifyResults(outputDir string, plan *executor.Installati
 		expectedExitCode = *plan.Verify.ExitCode
 	}
 
-	// Expand {version} in the pattern to the resolved version string.
+	// Expand {version} in the pattern(s) to the resolved version string.
 	// The plan stores patterns verbatim from the recipe (e.g. "{version}"),
 	// but the tool output contains the actual version number.
-	pattern := strings.ReplaceAll(plan.Verify.Pattern, "{version}", plan.Version)
-	verified := executor.CheckPlanVerification(verifyExitCode, output, expectedExitCode, pattern)
+	patterns := planVerifyPatterns(plan.Verify, plan.Version)
+	verified := executor.CheckPlanVerification(verifyExitCode, output, expectedExitCode, patterns)
 	return verified, verifyExitCode, output
+}
+
+// planVerifyPatterns returns the verify patterns from a PlanVerify with
+// {version} substituted. Patterns takes precedence over Pattern when set
+// (the validator already enforces mutual exclusion at recipe parse time).
+func planVerifyPatterns(v *executor.PlanVerify, version string) []string {
+	subst := func(p string) string {
+		return strings.ReplaceAll(p, "{version}", version)
+	}
+	if len(v.Patterns) > 0 {
+		out := make([]string, len(v.Patterns))
+		for i, p := range v.Patterns {
+			out[i] = subst(p)
+		}
+		return out
+	}
+	if v.Pattern != "" {
+		return []string{subst(v.Pattern)}
+	}
+	return nil
 }
 
 // augmentWithInfrastructurePackages adds packages needed for sandbox execution

--- a/internal/validate/executor.go
+++ b/internal/validate/executor.go
@@ -337,13 +337,17 @@ func (e *Executor) checkVerification(r *recipe.Recipe, result *RunResult) bool {
 		expectedExitCode = *r.Verify.ExitCode
 	}
 
-	pattern := ""
+	var patterns []string
 	if r.Verify != nil {
-		pattern = r.Verify.Pattern
+		if len(r.Verify.Patterns) > 0 {
+			patterns = r.Verify.Patterns
+		} else if r.Verify.Pattern != "" {
+			patterns = []string{r.Verify.Pattern}
+		}
 	}
 
 	output := result.Stdout + result.Stderr
-	return planexec.CheckPlanVerification(result.ExitCode, output, expectedExitCode, pattern)
+	return planexec.CheckPlanVerification(result.ExitCode, output, expectedExitCode, patterns)
 }
 
 // GetAssetChecksum returns the SHA256 checksum of a downloaded asset.

--- a/recipes/b/btop.toml
+++ b/recipes/b/btop.toml
@@ -14,8 +14,7 @@ supported_os = ["linux"]
 action = "github_archive"
 when = { os = ["linux"], libc = ["glibc", "musl"] }
 repo = "aristocratos/btop"
-asset_pattern = "btop-{arch}-unknown-linux-musl.tbz"
-archive_format = "tbz"
+asset_pattern = "btop-{arch}-unknown-linux-musl.tar.gz"
 arch_mapping = { amd64 = "x86_64", arm64 = "aarch64" }
 strip_dirs = 0
 binaries = ["btop/bin/btop"]


### PR DESCRIPTION
Extend `[verify]` to accept a `patterns = [...]` array (mutually exclusive with the existing `pattern` field) so recipes can bind multiple independent facts against the verify command's output via substring AND-matching. Threads the new field through every consumer of the verify section: `internal/recipe/types.go` schema, `internal/recipe/validator.go` rules (mutex with `pattern`, reject empty array, reject empty entries, warn in version mode when no entry has `{version}`), `internal/executor/plan.go`'s `PlanVerify` plus the plan generator and plan cache, `internal/sandbox/executor.go` and `internal/validate/executor.go` (the curated nightly's verification path), and the visible/hidden post-install verification paths in `cmd/tsuku/verify.go`. `CheckPlanVerification` migrates from `pattern string` to `patterns []string` with AND-semantics — the function is internal to the project and both production callers update in this PR.

The single-substring `pattern` field is the right shape when one match confirms the install. It breaks down when the facts to confirm appear in non-adjacent positions in the output. Concrete case from PR #2362's curated openjdk family: Microsoft's Build of OpenJDK prints `OpenJDK Runtime Environment Microsoft-{internal-build-hash}` with the JDK version on a different line, where one substring can verify the vendor or the version but not both. Multi-pattern AND lets the recipe assert both: `patterns = ["Microsoft", "openjdk {version}"]`.

Also includes a docs/plans/PLAN-curated-recipes.md update (cherry-picked from PR #2362's branch) that records this issue as a Wave 4 blocker for the openjdk family.

---

## What this enables

PR #2362's `recipes/m/microsoft-openjdk.toml` switches from `pattern = "Microsoft"` (vendor-only) to `patterns = ["Microsoft", "openjdk {version}"]` (vendor + version) once this PR lands. PR #2362 is held open on that switch.

## Test plan

- [x] `go test ./...` — passes across recipe, executor, sandbox, validate, cmd/tsuku
- [x] Validator unit tests cover: pattern+patterns mutex error, `patterns = []` empty-array error, empty-entry error, version-mode warning when no entry has `{version}`, no-warning when at least one entry has `{version}`
- [x] Helper unit tests cover: `substitutedVerifyPatterns` precedence and substitution, `matchVerifyPatterns` AND-semantics with named missing-pattern reporting
- [x] `CheckPlanVerification` table-driven tests migrated to `[]string` plus new multi-pattern AND/missing cases
- [x] End-to-end: `tsuku validate --strict` rejects each negative case, accepts each positive case, and existing single-`pattern` recipes still validate
- [x] End-to-end: `tsuku install` against a recipe using `patterns` runs through verify and matches AND-semantics; missing patterns are named in the error
- [ ] CI nightly curated-test matrix — PR #2362's microsoft-openjdk recipe will exercise the schema in production once both PRs are merged

Closes #2365.