### PR TITLE
fix(recipes): tmux verify in sandbox containers via system packages

### DIFF
--- a/internal/sandbox/container_spec.go
+++ b/internal/sandbox/container_spec.go
@@ -291,13 +291,24 @@ func generateArchCommands(packages []string, repositories []RepositoryConfig) []
 	// Arch doesn't commonly use third-party repositories in containers
 	// If needed, repository support can be added later
 
-	// Install packages
+	// Install packages.
+	//
+	// Use `pacman -Syu` (sync DB + full system upgrade) instead of `pacman -Sy`
+	// (DB-only) to avoid the well-known Arch "partial upgrade" trap: if the
+	// base archlinux:base image is older than the current package repos, then
+	// `-Sy` updates the DB to the latest manifests, and a subsequent install
+	// pulls newer versions of the requested packages while leaving their
+	// already-present system-lib dependencies at the older base-image versions.
+	// The result is unresolved symbols at runtime (e.g. pacman itself failing
+	// with `libcurl.so.4: undefined symbol: ngtcp2_crypto_get_path_challenge_…`).
+	// `-Syu` syncs everything in one step so installed packages and their
+	// runtime libs remain ABI-compatible.
 	if len(packages) > 0 {
 		sorted := make([]string, len(packages))
 		copy(sorted, packages)
 		sort.Strings(sorted)
 		pkgList := strings.Join(sorted, " ")
-		commands = append(commands, fmt.Sprintf("RUN pacman -Sy --noconfirm %s", pkgList))
+		commands = append(commands, fmt.Sprintf("RUN pacman -Syu --noconfirm %s", pkgList))
 	}
 
 	return commands

--- a/internal/sandbox/container_spec.go
+++ b/internal/sandbox/container_spec.go
@@ -291,18 +291,13 @@ func generateArchCommands(packages []string, repositories []RepositoryConfig) []
 	// Arch doesn't commonly use third-party repositories in containers
 	// If needed, repository support can be added later
 
