### PR TITLE
fix(sandbox): add arm64 glibc fallbacks for make and pkg-config dep recipes

### DIFF
--- a/.github/workflows/test-recipe.yml
+++ b/.github/workflows/test-recipe.yml
@@ -382,6 +382,15 @@ jobs:
             exit 1
           fi
 
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: recipe-logs-linux-x86_64-${{ matrix.batch.batch_id }}-${{ github.run_id }}
+          path: .log-*.txt
+          retention-days: 7
+          if-no-files-found: ignore
+
   # Linux arm64: test in sandbox containers for four families (no arch arm64 image).
   # Same batched parallel-families approach as x86_64.
   test-linux-arm64:
@@ -532,6 +541,15 @@ jobs:
             echo "::error::$FAILED of $TOTAL tests failed (Linux arm64 batch ${{ matrix.batch.batch_id }})"
             exit 1
           fi
+
+      - name: Upload failure logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: recipe-logs-linux-arm64-${{ matrix.batch.batch_id }}-${{ github.run_id }}
+          path: .log-*.txt
+          retention-days: 7
+          if-no-files-found: ignore
 
   # macOS arm64: native runner test.
   # Recipes are split into batches (one job per batch) to stay within the timeout.

--- a/cmd/tsuku/install.go
+++ b/cmd/tsuku/install.go
@@ -504,7 +504,7 @@ type installError struct {
 	Subcategory    string   `json:"subcategory,omitempty"`
 	Message        string   `json:"message"`
 	MissingRecipes []string `json:"missing_recipes"`
-	ExitCode       int      `json:"exit_code"`
+	ExitCode       int      `json:"install_exit_code"`
 }
 
 // categoryFromExitCode maps an exit code to its category string for the CLI's

