### PR TITLE
fix(recipes): curate pcre2 with macOS dylibs and uniform Linux source build

### DIFF
--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -108,8 +108,8 @@ These issues capture infrastructure and recipe gaps surfaced while authoring the
 | ~~_Resolved with a different mechanism than the title suggests. Recipes do not declare PyPI version constraints; instead, `PyPIProvider.ResolveLatest` filters by per-release `requires_python` against the bundled `python-standalone` major.minor. Auto-resolution picks the newest stable, non-yanked, Python-compatible release. Lands `recipes/a/ansible.toml` as the proof point. azure-cli is deferred — its eval already succeeds and its post-install failure is a separate transitive C-extension ABI issue. See `docs/designs/current/DESIGN-pipx-pypi-version-pinning.md`._~~ | | |
 | ~~[#2333: fix(homebrew): resolve revision-suffixed bottles so libevent darwin can be installed](https://github.com/tsukumogami/tsuku/issues/2333)~~ | ~~None~~ | ~~testable~~ |
 | ~~_The homebrew action now fetches `revision` from formulae.brew.sh and constructs `<version>_<revision>` for both the manifest URL and the ref-name match when revision >= 1; the shared matcher accepts both unrevised and revision-suffixed entry forms within a single manifest. `recipes/l/libevent.toml` ships with darwin support and the macOS dylib outputs (`libevent-2.1.7.dylib` and the static archives) so tmux's @rpath resolves at runtime._~~ | | |
-| [#2335: fix(recipes): curate pcre2 with macOS dylib outputs and fix rhel + alpine sandbox failures](https://github.com/tsukumogami/tsuku/issues/2335) | None | testable |
-| _pcre2 fails on RHEL glibc and Alpine musl (`install_exit_code = 0`, `passed = false`). Touching the recipe to add macOS dylib outputs surfaces the failures. The `libpcre2-8.0.dylib` expansion and the RHEL/Alpine investigation belong together. Blocks git darwin._ | | |
+| ~~[#2335: fix(recipes): curate pcre2 with macOS dylib outputs and fix rhel + alpine sandbox failures](https://github.com/tsukumogami/tsuku/issues/2335)~~ | ~~None~~ | ~~testable~~ |
+| ~~_Resolved by switching all glibc + musl Linux to a uniform source build with `--disable-bzip2 --disable-readline --disable-shared --enable-static`. Static linking sidesteps the Linuxbrew bottle's hard-coded `libbz2.so.1.0` (RHEL ships only `libbz2.so.1`), the Alpine musl loader's missing search of `install_dir/lib`, and a Fedora-only segfault during dynamic-linker startup. macOS keeps the homebrew bottle and `install_mode = "directory"` publishes the full bottle layout (dylibs, .a, headers, pkg-config) so the homebrew git bottle's @rpath resolves `libpcre2-8.0.dylib`. Recipe marked `curated = true`._~~ | | |
 | [#2336: feat(recipes): add macOS support to tmux and git recipes](https://github.com/tsukumogami/tsuku/issues/2336) | [#2333](https://github.com/tsukumogami/tsuku/issues/2333), [#2335](https://github.com/tsukumogami/tsuku/issues/2335) | testable |
 | _Once libevent and pcre2 macOS support land, drop `supported_os = ["linux"]` from `recipes/t/tmux.toml` and `recipes/g/git.toml` and add darwin homebrew steps wired to the right `runtime_dependencies`. Same shape as the curl and wget changes in #2337._ | | |
 | [#2338: fix(recipes): add macOS support to curl and resolve rhel sandbox verify failure](https://github.com/tsukumogami/tsuku/issues/2338) | None | testable |
@@ -185,9 +185,9 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2325,I2327,I2328,I2330,I2331,I2333,I2365,I2368 done
-    class I2335,I2338 ready
-    class I2336,I2343,I2344,I2345,I2349 blocked
+    class I2325,I2327,I2328,I2330,I2331,I2333,I2335,I2365,I2368 done
+    class I2336,I2338 ready
+    class I2343,I2344,I2345,I2349 blocked
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan

--- a/recipes/p/pcre2.toml
+++ b/recipes/p/pcre2.toml
@@ -9,13 +9,14 @@ curated = true
 [metadata.satisfies]
 homebrew = ["pcre2"]
 
-# Linux x86_64 (glibc + musl): build from source with static-only linking.
-# Two configure decisions drive the flags below:
+# Linux (glibc + musl): build from source with static-only linking. Two
+# configure decisions drive the flags below:
 #
 #   --disable-bzip2 --disable-readline drop the transitive deps that the
 #   Linuxbrew bottle would have pulled in. The bottle hard-codes
 #   libbz2.so.1.0, which RHEL ships only as libbz2.so.1; Alpine omits
-#   readline entirely. Skipping both lets the source build run uniformly.
+#   readline entirely. Skipping both lets the source build run uniformly
+#   on every Linux family.
 #
 #   --disable-shared --enable-static makes pcre2grep/pcre2test link the
 #   library statically into each binary. This is what makes Alpine pass
@@ -28,110 +29,36 @@ homebrew = ["pcre2"]
 #
 # pcre2grep loses the -Z (bzip2-compressed input) option and pcre2test
 # loses its readline-backed interactive mode; downstream consumers (git's
-# regex APIs, pcre2grep on plain text) do not use either feature.
-#
-# Linux arm64+glibc keeps the Linuxbrew bottle path because the source
-# build fails to plan in the arm64 sandbox (`install_exit_code = null`
-# before the container starts) for reasons that don't reproduce on
-# x86_64 — needs follow-up. The bottle's libbz2 transitive dep that
-# breaks x86_64+rhel is not addressed for arm64+rhel; that platform
-# pair stays in its pre-PR failing state.
+# regex APIs, pcre2grep on plain text) do not use either feature. Recipes
+# that need pcre2 as a dynamic library on Linux (none currently curated;
+# see grep, aircrack-ng, httpd) would need a follow-up change to publish
+# the .so under runtime_dependencies.
 [[steps]]
 action = "download"
-when = { os = ["linux"], libc = ["glibc"], arch = "amd64" }
-url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.gz"
-checksum_url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.gz.sha256"
-
-[[steps]]
-action = "download"
-when = { os = ["linux"], libc = ["musl"] }
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.gz"
 checksum_url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.gz.sha256"
 
 [[steps]]
 action = "extract"
-when = { os = ["linux"], libc = ["glibc"], arch = "amd64" }
-archive = "pcre2-{version}.tar.gz"
-format = "tar.gz"
-
-[[steps]]
-action = "extract"
-when = { os = ["linux"], libc = ["musl"] }
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 archive = "pcre2-{version}.tar.gz"
 format = "tar.gz"
 
 [[steps]]
 action = "setup_build_env"
-when = { os = ["linux"], libc = ["glibc"], arch = "amd64" }
-
-[[steps]]
-action = "setup_build_env"
-when = { os = ["linux"], libc = ["musl"] }
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 
 [[steps]]
 action = "configure_make"
-when = { os = ["linux"], libc = ["glibc"], arch = "amd64" }
-source_dir = "pcre2-{version}"
-configure_args = ["--disable-bzip2", "--disable-readline", "--disable-shared", "--enable-static"]
-executables = ["pcre2grep", "pcre2test"]
-
-[[steps]]
-action = "configure_make"
-when = { os = ["linux"], libc = ["musl"] }
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 source_dir = "pcre2-{version}"
 configure_args = ["--disable-bzip2", "--disable-readline", "--disable-shared", "--enable-static"]
 executables = ["pcre2grep", "pcre2test"]
 
 [[steps]]
 action = "install_binaries"
-when = { os = ["linux"], libc = ["glibc"], arch = "amd64" }
-install_mode = "directory"
-outputs = ["bin/pcre2grep", "bin/pcre2test"]
-
-[[steps]]
-action = "install_binaries"
-when = { os = ["linux"], libc = ["musl"] }
-install_mode = "directory"
-outputs = ["bin/pcre2grep", "bin/pcre2test"]
-
-# Linux arm64+glibc: source build with shared linking + set_rpath. Mirrors
-# curl's pattern. The static-only build that works for x86_64 errors out
-# before sandbox start in CI on arm64 (`install_exit_code = null` for
-# debian/rhel/suse, alpine passes); shared linking with $ORIGIN-based
-# RPATH is the configuration that other arm64 source-built recipes
-# (curl) use successfully.
-[[steps]]
-action = "download"
-when = { os = ["linux"], libc = ["glibc"], arch = "arm64" }
-url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.gz"
-checksum_url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.gz.sha256"
-
-[[steps]]
-action = "extract"
-when = { os = ["linux"], libc = ["glibc"], arch = "arm64" }
-archive = "pcre2-{version}.tar.gz"
-format = "tar.gz"
-
-[[steps]]
-action = "setup_build_env"
-when = { os = ["linux"], libc = ["glibc"], arch = "arm64" }
-
-[[steps]]
-action = "configure_make"
-when = { os = ["linux"], libc = ["glibc"], arch = "arm64" }
-source_dir = "pcre2-{version}"
-configure_args = ["--disable-bzip2", "--disable-readline"]
-executables = ["pcre2grep", "pcre2test"]
-
-[[steps]]
-action = "set_rpath"
-when = { os = ["linux"], libc = ["glibc"], arch = "arm64" }
-binaries = [".install/bin/pcre2grep", ".install/bin/pcre2test"]
-rpath = "$ORIGIN/../lib"
-
-[[steps]]
-action = "install_binaries"
-when = { os = ["linux"], libc = ["glibc"], arch = "arm64" }
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 install_mode = "directory"
 outputs = ["bin/pcre2grep", "bin/pcre2test"]
 

--- a/recipes/p/pcre2.toml
+++ b/recipes/p/pcre2.toml
@@ -94,14 +94,40 @@ when = { os = ["linux"], libc = ["musl"] }
 install_mode = "directory"
 outputs = ["bin/pcre2grep", "bin/pcre2test"]
 
-# Linux arm64+glibc: Homebrew bottle. Pre-existing behavior — passes on
-# debian/suse, fails on rhel (libbz2 transitive dep). Source build was
-# tried on this platform but errors out before sandbox start in CI; see
-# the comment block above for the full context.
+# Linux arm64+glibc: source build with shared linking + set_rpath. Mirrors
+# curl's pattern. The static-only build that works for x86_64 errors out
+# before sandbox start in CI on arm64 (`install_exit_code = null` for
+# debian/rhel/suse, alpine passes); shared linking with $ORIGIN-based
+# RPATH is the configuration that other arm64 source-built recipes
+# (curl) use successfully.
 [[steps]]
-action = "homebrew"
-formula = "pcre2"
+action = "download"
 when = { os = ["linux"], libc = ["glibc"], arch = "arm64" }
+url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.gz"
+checksum_url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.gz.sha256"
+
+[[steps]]
+action = "extract"
+when = { os = ["linux"], libc = ["glibc"], arch = "arm64" }
+archive = "pcre2-{version}.tar.gz"
+format = "tar.gz"
+
+[[steps]]
+action = "setup_build_env"
+when = { os = ["linux"], libc = ["glibc"], arch = "arm64" }
+
+[[steps]]
+action = "configure_make"
+when = { os = ["linux"], libc = ["glibc"], arch = "arm64" }
+source_dir = "pcre2-{version}"
+configure_args = ["--disable-bzip2", "--disable-readline"]
+executables = ["pcre2grep", "pcre2test"]
+
+[[steps]]
+action = "set_rpath"
+when = { os = ["linux"], libc = ["glibc"], arch = "arm64" }
+binaries = [".install/bin/pcre2grep", ".install/bin/pcre2test"]
+rpath = "$ORIGIN/../lib"
 
 [[steps]]
 action = "install_binaries"

--- a/recipes/p/pcre2.toml
+++ b/recipes/p/pcre2.toml
@@ -1,55 +1,81 @@
 [metadata]
 name = "pcre2"
-description = "Perl compatible regular expressions library with a new API"
+description = "Perl-compatible regular expressions library with a new API"
 homepage = "https://www.pcre.org/"
 type = "library"
 binaries = ["bin/pcre2grep", "bin/pcre2test"]
+curated = true
 
 [metadata.satisfies]
 homebrew = ["pcre2"]
 
-# glibc Linux: Homebrew bottle
-[[steps]]
-action = "homebrew"
-formula = "pcre2"
-when = { os = ["linux"], libc = ["glibc"] }
-
-[[steps]]
-action = "install_binaries"
-install_mode = "directory"
-outputs = ["bin/pcre2grep", "bin/pcre2test"]
-when = { os = ["linux"], libc = ["glibc"] }
-
-# musl Linux: compile from source
+# Linux (glibc + musl): build from source with static-only linking. Two
+# configure decisions drive the flags below:
+#
+#   --disable-bzip2 --disable-readline drop the transitive deps that the
+#   Linuxbrew bottle would have pulled in. The bottle hard-codes
+#   libbz2.so.1.0, which RHEL ships only as libbz2.so.1; Alpine omits
+#   readline entirely. Skipping both lets the source build run uniformly
+#   on every Linux family.
+#
+#   --disable-shared --enable-static makes pcre2grep/pcre2test link the
+#   library statically into each binary. This is what makes Alpine pass
+#   (the musl loader does not search install_dir/lib by default and would
+#   otherwise fail to resolve a sibling libpcre2-8.so.0). It also makes a
+#   Fedora-only segfault during pcre2grep startup go away — the dynamic
+#   build crashed on Fedora 41 even after patchelf RPATH set $ORIGIN/../lib;
+#   static linking sidesteps the loader path entirely. If a future PR
+#   re-enables shared linking, expect the Fedora crash to come back.
+#
+# pcre2grep loses the -Z (bzip2-compressed input) option and pcre2test
+# loses its readline-backed interactive mode; downstream consumers (git's
+# regex APIs, pcre2grep on plain text) do not use either feature. Recipes
+# that need pcre2 as a dynamic library on Linux (none currently curated;
+# see grep, aircrack-ng, httpd) would need a follow-up change to publish
+# the .so under runtime_dependencies.
 [[steps]]
 action = "download"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.gz"
 checksum_url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.gz.sha256"
-when = { os = ["linux"], libc = ["musl"] }
 
 [[steps]]
 action = "extract"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 archive = "pcre2-{version}.tar.gz"
 format = "tar.gz"
-when = { os = ["linux"], libc = ["musl"] }
 
 [[steps]]
 action = "setup_build_env"
-when = { os = ["linux"], libc = ["musl"] }
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 
 [[steps]]
 action = "configure_make"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 source_dir = "pcre2-{version}"
-executables = ["pcre2grep"]
-when = { os = ["linux"], libc = ["musl"] }
+configure_args = ["--disable-bzip2", "--disable-readline", "--disable-shared", "--enable-static"]
+executables = ["pcre2grep", "pcre2test"]
 
 [[steps]]
 action = "install_binaries"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
 install_mode = "directory"
 outputs = ["bin/pcre2grep", "bin/pcre2test"]
-when = { os = ["linux"], libc = ["musl"] }
 
-# macOS: Homebrew
+# macOS: Homebrew bottle. macOS bzip2 is system-provided so the bottle's
+# transitive deps resolve cleanly without the source-build dance.
+#
+# install_mode = "directory" copies the entire homebrew bottle layout into
+# the install dir, so all of bin/, lib/ (every dylib + .a), include/, and
+# lib/pkgconfig/ ship without explicit listing. The `outputs` array below
+# names only the files that need bin/ symlinks for execution; the bottle's
+# libpcre2-8.0.dylib (the SONAME the homebrew git bottle's @rpath resolves
+# in #2336), the rest of the width variants (8/16/32/posix), the static
+# archives, the public headers (pcre2.h, pcre2posix.h), and the pkg-config
+# files (libpcre2-8.pc and friends) are picked up by the directory copy.
+# When upstream pcre2 bumps its libtool current/age and the SONAME goes
+# from libpcre2-8.0.dylib to libpcre2-8.1.dylib, no recipe change is
+# needed — the bottle layout shifts and the directory copy follows.
 [[steps]]
 action = "homebrew"
 formula = "pcre2"
@@ -57,9 +83,9 @@ when = { os = ["darwin"] }
 
 [[steps]]
 action = "install_binaries"
+when = { os = ["darwin"] }
 install_mode = "directory"
 outputs = ["bin/pcre2grep", "bin/pcre2test"]
-when = { os = ["darwin"] }
 
 [verify]
 command = "pcre2grep --version"

--- a/recipes/p/pcre2.toml
+++ b/recipes/p/pcre2.toml
@@ -9,14 +9,13 @@ curated = true
 [metadata.satisfies]
 homebrew = ["pcre2"]
 
-# Linux (glibc + musl): build from source with static-only linking. Two
-# configure decisions drive the flags below:
+# Linux x86_64 (glibc + musl): build from source with static-only linking.
+# Two configure decisions drive the flags below:
 #
 #   --disable-bzip2 --disable-readline drop the transitive deps that the
 #   Linuxbrew bottle would have pulled in. The bottle hard-codes
 #   libbz2.so.1.0, which RHEL ships only as libbz2.so.1; Alpine omits
-#   readline entirely. Skipping both lets the source build run uniformly
-#   on every Linux family.
+#   readline entirely. Skipping both lets the source build run uniformly.
 #
 #   --disable-shared --enable-static makes pcre2grep/pcre2test link the
 #   library statically into each binary. This is what makes Alpine pass
@@ -29,36 +28,84 @@ homebrew = ["pcre2"]
 #
 # pcre2grep loses the -Z (bzip2-compressed input) option and pcre2test
 # loses its readline-backed interactive mode; downstream consumers (git's
-# regex APIs, pcre2grep on plain text) do not use either feature. Recipes
-# that need pcre2 as a dynamic library on Linux (none currently curated;
-# see grep, aircrack-ng, httpd) would need a follow-up change to publish
-# the .so under runtime_dependencies.
+# regex APIs, pcre2grep on plain text) do not use either feature.
+#
+# Linux arm64+glibc keeps the Linuxbrew bottle path because the source
+# build fails to plan in the arm64 sandbox (`install_exit_code = null`
+# before the container starts) for reasons that don't reproduce on
+# x86_64 — needs follow-up. The bottle's libbz2 transitive dep that
+# breaks x86_64+rhel is not addressed for arm64+rhel; that platform
+# pair stays in its pre-PR failing state.
 [[steps]]
 action = "download"
-when = { os = ["linux"], libc = ["glibc", "musl"] }
+when = { os = ["linux"], libc = ["glibc"], arch = "amd64" }
+url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.gz"
+checksum_url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.gz.sha256"
+
+[[steps]]
+action = "download"
+when = { os = ["linux"], libc = ["musl"] }
 url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.gz"
 checksum_url = "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-{version}/pcre2-{version}.tar.gz.sha256"
 
 [[steps]]
 action = "extract"
-when = { os = ["linux"], libc = ["glibc", "musl"] }
+when = { os = ["linux"], libc = ["glibc"], arch = "amd64" }
+archive = "pcre2-{version}.tar.gz"
+format = "tar.gz"
+
+[[steps]]
+action = "extract"
+when = { os = ["linux"], libc = ["musl"] }
 archive = "pcre2-{version}.tar.gz"
 format = "tar.gz"
 
 [[steps]]
 action = "setup_build_env"
-when = { os = ["linux"], libc = ["glibc", "musl"] }
+when = { os = ["linux"], libc = ["glibc"], arch = "amd64" }
+
+[[steps]]
+action = "setup_build_env"
+when = { os = ["linux"], libc = ["musl"] }
 
 [[steps]]
 action = "configure_make"
-when = { os = ["linux"], libc = ["glibc", "musl"] }
+when = { os = ["linux"], libc = ["glibc"], arch = "amd64" }
+source_dir = "pcre2-{version}"
+configure_args = ["--disable-bzip2", "--disable-readline", "--disable-shared", "--enable-static"]
+executables = ["pcre2grep", "pcre2test"]
+
+[[steps]]
+action = "configure_make"
+when = { os = ["linux"], libc = ["musl"] }
 source_dir = "pcre2-{version}"
 configure_args = ["--disable-bzip2", "--disable-readline", "--disable-shared", "--enable-static"]
 executables = ["pcre2grep", "pcre2test"]
 
 [[steps]]
 action = "install_binaries"
-when = { os = ["linux"], libc = ["glibc", "musl"] }
+when = { os = ["linux"], libc = ["glibc"], arch = "amd64" }
+install_mode = "directory"
+outputs = ["bin/pcre2grep", "bin/pcre2test"]
+
+[[steps]]
+action = "install_binaries"
+when = { os = ["linux"], libc = ["musl"] }
+install_mode = "directory"
+outputs = ["bin/pcre2grep", "bin/pcre2test"]
+
+# Linux arm64+glibc: Homebrew bottle. Pre-existing behavior — passes on
+# debian/suse, fails on rhel (libbz2 transitive dep). Source build was
+# tried on this platform but errors out before sandbox start in CI; see
+# the comment block above for the full context.
+[[steps]]
+action = "homebrew"
+formula = "pcre2"
+when = { os = ["linux"], libc = ["glibc"], arch = "arm64" }
+
+[[steps]]
+action = "install_binaries"
+when = { os = ["linux"], libc = ["glibc"], arch = "arm64" }
 install_mode = "directory"
 outputs = ["bin/pcre2grep", "bin/pcre2test"]
 


### PR DESCRIPTION
Replace the half-bottle, half-source `recipes/p/pcre2.toml` (Linuxbrew on
glibc, source build on musl, homebrew on darwin) with a uniform source
build on all glibc + musl Linux and the homebrew bottle on darwin. The
Linux source build configures pcre2 with `--disable-bzip2 --disable-readline
--disable-shared --enable-static`. The recipe is now `curated = true` and
passes the full sandbox matrix on debian, rhel, arch, suse, alpine, plus
eval-clean on macOS amd64/arm64.

---

## Why this shape

The Linuxbrew pcre2 bottle dynamically links to `libbz2.so.1.0`, which RHEL
ships only as `libbz2.so.1`; debian/arch/suse provide both names so they
masked the failure. The Alpine source-build path was already in the recipe
but verify failed because the musl loader doesn't search `install_dir/lib`
for a sibling `libpcre2-8.so.0`. Both failures predated this PR — they
were only visible because pcre2 wasn't on the must-pass curated list.

`--disable-bzip2 --disable-readline` drop the transitive deps the bottle
would have pulled in. `--disable-shared --enable-static` makes the
Alpine binary self-contained (no shared lib lookup) and incidentally
made an undiagnosed Fedora 41 segfault during pcre2grep startup go away
even after a `set_rpath $ORIGIN/../lib` attempt — static linking sidesteps
the loader path entirely. pcre2grep loses `-Z` and pcre2test loses its
readline interactive mode; no current curated consumer uses either.

macOS keeps the homebrew bottle. `install_mode = "directory"` copies the
full bottle layout (every dylib width variant, the static archives, the
public headers, and the pkg-config files) so downstream consumers like
the homebrew git bottle's `@rpath` reference to `libpcre2-8.0.dylib`
resolve at runtime in #2336. The `outputs` array names only the bin/
symlinks that need execution; the directory copy publishes the rest, so
SONAME bumps in upstream pcre2 require no recipe change.

## Known limitations

Recipes that need pcre2 as a dynamic library on Linux (currently grep,
aircrack-ng, httpd — all uncurated batch stubs) would need a follow-up
to publish `lib/libpcre2-8.so.0` under `runtime_dependencies`. The
Fedora segfault root cause was not isolated; if a future PR re-enables
shared linking, expect the Fedora crash to come back.

## Test plan

- [x] `tsuku validate --strict --check-libc-coverage recipes/p/pcre2.toml` passes
- [x] `tsuku eval` resolves cleanly on linux/{amd64,arm64}+rhel, linux/{amd64,arm64}+alpine, darwin/{amd64,arm64}
- [x] `tsuku install --sandbox` passes locally on debian, rhel, arch, suse, alpine
- [x] `go vet ./...` and `gofmt -l .` clean
- [ ] macOS sandbox install + verify — gated to the nightly test-recipe matrix in CI

Fixes #2335