-	// Install packages.
-	//
-	// Use `pacman -Syu` (sync DB + full system upgrade) instead of `pacman -Sy`
-	// (DB-only) to avoid the well-known Arch "partial upgrade" trap: if the
-	// base archlinux:base image is older than the current package repos, then
-	// `-Sy` updates the DB to the latest manifests, and a subsequent install
-	// pulls newer versions of the requested packages while leaving their
-	// already-present system-lib dependencies at the older base-image versions.
-	// The result is unresolved symbols at runtime (e.g. pacman itself failing
-	// with `libcurl.so.4: undefined symbol: ngtcp2_crypto_get_path_challenge_…`).
-	// `-Syu` syncs everything in one step so installed packages and their
-	// runtime libs remain ABI-compatible.
+	// Install packages with full system upgrade (-Syu, not -Sy) so installed
+	// packages and base-image system libs stay ABI-compatible: the base
+	// archlinux:base image lags the live repos, and -Sy alone triggers the
+	// Arch "partial upgrade" trap (#2385). Cost: 30-120s and ~50-200MB extra
+	// per cold-cache build. ContainerImageName does not hash BuildCommands,
+	// so existing cached arch images keep their old layers and only fresh
+	// builds pick this up.
 	if len(packages) > 0 {
 		sorted := make([]string, len(packages))
 		copy(sorted, packages)

--- a/internal/sandbox/container_spec_test.go
+++ b/internal/sandbox/container_spec_test.go
@@ -163,7 +163,9 @@ func TestDeriveContainerSpec_BuildCommands(t *testing.T) {
 			name:     "arch - pacman packages",
 			packages: map[string][]string{"pacman": {"git", "base-devel"}},
 			wantCommands: []string{
-				"RUN pacman -Sy --noconfirm base-devel git",
+				// -Syu (full system upgrade) avoids partial-upgrade ABI breaks
+				// when the base archlinux:base image lags the live package repos.
+				"RUN pacman -Syu --noconfirm base-devel git",
 			},
 		},
 		{

--- a/internal/sandbox/container_spec_test.go
+++ b/internal/sandbox/container_spec_test.go
@@ -160,11 +160,10 @@ func TestDeriveContainerSpec_BuildCommands(t *testing.T) {
 			},
 		},
 		{
-			name:     "arch - pacman packages",
+			// Asserts -Syu (not -Sy) to avoid the Arch partial-upgrade trap (#2385).
+			name:     "arch - pacman uses -Syu to avoid partial upgrades",
 			packages: map[string][]string{"pacman": {"git", "base-devel"}},
 			wantCommands: []string{
-				// -Syu (full system upgrade) avoids partial-upgrade ABI breaks
-				// when the base archlinux:base image lags the live package repos.
 				"RUN pacman -Syu --noconfirm base-devel git",
 			},
 		},

--- a/recipes/t/tmux.toml
+++ b/recipes/t/tmux.toml
@@ -10,19 +10,19 @@ curated = true
 # on macOS via tsuku. darwin coverage is excluded until these deps are supported.
 supported_os = ["linux"]
 
-# Linux: install via system package manager. The Homebrew bottle path was
-# tried first but fails inside sandbox containers because the bottle's
-# NEEDED entries (libutf8proc.so.3, libevent-2.1.so.7, libncursesw.so.6)
-# resolve via the system loader, and runtime_dependencies are not yet
-# wired through plan generation / sandbox install (#2385). System packages
-# pull tmux's transitive lib chain in as a single distro-managed unit and
-# match the established pattern for tools that depend on multiple system
-# libraries (see mesa-vulkan-drivers, vulkan-loader, nvidia-driver).
+# Linux: install via system package manager (tactical workaround, #2385).
+# Was Homebrew bottle until #2385; reverted because the bottle's NEEDED
+# entries (libutf8proc, libevent, libncursesw) need a chained-lib RPATH
+# walk to resolve in sandbox containers, and that architecture isn't on
+# main yet. Same pattern as mesa-vulkan-drivers / vulkan-loader /
+# nvidia-driver. The five families below cover every Linux family tsuku
+# resolves (see internal/platform/family.go); other distros are rejected
+# at family-resolution time.
 #
-# TODO(#2381): once the chained-lib-dependencies / RPATH chain-walk
-# architecture lands, this recipe can revert to the Homebrew bottle path
-# (which gives version pinning) and re-enable macOS via runtime_dependencies =
-# ["libevent", "utf8proc", "ncurses"].
+# TODO(#2381): revert to Homebrew bottle + runtime_dependencies =
+# ["libevent", "utf8proc", "ncurses"] once `resolveRuntimeDepVersion`
+# lands in internal/actions/homebrew_relocate.go and ncurses.toml
+# declares type = "library".
 
 [[steps]]
 action = "apt_install"
@@ -53,5 +53,8 @@ when = { os = ["linux"], libc = ["musl"] }
 [verify]
 command = "tmux -V"
 mode = "output"
+# Literal-word substring (not a version regex): survives distro version drift
+# while still catching the case where some other binary aliased to `tmux` exits
+# 0 with non-tmux output.
 pattern = "tmux"
-reason = "System packages install at the distribution's pinned tmux version, not the recipe's pinned version; output mode + a 'tmux' substring pattern verifies availability and that the binary that ran is actually tmux (not a silently-broken ABI mismatch printing garbage), without locking to a specific version string."
+reason = "System packages install at the distribution's pinned tmux version, not the recipe's pinned version; output mode verifies availability and binary identity across distro version drift."

--- a/recipes/t/tmux.toml
+++ b/recipes/t/tmux.toml
@@ -17,7 +17,12 @@ supported_os = ["linux"]
 # wired through plan generation / sandbox install (#2385). System packages
 # pull tmux's transitive lib chain in as a single distro-managed unit and
 # match the established pattern for tools that depend on multiple system
-# libraries (see make.toml).
+# libraries (see mesa-vulkan-drivers, vulkan-loader, nvidia-driver).
+#
+# TODO(#2381): once the chained-lib-dependencies / RPATH chain-walk
+# architecture lands, this recipe can revert to the Homebrew bottle path
+# (which gives version pinning) and re-enable macOS via runtime_dependencies =
+# ["libevent", "utf8proc", "ncurses"].
 
 [[steps]]
 action = "apt_install"
@@ -48,4 +53,5 @@ when = { os = ["linux"], libc = ["musl"] }
 [verify]
 command = "tmux -V"
 mode = "output"
-reason = "System packages install at the distribution's pinned tmux version, not the recipe's pinned version; output mode verifies availability across distro version drift."
+pattern = "tmux"
+reason = "System packages install at the distribution's pinned tmux version, not the recipe's pinned version; output mode + a 'tmux' substring pattern verifies availability and that the binary that ran is actually tmux (not a silently-broken ABI mismatch printing garbage), without locking to a specific version string."

--- a/recipes/t/tmux.toml
+++ b/recipes/t/tmux.toml
@@ -10,17 +10,34 @@ curated = true
 # on macOS via tsuku. darwin coverage is excluded until these deps are supported.
 supported_os = ["linux"]
 
-# glibc Linux: Homebrew bottle
-[[steps]]
-action = "homebrew"
-formula = "tmux"
-when = { os = ["linux"], libc = ["glibc"] }
+# Linux: install via system package manager. The Homebrew bottle path was
+# tried first but fails inside sandbox containers because the bottle's
+# NEEDED entries (libutf8proc.so.3, libevent-2.1.so.7, libncursesw.so.6)
+# resolve via the system loader, and runtime_dependencies are not yet
+# wired through plan generation / sandbox install (#2385). System packages
+# pull tmux's transitive lib chain in as a single distro-managed unit and
+# match the established pattern for tools that depend on multiple system
+# libraries (see make.toml).
 
 [[steps]]
-action = "install_binaries"
-install_mode = "directory"
-outputs = ["bin/tmux"]
-when = { os = ["linux"], libc = ["glibc"] }
+action = "apt_install"
+packages = ["tmux"]
+when = { os = ["linux"], libc = ["glibc"], linux_family = "debian" }
+
+[[steps]]
+action = "dnf_install"
+packages = ["tmux"]
+when = { os = ["linux"], libc = ["glibc"], linux_family = "rhel" }
+
+[[steps]]
+action = "pacman_install"
+packages = ["tmux"]
+when = { os = ["linux"], libc = ["glibc"], linux_family = "arch" }
+
+[[steps]]
+action = "zypper_install"
+packages = ["tmux"]
+when = { os = ["linux"], libc = ["glibc"], linux_family = "suse" }
 
 # musl Linux: Alpine package
 [[steps]]
@@ -30,4 +47,5 @@ when = { os = ["linux"], libc = ["musl"] }
 
 [verify]
 command = "tmux -V"
-pattern = "tmux {version}"
+mode = "output"
+reason = "System packages install at the distribution's pinned tmux version, not the recipe's pinned version; output mode verifies availability across distro version drift."

--- a/test/scripts/test-checksum-pinning.sh
+++ b/test/scripts/test-checksum-pinning.sh
@@ -89,8 +89,10 @@ WORKDIR /home/testuser
 EOF
         ;;
     arch)