--- a/cmd/tsuku/install_test.go
+++ b/cmd/tsuku/install_test.go
@@ -434,8 +434,8 @@ func TestInstallErrorJSON(t *testing.T) {
 		if _, exists := parsed["subcategory"]; exists {
 			t.Errorf("subcategory should be omitted when empty, got %v", parsed["subcategory"])
 		}
-		if parsed["exit_code"].(float64) != 8 {
-			t.Errorf("exit_code = %v, want 8", parsed["exit_code"])
+		if parsed["install_exit_code"].(float64) != 8 {
+			t.Errorf("install_exit_code = %v, want 8", parsed["install_exit_code"])
 		}
 		recipes := parsed["missing_recipes"].([]interface{})
 		if len(recipes) != 2 {
@@ -471,8 +471,8 @@ func TestInstallErrorJSON(t *testing.T) {
 		if parsed["subcategory"] != "timeout" {
 			t.Errorf("subcategory = %v, want %q", parsed["subcategory"], "timeout")
 		}
-		if parsed["exit_code"].(float64) != 5 {
-			t.Errorf("exit_code = %v, want 5", parsed["exit_code"])
+		if parsed["install_exit_code"].(float64) != 5 {
+			t.Errorf("install_exit_code = %v, want 5", parsed["install_exit_code"])
 		}
 	})
 }

--- a/internal/recipe/recipes/make.toml
+++ b/internal/recipe/recipes/make.toml
@@ -3,20 +3,36 @@ name = "make"
 description = "GNU Make build automation tool"
 homepage = "https://www.gnu.org/software/make/"
 curated = true
-# Homebrew's make installs as gmake on macOS, make on Linux - see #1581
+# Homebrew's make installs as gmake on macOS and amd64 Linux - see #1581
 binaries = ["bin/gmake"]
 
-# glibc Linux: Homebrew bottles
+# glibc Linux amd64: Homebrew bottles
 [[steps]]
 action = "homebrew"
 formula = "make"
-when = { os = ["linux"], libc = ["glibc"] }
+when = { os = ["linux"], libc = ["glibc"], arch = "amd64" }
 
 [[steps]]
 action = "install_binaries"
 install_mode = "directory"
 outputs = ["bin/gmake"]
-when = { os = ["linux"], libc = ["glibc"] }
+when = { os = ["linux"], libc = ["glibc"], arch = "amd64" }
+
+# glibc Linux arm64: System packages (Homebrew has no arm64_linux bottles for make)
+[[steps]]
+action = "apt_install"
+packages = ["make"]
+when = { os = ["linux"], libc = ["glibc"], arch = "arm64", linux_family = "debian" }
+
+[[steps]]
+action = "dnf_install"
+packages = ["make"]
+when = { os = ["linux"], libc = ["glibc"], arch = "arm64", linux_family = "rhel" }
+
+[[steps]]
+action = "zypper_install"
+packages = ["make"]
+when = { os = ["linux"], libc = ["glibc"], arch = "arm64", linux_family = "suse" }
 
 # musl Linux: System packages
 [[steps]]
@@ -37,7 +53,6 @@ outputs = ["bin/gmake"]
 when = { os = ["darwin"] }
 
 [verify]
-# Use PATH-based verification since binary name differs by platform
-# Proper fix tracked in #1581
-command = "gmake --version"
-pattern = ""
+command = "make --version"
+mode = "output"
+reason = "arm64 glibc installs make via system packages at a distribution version; output mode verifies availability across all platforms"

--- a/internal/recipe/recipes/pkg-config.toml
+++ b/internal/recipe/recipes/pkg-config.toml
@@ -4,17 +4,33 @@ description = "Helper tool for compile and link flags for libraries"
 homepage = "https://www.freedesktop.org/wiki/Software/pkg-config/"
 binaries = ["bin/pkg-config"]
 
-# glibc Linux: Homebrew bottles
+# glibc Linux amd64: Homebrew bottles
 [[steps]]
 action = "homebrew"
 formula = "pkgconf"
-when = { os = ["linux"], libc = ["glibc"] }
+when = { os = ["linux"], libc = ["glibc"], arch = "amd64" }
 
 [[steps]]
 action = "install_binaries"
 install_mode = "directory"
 outputs = ["bin/pkg-config", "bin/pkgconf", "lib/libpkgconf.so", "lib/libpkgconf.so.7", "lib/libpkgconf.so.7.0.0"]
-when = { os = ["linux"], libc = ["glibc"] }
+when = { os = ["linux"], libc = ["glibc"], arch = "amd64" }
+
+# glibc Linux arm64: System packages (Homebrew has no arm64_linux bottles for pkgconf)
+[[steps]]
+action = "apt_install"
+packages = ["pkgconf"]
+when = { os = ["linux"], libc = ["glibc"], arch = "arm64", linux_family = "debian" }
+
+[[steps]]
+action = "dnf_install"
+packages = ["pkgconf-pkg-config"]
+when = { os = ["linux"], libc = ["glibc"], arch = "arm64", linux_family = "rhel" }
+
+[[steps]]
+action = "zypper_install"
+packages = ["pkg-config"]
+when = { os = ["linux"], libc = ["glibc"], arch = "arm64", linux_family = "suse" }
 
 # musl Linux: System packages
 [[steps]]
@@ -36,4 +52,5 @@ when = { os = ["darwin"] }
 
 [verify]
 command = "pkg-config --version"
-pattern = "{version}"
+mode = "output"
+reason = "arm64 glibc installs pkgconf via system packages at a distribution version; output mode verifies availability across all platforms"


### PR DESCRIPTION
Homebrew does not publish \`arm64_linux\` bottles for \`make\` or \`pkgconf\`. When a recipe depends on \`configure_make\` on linux/arm64+glibc, plan generation walks the install-time dep tree (\`make\`, \`zig\`, \`pkg-config\`) and \`HomebrewAction.Decompose\` returns "no bottle found for platform tag: arm64\_linux" for both. That error propagates up through \`generateInstallPlan\` and exits through \`handleInstallError\`, which emits \`installError\` JSON with field \`exit_code\` rather than \`install_exit_code\`. CI's \`jq -r '.install_exit_code'\` reads \`null\`, and the family is reported as \`exit null\` in the test summary.

Three fixes:

**Recipe fallbacks** — split the \`when = { os = ["linux"], libc = ["glibc"] }\` homebrew steps in \`make.toml\` and \`pkg-config.toml\` to \`arch = "amd64"\` only, then add \`apt_install\`/\`dnf_install\`/\`zypper_install\` steps for \`arch = "arm64"\` on debian, rhel, and suse. Both verify sections change to \`mode = "output"\` since arm64 system packages install at distribution versions rather than the recipe-pinned version. \`zig\` is unaffected — it uses \`arch_mapping\` with a direct download, not Homebrew.

**JSON field alignment** — rename \`installError.ExitCode\`'s json tag from \`exit_code\` to \`install_exit_code\` so plan-generation error responses and sandbox success responses (\`sandboxJSONOutput\`) use the same field name. CI's \`jq\` filter works correctly for both paths after this change.

**Failure log artifacts** — add \`upload-artifact\` steps (gated on \`failure()\`) to both \`test-linux-x86_64\` and \`test-linux-arm64\` jobs to collect the existing \`.log-\${recipe}-\${family}.txt\` files. Future plan-generation errors are directly observable from the GitHub Actions UI without an arm64 dev machine.

---

Fixes #2374