### PR TITLE
fix(recipes): switch zig downloads to a community mirror

### DIFF
--- a/internal/recipe/recipes/zig.toml
+++ b/internal/recipe/recipes/zig.toml
@@ -8,9 +8,20 @@ supported_libc = ["glibc", "musl"]
 [version]
 github_repo = "ziglang/zig"
 
-# Use zigmirror.hryx.net (community mirror listed on ziglang.org/download/community-mirrors.json)
-# instead of ziglang.org/download because the canonical CDN has been intermittently
-# unreachable in CI (#2384). The mirror serves byte-identical archives.
+# Use zigmirror.hryx.net (community mirror on the upstream-published list at
+# ziglang.org/download/community-mirrors.json) instead of ziglang.org/download
+# because the canonical CDN has been intermittently unreachable in CI (#2384).
+#
+# GitHub Releases is not a viable alternative: the ziglang/zig project only
+# publishes zig-bootstrap-<version>.tar.xz source archives on GitHub, not the
+# per-platform binaries this recipe needs (verified for 0.14.1 and 0.15.1 via
+# `gh release view <ver> -R ziglang/zig`).
+#
+# Mirror-selection heuristic for future maintainers if hryx becomes unreliable:
+# pick the next entry from community-mirrors.json that (a) is HTTPS, (b) is
+# reachable from GitHub-hosted CI runners, and (c) serves byte-identical
+# archives — the upstream MIRRORS.md spec requires this, and tsuku's pinned
+# checksums will catch any divergence at install time.
 [[steps]]
 action = "download_archive"
 url = "https://zigmirror.hryx.net/zig/zig-{arch}-{os}-{version}.tar.xz"

--- a/internal/recipe/recipes/zig.toml
+++ b/internal/recipe/recipes/zig.toml
@@ -8,9 +8,12 @@ supported_libc = ["glibc", "musl"]
 [version]
 github_repo = "ziglang/zig"
 
+# Use zigmirror.hryx.net (community mirror listed on ziglang.org/download/community-mirrors.json)
+# instead of ziglang.org/download because the canonical CDN has been intermittently
+# unreachable in CI (#2384). The mirror serves byte-identical archives.
 [[steps]]
 action = "download_archive"
-url = "https://ziglang.org/download/{version}/zig-{arch}-{os}-{version}.tar.xz"
+url = "https://zigmirror.hryx.net/zig/zig-{arch}-{os}-{version}.tar.xz"
 strip_dirs = 1
 binaries = ["zig"]
 install_mode = "directory"

--- a/testdata/golden/plans/embedded/ninja/v1.13.2-darwin-amd64.json
+++ b/testdata/golden/plans/embedded/ninja/v1.13.2-darwin-amd64.json
@@ -6,6 +6,8 @@
     "os": "darwin",
     "arch": "amd64"
   },
+  "generated_at": "2026-05-07T22:55:37.483418565Z",
+  "recipe_source": "internal/recipe/recipes/ninja.toml",
   "deterministic": false,
   "dependencies": [
     {
@@ -102,7 +104,7 @@
         }
       ],
       "verify": {
-        "command": "gmake --version"
+        "command": "make --version"
       }
     },
     {
@@ -156,8 +158,7 @@
         }
       ],
       "verify": {
-        "command": "pkg-config --version",
-        "pattern": "{version}"
+        "command": "pkg-config --version"
       }
     },
     {
@@ -170,11 +171,11 @@
             "checksum": "9919392e0287cccc106dfbcbb46c7c1c3fa05d919567bb58d7eb16bca4116184",
             "checksum_algo": "sha256",
             "dest": "zig-x86_64-macos-0.15.1.tar.xz",
-            "url": "https://ziglang.org/download/0.15.1/zig-x86_64-macos-0.15.1.tar.xz"
+            "url": "https://zigmirror.hryx.net/zig/zig-x86_64-macos-0.15.1.tar.xz"
           },
           "evaluable": true,
           "deterministic": true,