+        # -Syu (full system upgrade) keeps installed packages ABI-compatible
+        # with base-image system libs; matches sandbox/container_spec.go (#2385).
         cat >> "$DOCKERFILE" << 'EOF'
-RUN pacman -Sy --noconfirm ca-certificates
+RUN pacman -Syu --noconfirm ca-certificates
 RUN useradd -m -s /bin/bash testuser
 USER testuser
 WORKDIR /home/testuser


### PR DESCRIPTION
The `tmux` recipe's Homebrew-bottle path on Linux glibc fails inside sandbox containers because the bottle's binary has NEEDED entries for `libutf8proc.so.3`, `libevent-2.1.so.7`, and `libncursesw.so.6`. None of those resolve in the sandbox containers, and `runtime_dependencies` is not consumed by the `--sandbox` / `--plan` install paths today (only `cmd/tsuku/install_deps.go` reads it). PR #2381's chain-walk RPATH design will be the architectural fix; this PR is a tactical workaround so the test matrix passes today.

Switched the Linux glibc steps from `homebrew` + `install_binaries` to per-family system packages (`apt_install` / `dnf_install` / `pacman_install` / `zypper_install`) and kept alpine on the existing `apk_install`. macOS remains excluded via `supported_os = ["linux"]` until #2381 lands. Verify becomes `mode = "output"` with `pattern = "tmux"` so distro version drift is accepted while binary identity is still asserted. The recipe carries an inline `TODO(#2381)` with checkable in-repo preconditions so a future maintainer can spot when the revert is unblocked.

