### PR TITLE
fix(notices): clear failure notices on successful update or install

### DIFF
--- a/cmd/tsuku/cmd_notices.go
+++ b/cmd/tsuku/cmd_notices.go
@@ -11,11 +11,12 @@ import (
 
 var noticesCmd = &cobra.Command{
 	Use:   "notices",
-	Short: "Show recent update failure notices",
-	Long: `Display details of recent auto-update failures.
+	Short: "Show recent update notices",
+	Long: `Display recent auto-update results.
 
-Shows tool name, attempted version, error message, and timestamp for
-each failed update. Includes both previously shown and unshown notices.`,
+Shows tool name, attempted version, error message (if any), and timestamp for
+each update result. Failure notices persist until the tool is successfully updated.
+Success notices are shown once and cleared after viewing.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg, err := config.DefaultConfig()
@@ -32,11 +33,12 @@ each failed update. Includes both previously shown and unshown notices.`,
 		}
 
 		if len(all) == 0 {
-			printInfo("No update failure notices.")
+			printInfo("No update notices.")
 			return
 		}
 
 		fmt.Printf("%-15s  %-15s  %-30s  %s\n", "TOOL", "VERSION", "ERROR", "TIMESTAMP")
+		var failures, successes int
 		for _, n := range all {
 			errMsg := n.Error
 			if len(errMsg) > 30 {
@@ -48,9 +50,28 @@ each failed update. Includes both previously shown and unshown notices.`,
 				errMsg,
 				n.Timestamp.Format("2006-01-02 15:04:05"),
 			)
+			if n.Error != "" {
+				failures++
+			} else {
+				successes++
+			}
 		}
 
-		printInfof("\n%d notice(s) total. Failed updates were auto-rolled back.\n", len(all))
+		switch {
+		case failures > 0 && successes > 0:
+			printInfof("\n%d failure(s), %d success(es). Failed updates were auto-rolled back. Success entries cleared after viewing.\n", failures, successes)
+		case failures > 0:
+			printInfof("\n%d failure(s). Failed updates were auto-rolled back.\n", failures)
+		default:
+			printInfof("\n%d success(es). Cleared after viewing.\n", successes)
+		}
+
+		// Success notices are shown once; delete them after display.
+		for _, n := range all {
+			if n.Error == "" {
+				_ = notices.RemoveNotice(noticesDir, n.Tool)
+			}
+		}
 	},
 }
 

--- a/cmd/tsuku/install.go
+++ b/cmd/tsuku/install.go
@@ -192,6 +192,7 @@ Exit codes for project install:
 			if err := runInstallWithTelemetry(toolName, "", "", true, "", telemetryClient); err != nil {
 				handleInstallError(err)
 			}
+			clearAndRecordInstallSuccess(toolName)
 			return
 		}
 
@@ -268,6 +269,7 @@ Exit codes for project install:
 				if err := runInstallWithTelemetry(dArgs.RecipeName, resolveVersion, versionConstraint, true, "", telemetryClient); err != nil {
 					handleInstallError(err)
 				}
+				clearAndRecordInstallSuccess(dArgs.RecipeName)
 
 				// Record source and recipe hash on the tool state.
 				// This runs after the install's own state write (which sets Source
@@ -341,6 +343,7 @@ Exit codes for project install:
 			if err := runInstallWithTelemetry(toolName, resolveVersion, versionConstraint, true, "", telemetryClient); err != nil {
 				handleInstallError(err)
 			}
+			clearAndRecordInstallSuccess(toolName)
 		}
 
 		// Recommend shell integration for timely update checks (R5)

--- a/cmd/tsuku/install_deps.go
+++ b/cmd/tsuku/install_deps.go
@@ -6,11 +6,13 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/tsukumogami/tsuku/internal/actions"
 	"github.com/tsukumogami/tsuku/internal/config"
 	"github.com/tsukumogami/tsuku/internal/executor"
 	"github.com/tsukumogami/tsuku/internal/install"
+	"github.com/tsukumogami/tsuku/internal/notices"
 	"github.com/tsukumogami/tsuku/internal/progress"
 	"github.com/tsukumogami/tsuku/internal/recipe"
 	"github.com/tsukumogami/tsuku/internal/shellenv"
@@ -709,4 +711,39 @@ func isSystemDependencyPlan(plan *executor.InstallationPlan) bool {
 		}
 	}
 	return true
+}
+
+// clearAndRecordInstallSuccess checks whether toolName had a failure notice and,
+// if so, removes it and writes a success notice with the tool's current active version.
+// Best-effort: silently ignores errors so notice management never fails an install.
+func clearAndRecordInstallSuccess(toolName string) {
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		return
+	}
+	noticesDir := notices.NoticesDir(cfg.HomeDir)
+	existing, err := notices.ReadNotice(noticesDir, toolName)
+	if err != nil || existing == nil || existing.Error == "" {
+		return
+	}
+	var activeVersion string
+	mgr := install.New(cfg)
+	if tools, err := mgr.List(); err == nil {
+		for _, t := range tools {
+			if t.Name == toolName && t.IsActive {
+				activeVersion = t.Version
+				break
+			}
+		}
+	}
+	_ = notices.RemoveNotice(noticesDir, toolName)
+	if activeVersion != "" {
+		_ = notices.WriteNotice(noticesDir, &notices.Notice{
+			Tool:             toolName,
+			AttemptedVersion: activeVersion,
+			Error:            "",
+			Timestamp:        time.Now(),
+			Shown:            false,
+		})
+	}
 }

--- a/cmd/tsuku/install_deps_test.go
+++ b/cmd/tsuku/install_deps_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/tsukumogami/tsuku/internal/config"
 	"github.com/tsukumogami/tsuku/internal/executor"
 	"github.com/tsukumogami/tsuku/internal/install"
+	"github.com/tsukumogami/tsuku/internal/notices"
 	"github.com/tsukumogami/tsuku/internal/progress"
 	"github.com/tsukumogami/tsuku/internal/testutil"
 )
@@ -588,5 +589,74 @@ func TestInstallWithDependencies_NoStdoutEscape(t *testing.T) {
 	}
 	if len(buf) > 0 {
 		t.Errorf("unexpected bytes written to os.Stdout (%d bytes): %q", len(buf), buf)
+	}
+}
+
+func TestClearAndRecordInstallSuccess_NoFailureNotice(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TSUKU_HOME", dir)
+
+	// No notice on disk — function should be a no-op.
+	clearAndRecordInstallSuccess("infisical")
+
+	noticesDir := notices.NoticesDir(dir)
+	all, err := notices.ReadAllNotices(noticesDir)
+	if err != nil {
+		t.Fatalf("ReadAllNotices: %v", err)
+	}
+	if len(all) != 0 {
+		t.Errorf("expected no notices after no-op, got %d", len(all))
+	}
+}
+
+func TestClearAndRecordInstallSuccess_SuccessNoticeExisting(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TSUKU_HOME", dir)
+
+	// Write a success notice (Error="") — should not be touched.
+	noticesDir := notices.NoticesDir(dir)
+	_ = notices.WriteNotice(noticesDir, &notices.Notice{
+		Tool:             "infisical",
+		AttemptedVersion: "0.43.79",
+		Error:            "",
+		Timestamp:        time.Now(),
+		Shown:            false,
+	})
+
+	clearAndRecordInstallSuccess("infisical")
+
+	all, err := notices.ReadAllNotices(noticesDir)
+	if err != nil {
+		t.Fatalf("ReadAllNotices: %v", err)
+	}
+	if len(all) != 1 {
+		t.Errorf("expected success notice to remain untouched, got %d notices", len(all))
+	}
+}
+
+func TestClearAndRecordInstallSuccess_FailureNoticeCleared(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TSUKU_HOME", dir)
+
+	// Write a failure notice.
+	noticesDir := notices.NoticesDir(dir)
+	_ = notices.WriteNotice(noticesDir, &notices.Notice{
+		Tool:             "infisical",
+		AttemptedVersion: "0.43.79",
+		Error:            "install infisical@0.43.79: download failed",
+		Timestamp:        time.Now(),
+		Shown:            false,
+	})
+
+	// Without a real state.json, List() returns empty so activeVersion="".
+	// The function should still clear the failure notice.
+	clearAndRecordInstallSuccess("infisical")
+
+	all, err := notices.ReadAllNotices(noticesDir)
+	if err != nil {
+		t.Fatalf("ReadAllNotices: %v", err)
+	}
+	if len(all) != 0 {
+		t.Errorf("expected failure notice to be removed, got %d notices", len(all))
 	}
 }

--- a/cmd/tsuku/update.go
+++ b/cmd/tsuku/update.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/tsukumogami/tsuku/internal/config"
 	"github.com/tsukumogami/tsuku/internal/install"
+	"github.com/tsukumogami/tsuku/internal/notices"
 	"github.com/tsukumogami/tsuku/internal/progress"
 	"github.com/tsukumogami/tsuku/internal/telemetry"
 )
@@ -193,6 +195,19 @@ Examples:
 			telemetryClient.SendUpdateOutcome(telemetry.NewUpdateOutcomeSuccessEvent(
 				toolName, previousVersion, newVersion, "manual"))
 		}
+
+		// Clear failure notice; write success notice when version changed.
+		noticesDir := notices.NoticesDir(cfg.HomeDir)
+		_ = notices.RemoveNotice(noticesDir, toolName)
+		if newVersion != "" && newVersion != previousVersion {
+			_ = notices.WriteNotice(noticesDir, &notices.Notice{
+				Tool:             toolName,
+				AttemptedVersion: newVersion,
+				Error:            "",
+				Timestamp:        time.Now(),
+				Shown:            false,
+			})
+		}
 	},
 }
 
@@ -365,6 +380,20 @@ func runUpdateAll(cmd *cobra.Command) {
 		} else {
 			updated++
 		}
+
+		// Clear failure notice; write success notice when version changed.
+		noticesDir := notices.NoticesDir(cfg.HomeDir)
+		_ = notices.RemoveNotice(noticesDir, tool.Name)
+		if newVersion != previousVersion {
+			_ = notices.WriteNotice(noticesDir, &notices.Notice{
+				Tool:             tool.Name,
+				AttemptedVersion: newVersion,
+				Error:            "",
+				Timestamp:        time.Now(),
+				Shown:            false,
+			})
+		}
+
 		toolReporter.Stop()
 		toolReporter.FlushDeferred()
 	}


### PR DESCRIPTION
`tsuku update <tool>` and `tsuku install <tool>` did not remove failure notices after a successful install. A tool could be updated successfully yet still show a failure entry in `tsuku notices` from a previous attempt. The same was true for the `--all` update path. This also adds success notices (cleared after viewing with `tsuku notices`) so users can see when a tool was last updated.

Four changes:

1. **`cmd/tsuku/update.go`**: After a successful single-tool update, call `RemoveNotice` to clear any failure entry and write a success notice (with timestamp) when the version actually changed. The `--all` path gets the same treatment per tool.

2. **`cmd/tsuku/install_deps.go`**: Add `clearAndRecordInstallSuccess` helper that checks whether a failure notice exists for the tool, removes it, and writes a success notice with the now-active version. Only fires when a failure notice is present, so fresh installs don't generate noise.

3. **`cmd/tsuku/install.go`**: Call `clearAndRecordInstallSuccess` at the three install success sites: `--from` installs, distributed installs, and regular named installs.

4. **`cmd/tsuku/cmd_notices.go`**: Update the `notices` command to delete success entries after display (show-once semantics). Rework the footer to report separate failure and success counts with appropriate messages. Update help text to describe both entry types.

Three unit tests cover the new helper: no-op when no failure notice exists, no-op when a success notice already exists, and correct clear-and-rewrite when a failure notice is found.

---

Fixes #2379