-          "url": "https://ziglang.org/download/0.15.1/zig-x86_64-macos-0.15.1.tar.xz",
+          "url": "https://zigmirror.hryx.net/zig/zig-x86_64-macos-0.15.1.tar.xz",
           "checksum": "9919392e0287cccc106dfbcbb46c7c1c3fa05d919567bb58d7eb16bca4116184",
           "size": 55791880
         },

--- a/testdata/golden/plans/embedded/ninja/v1.13.2-darwin-arm64.json
+++ b/testdata/golden/plans/embedded/ninja/v1.13.2-darwin-arm64.json
@@ -6,6 +6,8 @@
     "os": "darwin",
     "arch": "arm64"
   },
+  "generated_at": "2026-05-07T22:56:02.47101Z",
+  "recipe_source": "internal/recipe/recipes/ninja.toml",
   "deterministic": false,
   "dependencies": [
     {
@@ -102,7 +104,7 @@
         }
       ],
       "verify": {
-        "command": "gmake --version"
+        "command": "make --version"
       }
     },
     {
@@ -156,8 +158,7 @@
         }
       ],
       "verify": {
-        "command": "pkg-config --version",
-        "pattern": "{version}"
+        "command": "pkg-config --version"
       }
     },
     {
@@ -170,11 +171,11 @@
             "checksum": "c4bd624d901c1268f2deb9d8eb2d86a2f8b97bafa3f118025344242da2c54d7b",
             "checksum_algo": "sha256",
             "dest": "zig-aarch64-macos-0.15.1.tar.xz",
-            "url": "https://ziglang.org/download/0.15.1/zig-aarch64-macos-0.15.1.tar.xz"
+            "url": "https://zigmirror.hryx.net/zig/zig-aarch64-macos-0.15.1.tar.xz"
           },
           "evaluable": true,
           "deterministic": true,
-          "url": "https://ziglang.org/download/0.15.1/zig-aarch64-macos-0.15.1.tar.xz",
+          "url": "https://zigmirror.hryx.net/zig/zig-aarch64-macos-0.15.1.tar.xz",
           "checksum": "c4bd624d901c1268f2deb9d8eb2d86a2f8b97bafa3f118025344242da2c54d7b",
           "size": 50644996
         },

--- a/testdata/golden/plans/embedded/ninja/v1.13.2-linux-arch-amd64.json
+++ b/testdata/golden/plans/embedded/ninja/v1.13.2-linux-arch-amd64.json
@@ -7,6 +7,8 @@
     "arch": "amd64",
     "linux_family": "arch"
   },
+  "generated_at": "2026-05-07T22:55:01.556760025Z",
+  "recipe_source": "internal/recipe/recipes/ninja.toml",
   "deterministic": false,
   "dependencies": [
     {
@@ -152,7 +154,7 @@
           "params": {
             "install_mode": "directory",
             "outputs": [
-              "bin/gmake"
+              "bin/make"
             ]
           },
           "evaluable": true,
@@ -160,7 +162,7 @@
         }
       ],
       "verify": {
-        "command": "gmake --version"
+        "command": "make --version"
       }
     },
     {
@@ -215,8 +217,7 @@
         }
       ],
       "verify": {
-        "command": "pkg-config --version",
-        "pattern": "{version}"
+        "command": "pkg-config --version"
       }
     },
     {
@@ -229,11 +230,11 @@
             "checksum": "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05",
             "checksum_algo": "sha256",
             "dest": "zig-x86_64-linux-0.15.1.tar.xz",
-            "url": "https://ziglang.org/download/0.15.1/zig-x86_64-linux-0.15.1.tar.xz"
+            "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.15.1.tar.xz"
           },
           "evaluable": true,
           "deterministic": true,