While exercising the arch leg, also fixed a generic Arch sandbox bug: `internal/sandbox/container_spec.go:generateArchCommands` emitted `pacman -Sy --noconfirm <pkgs>` which triggered the well-known partial-upgrade trap. The base `archlinux:base` image lags the live repos; `-Sy` refreshes the DB and a subsequent install pulls newer packages while leaving system libs at older base-image versions, breaking pacman itself with `libcurl.so.4: undefined symbol: ngtcp2_crypto_get_path_challenge_data2_cb`. Switched to `pacman -Syu` so installed packages and runtime libs upgrade in lockstep. Test fixture and the parallel `pacman -Sy` in `test/scripts/test-checksum-pinning.sh` were updated to match.

---

## What This Fixes

- All five Linux container family sandbox tests pass tmux verify locally (`debian`, `rhel`, `arch`, `suse`, `alpine`).
- Any recipe using `pacman_install` no longer hits the Arch partial-upgrade trap on a cold cache.
- Loose `tsuku install tmux` on a glibc Linux dev host now reports a `DependencyMissingError` with a copy-paste `apt`/`dnf`/`pacman`/`zypper` command instead of silently installing a Homebrew bottle that won't run portably.

## Test Plan

- [x] `make build` (CGO_ENABLED=0)
- [x] `tsuku validate --strict recipes/t/tmux.toml` — Valid
- [x] For each of `debian`, `rhel`, `arch`, `suse`, `alpine`: `tsuku install --sandbox --force --recipe recipes/t/tmux.toml --target-family $f --json` returns `passed: true, verify_exit_code: 0`
- [x] `go test ./internal/sandbox/... ./internal/recipe/...` is green
- [x] `go test ./...` is green (one pre-existing unrelated `internal/builders/TestLLMGroundTruth` LLM-benchmark failure observed; out of scope)
- [x] Linux arm64 sandbox (deferred to CI runners — local host is x86_64; recipe is arch-agnostic)

## Follow-ups

- PR #2381 is the architectural fix that will let tmux revert to the Homebrew-bottle path with `runtime_dependencies = ["libevent", "utf8proc", "ncurses"]`. The recipe's inline `TODO(#2381)` names the in-repo signals (`resolveRuntimeDepVersion` in `homebrew_relocate.go`, `type = "library"` on `ncurses.toml`) so the revert is grep-able.
- macOS arm64 (raised in an issue comment as a scope correction) needs PR #2381's chain-walk and the ncurses retype; explicitly deferred from this PR.
- `ContainerImageName` does not hash `BuildCommands`, so the `pacman -Syu` change does not auto-invalidate previously-cached arch sandbox images. Documented inline; worth a separate PR.

Fixes #2385