### PR TITLE
feat(recipes): add macOS support to git

### DIFF
--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -110,8 +110,8 @@ These issues capture infrastructure and recipe gaps surfaced while authoring the
 | ~~_The homebrew action now fetches `revision` from formulae.brew.sh and constructs `<version>_<revision>` for both the manifest URL and the ref-name match when revision >= 1; the shared matcher accepts both unrevised and revision-suffixed entry forms within a single manifest. `recipes/l/libevent.toml` ships with darwin support and the macOS dylib outputs (`libevent-2.1.7.dylib` and the static archives) so tmux's @rpath resolves at runtime._~~ | | |
 | ~~[#2335: fix(recipes): curate pcre2 with macOS dylib outputs and fix rhel + alpine sandbox failures](https://github.com/tsukumogami/tsuku/issues/2335)~~ | ~~None~~ | ~~testable~~ |
 | ~~_Resolved by switching all glibc + musl Linux to a uniform source build with `--disable-bzip2 --disable-readline --disable-shared --enable-static`. Static linking sidesteps the Linuxbrew bottle's hard-coded `libbz2.so.1.0` (RHEL ships only `libbz2.so.1`), the Alpine musl loader's missing search of `install_dir/lib`, and a Fedora-only segfault during dynamic-linker startup. macOS keeps the homebrew bottle and `install_mode = "directory"` publishes the full bottle layout (dylibs, .a, headers, pkg-config) so the homebrew git bottle's @rpath resolves `libpcre2-8.0.dylib`. Recipe marked `curated = true`._~~ | | |
-| ~~[#2336: feat(recipes): add macOS support to tmux and git recipes](https://github.com/tsukumogami/tsuku/issues/2336)~~ | ~~[#2333](https://github.com/tsukumogami/tsuku/issues/2333), [#2335](https://github.com/tsukumogami/tsuku/issues/2335)~~ | ~~testable~~ |
-| ~~_Both prereqs (#2333 libevent macOS, #2335 pcre2 macOS dylibs) shipped, so this PR drops `supported_os = ["linux"]` from `recipes/t/tmux.toml` and `recipes/g/git.toml` and adds darwin homebrew + install_binaries steps wired to `runtime_dependencies = ["libevent", "utf8proc", "ncurses"]` (tmux) and `runtime_dependencies = ["pcre2"]` (git). Same shape as the wget recipe from #2337._~~ | | |
+| [#2336: feat(recipes): add macOS support to tmux and git recipes](https://github.com/tsukumogami/tsuku/issues/2336) | [#2333](https://github.com/tsukumogami/tsuku/issues/2333), [#2335](https://github.com/tsukumogami/tsuku/issues/2335) | testable |
+| _Both prereqs (#2333 libevent macOS, #2335 pcre2 macOS dylibs) shipped. git's macOS support landed: dropped `supported_os = ["linux"]` from `recipes/g/git.toml`, added darwin homebrew step wired to `runtime_dependencies = ["pcre2"]`. tmux's macOS support is deferred — the tmux Linux glibc path (homebrew bottle) requires `libutf8proc.so.3` from a sibling Linuxbrew install that tsuku does not chain into the binary's RPATH for tool recipes; pre-PR this was untested in CI but adding macOS support makes the matrix re-test the recipe and surfaces the gap. Needs follow-up work on transitive dylib chaining for tool recipes (architectural — applies to other tools depending on non-system shared libraries via homebrew bottles)._ | | |
 | [#2338: fix(recipes): add macOS support to curl and resolve rhel sandbox verify failure](https://github.com/tsukumogami/tsuku/issues/2338) | None | testable |
 | _A first attempt at the curl darwin step (subsequently reverted) cleared eval and macOS install but surfaced a rhel-only sandbox verify failure on Linux: install completes (`install_exit_code = 0`) but `passed = false`. Same shape as the pcre2 rhel issue. Needs local reproduction since the workflow does not upload `.log-*.txt` artifacts._ | | |
 | [#2349: chore(version): remove deprecated source = "hashicorp" after release](https://github.com/tsukumogami/tsuku/issues/2349) | tsuku release containing [#2328](https://github.com/tsukumogami/tsuku/issues/2328) | testable |
@@ -185,8 +185,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2325,I2327,I2328,I2330,I2331,I2333,I2335,I2336,I2365,I2368 done
-    class I2338 ready
+    class I2325,I2327,I2328,I2330,I2331,I2333,I2335,I2365,I2368 done
+    class I2336,I2338 ready
     class I2343,I2344,I2345,I2349 blocked
 ```
 

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -110,8 +110,8 @@ These issues capture infrastructure and recipe gaps surfaced while authoring the
 | ~~_The homebrew action now fetches `revision` from formulae.brew.sh and constructs `<version>_<revision>` for both the manifest URL and the ref-name match when revision >= 1; the shared matcher accepts both unrevised and revision-suffixed entry forms within a single manifest. `recipes/l/libevent.toml` ships with darwin support and the macOS dylib outputs (`libevent-2.1.7.dylib` and the static archives) so tmux's @rpath resolves at runtime._~~ | | |
 | ~~[#2335: fix(recipes): curate pcre2 with macOS dylib outputs and fix rhel + alpine sandbox failures](https://github.com/tsukumogami/tsuku/issues/2335)~~ | ~~None~~ | ~~testable~~ |
 | ~~_Resolved by switching all glibc + musl Linux to a uniform source build with `--disable-bzip2 --disable-readline --disable-shared --enable-static`. Static linking sidesteps the Linuxbrew bottle's hard-coded `libbz2.so.1.0` (RHEL ships only `libbz2.so.1`), the Alpine musl loader's missing search of `install_dir/lib`, and a Fedora-only segfault during dynamic-linker startup. macOS keeps the homebrew bottle and `install_mode = "directory"` publishes the full bottle layout (dylibs, .a, headers, pkg-config) so the homebrew git bottle's @rpath resolves `libpcre2-8.0.dylib`. Recipe marked `curated = true`._~~ | | |
-| [#2336: feat(recipes): add macOS support to tmux and git recipes](https://github.com/tsukumogami/tsuku/issues/2336) | [#2333](https://github.com/tsukumogami/tsuku/issues/2333), [#2335](https://github.com/tsukumogami/tsuku/issues/2335) | testable |
-| _Once libevent and pcre2 macOS support land, drop `supported_os = ["linux"]` from `recipes/t/tmux.toml` and `recipes/g/git.toml` and add darwin homebrew steps wired to the right `runtime_dependencies`. Same shape as the curl and wget changes in #2337._ | | |
+| ~~[#2336: feat(recipes): add macOS support to tmux and git recipes](https://github.com/tsukumogami/tsuku/issues/2336)~~ | ~~[#2333](https://github.com/tsukumogami/tsuku/issues/2333), [#2335](https://github.com/tsukumogami/tsuku/issues/2335)~~ | ~~testable~~ |
+| ~~_Both prereqs (#2333 libevent macOS, #2335 pcre2 macOS dylibs) shipped, so this PR drops `supported_os = ["linux"]` from `recipes/t/tmux.toml` and `recipes/g/git.toml` and adds darwin homebrew + install_binaries steps wired to `runtime_dependencies = ["libevent", "utf8proc", "ncurses"]` (tmux) and `runtime_dependencies = ["pcre2"]` (git). Same shape as the wget recipe from #2337._~~ | | |
 | [#2338: fix(recipes): add macOS support to curl and resolve rhel sandbox verify failure](https://github.com/tsukumogami/tsuku/issues/2338) | None | testable |
 | _A first attempt at the curl darwin step (subsequently reverted) cleared eval and macOS install but surfaced a rhel-only sandbox verify failure on Linux: install completes (`install_exit_code = 0`) but `passed = false`. Same shape as the pcre2 rhel issue. Needs local reproduction since the workflow does not upload `.log-*.txt` artifacts._ | | |
 | [#2349: chore(version): remove deprecated source = "hashicorp" after release](https://github.com/tsukumogami/tsuku/issues/2349) | tsuku release containing [#2328](https://github.com/tsukumogami/tsuku/issues/2328) | testable |
@@ -185,8 +185,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2325,I2327,I2328,I2330,I2331,I2333,I2335,I2365,I2368 done
-    class I2336,I2338 ready
+    class I2325,I2327,I2328,I2330,I2331,I2333,I2335,I2336,I2365,I2368 done
+    class I2338 ready
     class I2343,I2344,I2345,I2349 blocked
 ```
 

--- a/recipes/g/git.toml
+++ b/recipes/g/git.toml
@@ -4,10 +4,11 @@ description = "Distributed revision control system"
 homepage = "https://git-scm.com/"
 version_format = "semver"
 curated = true
-# macOS: homebrew git bottle has an RPATH reference to libpcre2-8.0.dylib from
-# pcre2, which tsuku does not yet install as a dylib on macOS. darwin coverage
-# is excluded until pcre2 installs its library files on macOS.
-supported_os = ["linux"]
+# `runtime_dependencies` ensures pcre2 is installed before `git --version`
+# runs at verify time. macOS support was previously gated by
+# `supported_os = ["linux"]` and unblocked once pcre2's macOS dylib outputs
+# (`libpcre2-8.0.dylib` and friends) landed in #2335.
+runtime_dependencies = ["pcre2"]
 
 # glibc Linux: Homebrew bottle
 [[steps]]
@@ -26,6 +27,27 @@ when = { os = ["linux"], libc = ["glibc"] }
 action = "apk_install"
 packages = ["git"]
 when = { os = ["linux"], libc = ["musl"] }
+
+# macOS: Homebrew bottle. The bottle's binary load chain references
+# `libpcre2-8.0.dylib` (from pcre2) — so the `runtime_dependencies` above
+# must ship pcre2's darwin dylibs in the same install layout the bottle
+# expects.
+#
+# The step-level `dependencies` is repeated here (not just via the metadata
+# `runtime_dependencies`) so the homebrew action can resolve install-time
+# deps during decomposition; without the step entry, the macOS plan would
+# not see them at install time. Keep the two lists in sync.
+[[steps]]
+action = "homebrew"
+formula = "git"
+when = { os = ["darwin"] }
+dependencies = ["pcre2"]
+
+[[steps]]
+action = "install_binaries"
+when = { os = ["darwin"] }
+install_mode = "directory"
+outputs = ["bin/git"]
 
 [verify]
 command = "git --version"

--- a/recipes/g/git.toml
+++ b/recipes/g/git.toml
@@ -51,4 +51,12 @@ outputs = ["bin/git"]
 
 [verify]
 command = "git --version"
-pattern = "git version {version}"
+mode = "output"
+pattern = "git version"
+# The Homebrew bottle ships a newer git than Alpine's apk package
+# (currently 2.54 vs 2.47), so a `{version}` pattern spuriously fails
+# verify on the alpine sandbox even when git runs cleanly. Every git
+# distribution prints `git version <X.Y.Z>` as the first line, so the
+# prefix is a faithful "did git run" signal across the matrix. Same
+# pattern openjdk uses for the same reason.
+reason = "version skew between Homebrew formula and Alpine apk; pattern matches the prefix"

--- a/recipes/t/tmux.toml
+++ b/recipes/t/tmux.toml
@@ -5,11 +5,10 @@ homepage = "https://github.com/tmux/tmux"
 # tmux uses non-standard versions like "3.6a"; raw format preserves them as-is
 version_format = "raw"
 curated = true
-# `runtime_dependencies` ensures these libraries are installed before
-# `tmux --version` runs at verify time. macOS support was previously gated by
-# `supported_os = ["linux"]` and unblocked once libevent's macOS bottle (#2333),
-# ncurses macOS dylibs, and utf8proc macOS dylibs (both #2312) all landed.
-runtime_dependencies = ["libevent", "utf8proc", "ncurses"]
+# macOS: homebrew tmux bottle has RPATH references to libutf8proc.3.dylib and
+# libevent from separate homebrew packages; libevent itself is not installable
+# on macOS via tsuku. darwin coverage is excluded until these deps are supported.
+supported_os = ["linux"]
 
 # glibc Linux: Homebrew bottle
 [[steps]]
@@ -28,27 +27,6 @@ when = { os = ["linux"], libc = ["glibc"] }
 action = "apk_install"
 packages = ["tmux"]
 when = { os = ["linux"], libc = ["musl"] }
-
-# macOS: Homebrew bottle. The bottle's binary load chain references
-# `libevent-2.1.7.dylib` (libevent), `libutf8proc.3.dylib` (utf8proc), and
-# `libncurses.6.dylib` (ncurses) — so the `runtime_dependencies` above must
-# all ship their darwin dylibs in the same install layout the bottle expects.
-#
-# The step-level `dependencies` is repeated here (not just via the metadata
-# `runtime_dependencies`) so the homebrew action can resolve install-time deps
-# during decomposition; without the step entry, the macOS plan would not see
-# them at install time. Keep the two lists in sync.
-[[steps]]
-action = "homebrew"
-formula = "tmux"
-when = { os = ["darwin"] }
-dependencies = ["libevent", "utf8proc", "ncurses"]
-
-[[steps]]
-action = "install_binaries"
-when = { os = ["darwin"] }
-install_mode = "directory"
-outputs = ["bin/tmux"]
 
 [verify]
 command = "tmux -V"

--- a/recipes/t/tmux.toml
+++ b/recipes/t/tmux.toml
@@ -5,10 +5,11 @@ homepage = "https://github.com/tmux/tmux"
 # tmux uses non-standard versions like "3.6a"; raw format preserves them as-is
 version_format = "raw"
 curated = true
-# macOS: homebrew tmux bottle has RPATH references to libutf8proc.3.dylib and
-# libevent from separate homebrew packages; libevent itself is not installable
-# on macOS via tsuku. darwin coverage is excluded until these deps are supported.
-supported_os = ["linux"]
+# `runtime_dependencies` ensures these libraries are installed before
+# `tmux --version` runs at verify time. macOS support was previously gated by
+# `supported_os = ["linux"]` and unblocked once libevent's macOS bottle (#2333),
+# ncurses macOS dylibs, and utf8proc macOS dylibs (both #2312) all landed.
+runtime_dependencies = ["libevent", "utf8proc", "ncurses"]
 
 # glibc Linux: Homebrew bottle
 [[steps]]
@@ -27,6 +28,27 @@ when = { os = ["linux"], libc = ["glibc"] }
 action = "apk_install"
 packages = ["tmux"]
 when = { os = ["linux"], libc = ["musl"] }
+
+# macOS: Homebrew bottle. The bottle's binary load chain references
+# `libevent-2.1.7.dylib` (libevent), `libutf8proc.3.dylib` (utf8proc), and
+# `libncurses.6.dylib` (ncurses) — so the `runtime_dependencies` above must
+# all ship their darwin dylibs in the same install layout the bottle expects.
+#
+# The step-level `dependencies` is repeated here (not just via the metadata
+# `runtime_dependencies`) so the homebrew action can resolve install-time deps
+# during decomposition; without the step entry, the macOS plan would not see
+# them at install time. Keep the two lists in sync.
+[[steps]]
+action = "homebrew"
+formula = "tmux"
+when = { os = ["darwin"] }
+dependencies = ["libevent", "utf8proc", "ncurses"]
+
+[[steps]]
+action = "install_binaries"
+when = { os = ["darwin"] }
+install_mode = "directory"
+outputs = ["bin/tmux"]
 
 [verify]
 command = "tmux -V"


### PR DESCRIPTION
Drop `supported_os = ["linux"]` from `recipes/g/git.toml` and add a darwin
homebrew + install_binaries step wired to `runtime_dependencies = ["pcre2"]`.
Mirrors the wget recipe shape from #2337. Both prereqs are on main: #2333
(libevent macOS bottle) and #2335 (pcre2 macOS dylib outputs).

Also fix a pre-existing git verify mismatch surfaced by this PR's matrix
run: Alpine apk ships git 2.47 while the Homebrew bottle ships 2.54, so
the `git version {version}` pattern spuriously failed on alpine. Switched
to `mode = "output"` with the version-agnostic prefix `git version` (same
pattern openjdk uses for the same reason).

`docs/plans/PLAN-curated-recipes.md`: records that git's macOS support
landed and that tmux's macOS support is deferred to a follow-up.

---

## Why git only

The original scope of #2336 included tmux, but tmux's homebrew bottle on
Linux glibc references `libutf8proc.so.3` from a sibling Linuxbrew install.
tsuku does not chain non-system shared libraries from `runtime_dependencies`
into a tool-recipe binary's RPATH, so tmux's verify fails on every Linux
glibc family with `libutf8proc.so.3: cannot open shared object file`. This
was always the case pre-PR but went untested because the recipe wasn't
modified; adding macOS support makes the matrix re-test the recipe and
surfaces the gap.

git is unaffected — it only depends on pcre2, whose macOS install (#2335)
ships the dylibs git's @rpath needs. tmux ships separately once the dylib
chaining gap is closed (architectural — applies to other tool recipes
depending on non-system shared libraries via homebrew bottles).

## Test plan

- [x] `tsuku validate --strict --check-libc-coverage recipes/g/git.toml` passes
- [x] `tsuku eval` resolves cleanly on darwin amd64 + arm64 with pcre2 as the top-level dep
- [x] Linux debian/rhel/suse/alpine sandbox installs pass (alpine version-skew fix verified)
- [x] `go vet ./...` and `gofmt -l .` clean
- [x] macOS install + verify on both arches via the PR test-recipe matrix (`./tsuku-darwin-{arm64,amd64} install --force --recipe recipes/g/git.toml`)

Partially addresses #2336 — git lands; tmux deferred (follow-up tracked in #2377).