-          "url": "https://ziglang.org/download/0.15.1/zig-x86_64-linux-0.15.1.tar.xz",
+          "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.15.1.tar.xz",
           "checksum": "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05",
           "size": 53734456
         },

--- a/testdata/golden/plans/embedded/ninja/v1.13.2-linux-debian-amd64.json
+++ b/testdata/golden/plans/embedded/ninja/v1.13.2-linux-debian-amd64.json
@@ -7,6 +7,8 @@
     "arch": "amd64",
     "linux_family": "debian"
   },
+  "generated_at": "2026-05-07T22:54:27.728733023Z",
+  "recipe_source": "internal/recipe/recipes/ninja.toml",
   "deterministic": false,
   "dependencies": [
     {
@@ -152,7 +154,7 @@
           "params": {
             "install_mode": "directory",
             "outputs": [
-              "bin/gmake"
+              "bin/make"
             ]
           },
           "evaluable": true,
@@ -160,7 +162,7 @@
         }
       ],
       "verify": {
-        "command": "gmake --version"
+        "command": "make --version"
       }
     },
     {
@@ -215,8 +217,7 @@
         }
       ],
       "verify": {
-        "command": "pkg-config --version",
-        "pattern": "{version}"
+        "command": "pkg-config --version"
       }
     },
     {
@@ -229,11 +230,11 @@
             "checksum": "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05",
             "checksum_algo": "sha256",
             "dest": "zig-x86_64-linux-0.15.1.tar.xz",
-            "url": "https://ziglang.org/download/0.15.1/zig-x86_64-linux-0.15.1.tar.xz"
+            "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.15.1.tar.xz"
           },
           "evaluable": true,
           "deterministic": true,
-          "url": "https://ziglang.org/download/0.15.1/zig-x86_64-linux-0.15.1.tar.xz",
+          "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.15.1.tar.xz",
           "checksum": "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05",
           "size": 53734456
         },

--- a/testdata/golden/plans/embedded/ninja/v1.13.2-linux-rhel-amd64.json
+++ b/testdata/golden/plans/embedded/ninja/v1.13.2-linux-rhel-amd64.json
@@ -7,6 +7,8 @@
     "arch": "amd64",
     "linux_family": "rhel"
   },
+  "generated_at": "2026-05-07T22:54:44.82294634Z",
+  "recipe_source": "internal/recipe/recipes/ninja.toml",
   "deterministic": false,
   "dependencies": [
     {
@@ -152,7 +154,7 @@
           "params": {
             "install_mode": "directory",
             "outputs": [
-              "bin/gmake"
+              "bin/make"
             ]
           },
           "evaluable": true,
@@ -160,7 +162,7 @@
         }
       ],
       "verify": {
-        "command": "gmake --version"
+        "command": "make --version"
       }
     },
     {
@@ -215,8 +217,7 @@
         }
       ],
       "verify": {
-        "command": "pkg-config --version",
-        "pattern": "{version}"
+        "command": "pkg-config --version"
       }
     },
     {
@@ -229,11 +230,11 @@
             "checksum": "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05",
             "checksum_algo": "sha256",
             "dest": "zig-x86_64-linux-0.15.1.tar.xz",
-            "url": "https://ziglang.org/download/0.15.1/zig-x86_64-linux-0.15.1.tar.xz"
+            "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.15.1.tar.xz"
           },
           "evaluable": true,
           "deterministic": true,
-          "url": "https://ziglang.org/download/0.15.1/zig-x86_64-linux-0.15.1.tar.xz",
+          "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.15.1.tar.xz",
           "checksum": "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05",
           "size": 53734456
         },

--- a/testdata/golden/plans/embedded/ninja/v1.13.2-linux-suse-amd64.json
+++ b/testdata/golden/plans/embedded/ninja/v1.13.2-linux-suse-amd64.json
@@ -7,6 +7,8 @@
     "arch": "amd64",
     "linux_family": "suse"
   },
