### PR TITLE
feat(recipes,actions): add macOS support to tmux + fix gmake fallback

### DIFF
--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -110,8 +110,10 @@ These issues capture infrastructure and recipe gaps surfaced while authoring the
 | ~~_The homebrew action now fetches `revision` from formulae.brew.sh and constructs `<version>_<revision>` for both the manifest URL and the ref-name match when revision >= 1; the shared matcher accepts both unrevised and revision-suffixed entry forms within a single manifest. `recipes/l/libevent.toml` ships with darwin support and the macOS dylib outputs (`libevent-2.1.7.dylib` and the static archives) so tmux's @rpath resolves at runtime._~~ | | |
 | ~~[#2335: fix(recipes): curate pcre2 with macOS dylib outputs and fix rhel + alpine sandbox failures](https://github.com/tsukumogami/tsuku/issues/2335)~~ | ~~None~~ | ~~testable~~ |
 | ~~_Resolved by switching all glibc + musl Linux to a uniform source build with `--disable-bzip2 --disable-readline --disable-shared --enable-static`. Static linking sidesteps the Linuxbrew bottle's hard-coded `libbz2.so.1.0` (RHEL ships only `libbz2.so.1`), the Alpine musl loader's missing search of `install_dir/lib`, and a Fedora-only segfault during dynamic-linker startup. macOS keeps the homebrew bottle and `install_mode = "directory"` publishes the full bottle layout (dylibs, .a, headers, pkg-config) so the homebrew git bottle's @rpath resolves `libpcre2-8.0.dylib`. Recipe marked `curated = true`._~~ | | |
-| [#2336: feat(recipes): add macOS support to tmux and git recipes](https://github.com/tsukumogami/tsuku/issues/2336) | [#2333](https://github.com/tsukumogami/tsuku/issues/2333), [#2335](https://github.com/tsukumogami/tsuku/issues/2335) | testable |
-| _Both prereqs (#2333 libevent macOS, #2335 pcre2 macOS dylibs) shipped. git's macOS support landed: dropped `supported_os = ["linux"]` from `recipes/g/git.toml`, added darwin homebrew step wired to `runtime_dependencies = ["pcre2"]`. tmux's macOS support is deferred — the tmux Linux glibc path (homebrew bottle) requires `libutf8proc.so.3` from a sibling Linuxbrew install that tsuku does not chain into the binary's RPATH for tool recipes; pre-PR this was untested in CI but adding macOS support makes the matrix re-test the recipe and surfaces the gap. Needs follow-up work on transitive dylib chaining for tool recipes (architectural — applies to other tools depending on non-system shared libraries via homebrew bottles)._ | | |
+| ~~[#2336: feat(recipes): add macOS support to tmux and git recipes](https://github.com/tsukumogami/tsuku/issues/2336)~~ | ~~[#2333](https://github.com/tsukumogami/tsuku/issues/2333), [#2335](https://github.com/tsukumogami/tsuku/issues/2335)~~ | ~~testable~~ |
+| ~~_Both prereqs (#2333 libevent macOS, #2335 pcre2 macOS dylibs) shipped. git's macOS support landed via PR #2376; tmux's macOS support landed via PR for #2377 (split out from #2336 because adding macOS support also surfaced a pre-existing Linux libutf8proc dylib chaining gap that needed `set_rpath` chains in the recipe plus a tsuku core fix for `gmake` resolution in source-build cascades)._~~ | | |
+| ~~[#2377: feat(recipes): add macOS support to tmux (deferred from #2336)](https://github.com/tsukumogami/tsuku/issues/2377)~~ | ~~None~~ | ~~testable~~ |
+| ~~_Drops `supported_os = ["linux"]` from `recipes/t/tmux.toml`, adds darwin homebrew step wired to `runtime_dependencies = ["libevent", "utf8proc", "ncurses"]` and a `set_rpath` step on Linux glibc that chains tsuku-installed dep lib dirs into tmux's RPATH so the bottle resolves `libutf8proc.so.3`. Tsuku's `findMake` was extended to fall back to `gmake` so source-build cascades (e.g., the ncurses configure_make that runs in tmux's foundation image) succeed when only the tsuku-managed `gmake` is on PATH._~~ | | |
 | [#2338: fix(recipes): add macOS support to curl and resolve rhel sandbox verify failure](https://github.com/tsukumogami/tsuku/issues/2338) | None | testable |
 | _A first attempt at the curl darwin step (subsequently reverted) cleared eval and macOS install but surfaced a rhel-only sandbox verify failure on Linux: install completes (`install_exit_code = 0`) but `passed = false`. Same shape as the pcre2 rhel issue. Needs local reproduction since the workflow does not upload `.log-*.txt` artifacts._ | | |
 | [#2349: chore(version): remove deprecated source = "hashicorp" after release](https://github.com/tsukumogami/tsuku/issues/2349) | tsuku release containing [#2328](https://github.com/tsukumogami/tsuku/issues/2328) | testable |
@@ -152,6 +154,7 @@ graph TD
         I2333["#2333: revision-suffixed homebrew bottles (libevent darwin)"]
         I2335["#2335: pcre2 macOS dylibs + rhel/alpine fixes"]
         I2336["#2336: tmux + git macOS support"]
+        I2377["#2377: tmux macOS support (deferred from #2336)"]
         I2338["#2338: curl macOS + rhel sandbox failure"]
         I2349["#2349: remove deprecated hashicorp source"]
         I2365["#2365: multi-pattern verify (blocks #2327 microsoft-openjdk)"]
@@ -166,6 +169,7 @@ graph TD
 
     I2333 --> I2336
     I2335 --> I2336
+    I2336 --> I2377
 
     I2365 --> I2327
     I2368 --> I2327
@@ -185,8 +189,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2325,I2327,I2328,I2330,I2331,I2333,I2335,I2365,I2368 done
-    class I2336,I2338 ready
+    class I2325,I2327,I2328,I2330,I2331,I2333,I2335,I2336,I2365,I2368,I2377 done
+    class I2338 ready
     class I2343,I2344,I2345,I2349 blocked
 ```
 
@@ -202,7 +206,7 @@ graph TD
 | Wave 1 | #2261, #2262, #2263, #2264, #2265 | After #2259 merges |
 | Wave 2 | #2266, #2267 | After both #2259 and #2260 merge |
 | Wave 3 | #2281–#2297, #2312, #2313, #2315 (20 backfill batches) | After #2259 and #2260 merge |
-| Wave 4 | #2325, #2327, #2328, #2330, #2331, #2333, #2335, #2336, #2338, #2365, #2368 | After Wave 3 surfaces the gap each issue captures |
+| Wave 4 | #2325, #2327, #2328, #2330, #2331, #2333, #2335, #2336, #2338, #2365, #2368, #2377 | After Wave 3 surfaces the gap each issue captures |
 | Wave 5 | #2343, #2344, #2345, #2346 | After the Wave 4 prereq for each lands and (if a code change) is included in a tsuku release |
 
 Wave 3 issues were fully independent of each other; each batch was scoped to a coherent tool category and shipped as a single PR.

--- a/internal/actions/configure_make.go
+++ b/internal/actions/configure_make.go
@@ -410,6 +410,12 @@ func isValidConfigureArg(arg string) bool {
 // findMake returns the path to make, preferring system make over tsuku-installed make.
 // This is important in minimal containers where Homebrew bottles may have dynamic
 // linking issues, but system make works correctly.
+//
+// Falls back to `gmake` when `make` is not on PATH — the tsuku-managed `make`
+// recipe installs as `bin/gmake` (matching Homebrew's naming on darwin and the
+// linuxbrew GNU make formula), and sandbox foundation-image builds for recipes
+// that depend on `configure_make` rely on this fallback when the base image
+// hasn't installed the system build-essential package yet.
 func findMake() string {
 	// Check common system locations first
 	systemPaths := []string{"/usr/bin/make", "/bin/make", "/usr/local/bin/make"}
@@ -418,7 +424,15 @@ func findMake() string {
 			return p
 		}
 	}
-	// Fall back to PATH lookup
+	// Fall back to PATH lookup, trying `make` then `gmake`
+	if path, err := exec.LookPath("make"); err == nil {
+		return path
+	}
+	if path, err := exec.LookPath("gmake"); err == nil {
+		return path
+	}
+	// Last resort: return "make" so the caller's exec error message names what
+	// was searched for instead of returning an empty string.
 	return "make"
 }
 

--- a/recipes/t/tmux.toml
+++ b/recipes/t/tmux.toml
@@ -5,16 +5,25 @@ homepage = "https://github.com/tmux/tmux"
 # tmux uses non-standard versions like "3.6a"; raw format preserves them as-is
 version_format = "raw"
 curated = true
-# macOS: homebrew tmux bottle has RPATH references to libutf8proc.3.dylib and
-# libevent from separate homebrew packages; libevent itself is not installable
-# on macOS via tsuku. darwin coverage is excluded until these deps are supported.
-supported_os = ["linux"]
+runtime_dependencies = ["libevent", "utf8proc", "ncurses"]
 
-# glibc Linux: Homebrew bottle
+# glibc Linux: Homebrew bottle. The bottle's tmux binary references
+# libutf8proc.so.3, libevent-2.1.7.so.7, and libncursesw.so.6 from sibling
+# Linuxbrew installs that tsuku does not chain into the binary's RPATH by
+# default. The set_rpath step extends the homebrew-set $ORIGIN/../lib with
+# the matching tsuku libs/<recipe>-<version>/lib directories so the runtime
+# linker resolves them.
 [[steps]]
 action = "homebrew"
 formula = "tmux"
 when = { os = ["linux"], libc = ["glibc"] }
+dependencies = ["libevent", "utf8proc", "ncurses"]
+
+[[steps]]
+action = "set_rpath"
+when = { os = ["linux"], libc = ["glibc"] }
+binaries = [".install/bin/tmux"]
+rpath = "$ORIGIN/../lib:{libs_dir}/libevent-{deps.libevent.version}/lib:{libs_dir}/utf8proc-{deps.utf8proc.version}/lib:{libs_dir}/ncurses-{deps.ncurses.version}/lib"
 
 [[steps]]
 action = "install_binaries"
@@ -27,6 +36,19 @@ when = { os = ["linux"], libc = ["glibc"] }
 action = "apk_install"
 packages = ["tmux"]
 when = { os = ["linux"], libc = ["musl"] }
+
+# macOS: Homebrew bottle.
+[[steps]]
+action = "homebrew"
+formula = "tmux"
+when = { os = ["darwin"] }
+dependencies = ["libevent", "utf8proc", "ncurses"]
+
+[[steps]]
+action = "install_binaries"
+when = { os = ["darwin"] }
+install_mode = "directory"
+outputs = ["bin/tmux"]
 
 [verify]
 command = "tmux -V"


### PR DESCRIPTION
Drops \`supported_os = [\"linux\"]\` from \`recipes/t/tmux.toml\`, adds the
darwin homebrew step wired to \`runtime_dependencies = [\"libevent\",
\"utf8proc\", \"ncurses\"]\`, and adds a \`set_rpath\` step on Linux glibc
that chains tsuku-installed dep lib dirs into tmux's RPATH so the
Linuxbrew tmux bottle can resolve \`libutf8proc.so.3\`,
\`libevent-2.1.7.so.7\`, and \`libncursesw.so.6\` at runtime. Same shape
as \`recipes/c/curl.toml\`'s set_rpath chain.

Extending tmux's source-build foundation image surfaces a separate cascade:
ncurses (a runtime_dep) uses \`configure_make\`, which calls \`findMake()\`
to locate the build tool. Tsuku's \`make\` recipe installs as \`bin/gmake\`
(matching Homebrew's GNU make naming); without \`make\` in the foundation
image's base layer, \`findMake()\` previously fell through to a literal
\`\"make\"\` and the exec failed. Extends \`findMake()\` to fall back to
\`gmake\` after \`make\` so source-build cascades succeed when only the
tsuku-managed \`gmake\` is on PATH.

\`docs/plans/PLAN-curated-recipes.md\`: marks #2336 done (tmux macOS lands
here, completing the issue alongside git from PR #2376) and adds #2377 as
the tracked split-out issue.

---

## Why both changes in one PR

#2377 is fundamentally a recipe authoring task, but the cascade gap in
\`findMake\` blocks it from succeeding. Splitting them would mean shipping
a tmux recipe that doesn't pass CI until the tsuku core fix lands
separately, then re-rebasing. One PR gets the recipe to green directly.

## Test plan

- [x] \`tsuku validate --strict --check-libc-coverage recipes/t/tmux.toml\` passes
- [x] \`go test ./internal/actions/...\` passes
- [x] Local install of \`ncurses\` succeeds with only \`gmake\` on PATH (verifying the findMake fallback)
- [ ] Sandbox install + verify across linux glibc + musl + macOS arm64/amd64 — gated to the PR test-recipe matrix in CI

Closes #2377. Together with PR #2376 closes #2336.