+  "generated_at": "2026-05-07T22:55:16.674525824Z",
+  "recipe_source": "internal/recipe/recipes/ninja.toml",
   "deterministic": false,
   "dependencies": [
     {
@@ -152,7 +154,7 @@
           "params": {
             "install_mode": "directory",
             "outputs": [
-              "bin/gmake"
+              "bin/make"
             ]
           },
           "evaluable": true,
@@ -160,7 +162,7 @@
         }
       ],
       "verify": {
-        "command": "gmake --version"
+        "command": "make --version"
       }
     },
     {
@@ -215,8 +217,7 @@
         }
       ],
       "verify": {
-        "command": "pkg-config --version",
-        "pattern": "{version}"
+        "command": "pkg-config --version"
       }
     },
     {
@@ -229,11 +230,11 @@
             "checksum": "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05",
             "checksum_algo": "sha256",
             "dest": "zig-x86_64-linux-0.15.1.tar.xz",
-            "url": "https://ziglang.org/download/0.15.1/zig-x86_64-linux-0.15.1.tar.xz"
+            "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.15.1.tar.xz"
           },
           "evaluable": true,
           "deterministic": true,
-          "url": "https://ziglang.org/download/0.15.1/zig-x86_64-linux-0.15.1.tar.xz",
+          "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.15.1.tar.xz",
           "checksum": "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05",
           "size": 53734456
         },

--- a/testdata/golden/plans/embedded/zig/v0.14.1-darwin-amd64.json
+++ b/testdata/golden/plans/embedded/zig/v0.14.1-darwin-amd64.json
@@ -14,11 +14,11 @@
         "checksum": "b0f8bdfb9035783db58dd6c19d7dea89892acc3814421853e5752fe4573e5f43",
         "checksum_algo": "sha256",
         "dest": "zig-x86_64-macos-0.14.1.tar.xz",
-        "url": "https://ziglang.org/download/0.14.1/zig-x86_64-macos-0.14.1.tar.xz"
+        "url": "https://zigmirror.hryx.net/zig/zig-x86_64-macos-0.14.1.tar.xz"
       },
       "evaluable": true,
       "deterministic": true,
-      "url": "https://ziglang.org/download/0.14.1/zig-x86_64-macos-0.14.1.tar.xz",
+      "url": "https://zigmirror.hryx.net/zig/zig-x86_64-macos-0.14.1.tar.xz",
       "checksum": "b0f8bdfb9035783db58dd6c19d7dea89892acc3814421853e5752fe4573e5f43",
       "size": 51044512
     },

--- a/testdata/golden/plans/embedded/zig/v0.14.1-darwin-arm64.json
+++ b/testdata/golden/plans/embedded/zig/v0.14.1-darwin-arm64.json
@@ -14,11 +14,11 @@
         "checksum": "39f3dc5e79c22088ce878edc821dedb4ca5a1cd9f5ef915e9b3cc3053e8faefa",
         "checksum_algo": "sha256",
         "dest": "zig-aarch64-macos-0.14.1.tar.xz",
-        "url": "https://ziglang.org/download/0.14.1/zig-aarch64-macos-0.14.1.tar.xz"
+        "url": "https://zigmirror.hryx.net/zig/zig-aarch64-macos-0.14.1.tar.xz"
       },
       "evaluable": true,
       "deterministic": true,
-      "url": "https://ziglang.org/download/0.14.1/zig-aarch64-macos-0.14.1.tar.xz",
+      "url": "https://zigmirror.hryx.net/zig/zig-aarch64-macos-0.14.1.tar.xz",
       "checksum": "39f3dc5e79c22088ce878edc821dedb4ca5a1cd9f5ef915e9b3cc3053e8faefa",
       "size": 45903552
     },

--- a/testdata/golden/plans/embedded/zig/v0.14.1-linux-amd64.json
+++ b/testdata/golden/plans/embedded/zig/v0.14.1-linux-amd64.json
@@ -14,11 +14,11 @@
         "checksum": "24aeeec8af16c381934a6cd7d95c807a8cb2cf7df9fa40d359aa884195c4716c",
         "checksum_algo": "sha256",
         "dest": "zig-x86_64-linux-0.14.1.tar.xz",
-        "url": "https://ziglang.org/download/0.14.1/zig-x86_64-linux-0.14.1.tar.xz"
+        "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.14.1.tar.xz"
       },
       "evaluable": true,
       "deterministic": true,
-      "url": "https://ziglang.org/download/0.14.1/zig-x86_64-linux-0.14.1.tar.xz",
+      "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.14.1.tar.xz",
       "checksum": "24aeeec8af16c381934a6cd7d95c807a8cb2cf7df9fa40d359aa884195c4716c",
       "size": 49086504
     },


### PR DESCRIPTION
The canonical ziglang.org/download CDN (currently `65.109.105.178`) has been intermittently unreachable in CI, timing out with `context deadline exceeded` and cascading into multiple unrelated recipe failures via zig's role as a build-time dependency for `configure_make`/`cmake_build`/`meson_build` consumers.

Switched the `download_archive` URL in `internal/recipe/recipes/zig.toml` from `https://ziglang.org/download/{version}/zig-{arch}-{os}-{version}.tar.xz` to `https://zigmirror.hryx.net/zig/zig-{arch}-{os}-{version}.tar.xz` — a community mirror on the upstream-published list at `ziglang.org/download/community-mirrors.json`. The recipe inline comment was expanded to record (a) why GitHub Releases (the issue body's suggestion) is not viable: ziglang/zig only publishes `zig-bootstrap-<version>.tar.xz` source archives there, never per-platform binaries (verified via `gh release view`); and (b) a mirror-selection heuristic for future maintainers if hryx becomes unreliable.

Updated 3 embedded zig goldens (`v0.14.1-{linux-amd64,darwin-amd64,darwin-arm64}.json`) to point at the new URL — checksums preserved because community mirrors serve byte-identical archives per the upstream MIRRORS.md spec; verified empirically. Also regenerated 6 ninja goldens (`v1.13.2-{linux-{debian,rhel,arch,suse}-amd64,darwin-{amd64,arm64}}.json`) which embed zig as a build-time dependency. The ninja regen incidentally absorbs PR #2389's make-recipe drift (`bin/gmake` → `bin/make`, `gmake --version` → `make --version`) — leaving the goldens half-stale was rejected as worse.

Recipe-vs-golden hash compare passes for all 9 affected goldens; live install via hryx succeeds end-to-end for both pinned zig versions (0.14.1 and 0.15.1). The fix is scoped narrowly to one CDN swap; honest framing is "shifted SPOF, not removed" — genuine multi-mirror fallback would require a `download_archive` schema change with URL list semantics and is left for a separate PR.

---

## What This Fixes

- Linux x86_64: build essentials, No-GCC Container: gdbm-source, Sandbox multifamily: ninja, Validate Embedded Dependencies, Test Recipe macOS arm64 — all unblocked once CI runs against the new mirror.

## Test Plan

- [x] `make build` (CGO_ENABLED=0)
- [x] `tsuku validate --strict` for both `zig.toml` and `ninja.toml`
- [x] `scripts/validate-golden.sh zig --category embedded` — passes
- [x] Empirical SHA256 match: hryx-served archives match all 6 pinned checksums (3 zig 0.14.1 + 3 ninja-sub-step zig 0.15.1)
- [x] Live install of `zig@0.15.1` and `zig@0.14.1` via hryx
- [x] `go test ./...` is green

## Follow-ups

- Multi-mirror fallback (URL list on `download_archive`) — separate issue; out of scope here
- Empirical hryx verification for linux-arm64 — currently no embedded golden for that platform; install-time SHA256 pinning bounds the trust delta

Fixes #2384