### PR TITLE
perf(ci): split Linux build-essentials job into per-tool matrix

### DIFF
--- a/.github/workflows/build-essentials.yml
+++ b/.github/workflows/build-essentials.yml
@@ -47,14 +47,37 @@ on:
       - 'go.mod'
 
 jobs:
-  # Consolidated Linux build essentials tests
-  # Each tool runs via tsuku install --sandbox for containerized execution.
-  # TLS test runs host-level (multi-recipe orchestration across ca-certs + curl).
-  # Pattern follows test-recipe.yml: --sandbox --force --json with result parsing.
+  # Each tool runs as a separate parallel matrix job so a single failure
+  # does not delay feedback on the others and each tool's pass/fail state
+  # appears as a distinct status check on the PR. The tradeoff is higher
+  # runner-minute consumption (~80 min across 10 jobs) vs. the old sequential
+  # approach (~25 min in one job), which is acceptable given the significant
+  # improvement to PR feedback latency.
+  #
+  # To add a new tool: insert one entry in the matrix list. No other changes needed.
   test-linux:
-    name: "Linux x86_64: build essentials"
+    name: "Linux x86_64: ${{ matrix.tool.name }}"
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        tool:
+          # Homebrew bottles (make excluded - see #1581)
+          # pngcrush tests dependency chain: pngcrush -> libpng -> zlib
+          - { name: pkg-config,      arg: "pkg-config" }
+          - { name: cmake,           arg: "cmake" }
+          - { name: gdbm,            arg: "gdbm" }
+          - { name: pngcrush,        arg: "pngcrush" }
+          # Source build recipes
+          - { name: libsixel-source, arg: "--recipe testdata/recipes/libsixel-source.toml" }
+          - { name: ninja,           arg: "ninja" }
+          - { name: sqlite-source,   arg: "--recipe testdata/recipes/sqlite-source.toml" }
+          - { name: git-source,      arg: "--recipe testdata/recipes/git-source.toml" }
+          # Binary install
+          - { name: zig,             arg: "zig" }
+          # TLS test (host-level, multi-recipe orchestration; no arg used)
+          - { name: tls-cacerts,     arg: "" }
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -67,105 +90,46 @@ jobs:
       - name: Build tsuku
         run: CGO_ENABLED=0 go build -o tsuku ./cmd/tsuku
 
-      - name: Test tools via sandbox
+      - name: "Test ${{ matrix.tool.name }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TSUKU_REGISTRY_URL: https://raw.githubusercontent.com/${{ github.repository }}/${{ github.head_ref || github.ref_name }}
         run: |
-          TOTAL=0
-          PASSED=0
-          FAILED=()
-          RESULTS=""
-
-          sandbox_test() {
-              local name="$1"
-              shift
-              TOTAL=$((TOTAL + 1))
-              echo "::group::Sandbox: $name"
-              RESULT_FILE=".result-${name}.json"
-
-              ./tsuku install --sandbox --force "$@" \
-                --env GITHUB_TOKEN="$GITHUB_TOKEN" \
-                --json > "$RESULT_FILE" || true
-
-              if [ -f "$RESULT_FILE" ] && jq -e . "$RESULT_FILE" > /dev/null 2>&1; then
-                SANDBOX_PASSED=$(jq -r '.passed' "$RESULT_FILE")
-                # Sandbox JSON uses install_exit_code; error JSON uses exit_code
-                if jq -e '.install_exit_code' "$RESULT_FILE" > /dev/null 2>&1; then
-                  EXIT_CODE=$(jq -r '.install_exit_code' "$RESULT_FILE")
-                else
-                  EXIT_CODE=$(jq -r '.exit_code // 1' "$RESULT_FILE")
-                fi
-              else
-                SANDBOX_PASSED="false"
-                EXIT_CODE=1
-              fi
-
-              if [ "$SANDBOX_PASSED" = "true" ]; then
-                PASSED=$((PASSED + 1))
-                RESULTS="$RESULTS| $name | pass |\n"
-                echo "PASS: $name"
-              else
-                FAILED+=("$name")
-                RESULTS="$RESULTS| $name | **FAIL** (exit $EXIT_CODE) |\n"
-                echo "FAIL: $name (exit $EXIT_CODE)"
-                # Print error details and full JSON for debugging
-                if [ -f "$RESULT_FILE" ]; then
-                  ERROR_MSG=$(jq -r '.error // .message // "unknown"' "$RESULT_FILE")
-                  echo "Error: $ERROR_MSG"
-                  echo "Full result:"
-                  jq . "$RESULT_FILE"
-                fi
-              fi
-              echo "::endgroup::"
-          }
-
-          # Homebrew tools (make excluded - see #1581)
-          # pngcrush tests dependency chain: pngcrush -> libpng -> zlib
-          for tool in pkg-config cmake gdbm pngcrush; do
-            sandbox_test "$tool" "$tool"
-          done
-
-          # Source build recipes
-          sandbox_test "libsixel-source" --recipe testdata/recipes/libsixel-source.toml
-          sandbox_test "ninja" ninja
-          sandbox_test "sqlite-source" --recipe testdata/recipes/sqlite-source.toml
-          sandbox_test "git-source" --recipe testdata/recipes/git-source.toml
-
-          # Binary install
-          sandbox_test "zig" zig
-
-          # TLS test (host-level, multi-recipe orchestration)
-          echo "::group::TLS CA certs"
-          TOTAL=$((TOTAL + 1))
-          export TSUKU_HOME="${{ runner.temp }}/tsuku-tls"
-          if timeout 300 ./test/scripts/test-tls-cacerts.sh ./tsuku; then
-            PASSED=$((PASSED + 1))
-            RESULTS="$RESULTS| tls-cacerts | pass |\n"
-            echo "PASS: tls-cacerts"
+          if [ "${{ matrix.tool.name }}" = "tls-cacerts" ]; then
+            export TSUKU_HOME="${{ runner.temp }}/tsuku-tls"
+            timeout 300 ./test/scripts/test-tls-cacerts.sh ./tsuku
           else
-            FAILED+=("tls-cacerts")
-            RESULTS="$RESULTS| tls-cacerts | **FAIL** |\n"
-            echo "FAIL: tls-cacerts"
-          fi
-          echo "::endgroup::"
+            RESULT_FILE=".result-${{ matrix.tool.name }}.json"
+            read -ra ARGS <<< "${{ matrix.tool.arg }}"
+            ./tsuku install --sandbox --force "${ARGS[@]}" \
+              --env GITHUB_TOKEN="$GITHUB_TOKEN" \
+              --json > "$RESULT_FILE" || true
 
-          # Job summary
-          {
-            echo "### Linux Build Essentials Results"
-            echo ""
-            echo "Passed: $PASSED / $TOTAL"
-            echo ""
-            echo "| Tool | Status |"
-            echo "|------|--------|"
-            echo -e "$RESULTS"
-          } >> "$GITHUB_STEP_SUMMARY"
+            if [ -f "$RESULT_FILE" ] && jq -e . "$RESULT_FILE" > /dev/null 2>&1; then
+              SANDBOX_PASSED=$(jq -r '.passed' "$RESULT_FILE")
+              # Sandbox JSON uses install_exit_code; error JSON uses exit_code
+              if jq -e '.install_exit_code' "$RESULT_FILE" > /dev/null 2>&1; then
+                EXIT_CODE=$(jq -r '.install_exit_code' "$RESULT_FILE")
+              else
+                EXIT_CODE=$(jq -r '.exit_code // 1' "$RESULT_FILE")
+              fi
+            else
+              SANDBOX_PASSED="false"
+              EXIT_CODE=1
+            fi
 
-          if [ ${#FAILED[@]} -gt 0 ]; then
-            echo "::error::Failed: ${FAILED[*]}"
-            exit 1
+            if [ "$SANDBOX_PASSED" = "true" ]; then
+              echo "PASS: ${{ matrix.tool.name }}"
+            else
+              echo "FAIL: ${{ matrix.tool.name }} (exit $EXIT_CODE)"
+              if [ -f "$RESULT_FILE" ]; then
+                echo "Error: $(jq -r '.error // .message // "unknown"' "$RESULT_FILE")"
+                echo "Full result:"
+                jq . "$RESULT_FILE"
+              fi
+              exit 1
+            fi
           fi
-          echo "All Linux build essentials tests passed"
 
   # Test source build with zig cc in container without system gcc
   # This validates that configure_make falls back to zig when no gcc exists

--- a/docs/ci-patterns.md
+++ b/docs/ci-patterns.md
@@ -8,6 +8,8 @@ This document describes the two standard patterns for structuring CI test jobs i
 
 **GHA group serialization** -- Use when running multiple independent tool tests on the same runner type. Each tool gets its own `$TSUKU_HOME` for isolation, but they share a download cache and the runner's Go toolchain.
 
+**GHA matrix strategy** -- Use when per-tool pass/fail visibility as a distinct GitHub status check is a requirement (e.g., a suite where pinpointing which specific tool broke without opening the log is important). Matrix trades runner-minute efficiency for faster wall-clock time and cleaner failure attribution. Each matrix entry runs in parallel and appears as a separate check in the PR UI. Add `fail-fast: false` so a single failure doesn't cancel the rest.
+
 If you're testing different runner types (`ubuntu-latest` vs `macos-latest` vs a container image), those are genuinely different environments and should be separate jobs.
 
 ## The Four Runner Types
@@ -251,13 +253,23 @@ The reduction comes from batching N tool tests into 1 job per runner type, and b
 
 ## Adding a New Test
 
-### New tool on an existing runner
+### New tool on an existing serialized runner
 
 Add the tool to the relevant serialized loop. For example, to add a new homebrew tool test on Linux, add it to the `TOOLS` array in `build-essentials.yml`'s `test-homebrew-linux` job:
 
 ```yaml
 TOOLS=(pkg-config cmake gdbm pngcrush your-new-tool)
 ```
+
+### New tool on a matrix job
+
+For jobs that use `strategy.matrix` (like `build-essentials.yml`'s `test-linux`), add one entry to the matrix list:
+
+```yaml
+- { name: your-new-tool, arg: "your-new-tool" }
+```
+
+No other changes are needed.
 
 ### New family variant for an existing test
 
@@ -267,6 +279,8 @@ Add the family to the relevant `FAMILIES` array. Most container loop jobs alread
 
 If you need a runner that doesn't match any existing job (for example, a Windows runner or a specific container image), create a new job. But batch any tests that will run on that runner into a single job using the GHA group serialization pattern.
 
-### What NOT to do
+### When matrix is and isn't appropriate
 
-Don't add a new `strategy.matrix` entry to fan out tests that could run sequentially on the same runner. The matrix strategy is appropriate when tests need genuinely different environments (different OS, different architecture). It's not appropriate for "test tool A" and "test tool B" on the same `ubuntu-latest` runner.
+**Use matrix when** per-tool failure attribution matters more than runner-minute efficiency — for example, a suite where identifying exactly which tool broke without reading a log is important. Matrix trades ~3× more runner-minutes for parallel execution and distinct GitHub status checks per entry.
+
+**Don't use matrix when** tests run on the same runner and there's no need for per-test status checks. Use GHA group serialization instead, which shares runner setup overhead and stays within a single job.


### PR DESCRIPTION
Replace the single sequential `test-linux` job in `build-essentials.yml` with a `strategy.matrix` job that runs all 10 tools in parallel with `fail-fast: false`. Each tool now produces a distinct GitHub status check on the PR, so a failure is visible without opening the run log.

The old job ran all tools sequentially via a `sandbox_test` shell function, with a total wall-clock time of ~25 min. A failure in the first tool forced the entire chain to run before the PR got any feedback. The new job has each tool run independently: wall-clock time drops to the duration of the slowest individual test (~12 min for source builds), and failures in one tool do not block the others.

Adding a new tool now requires a single matrix entry. The dispatch shell script with its `sandbox_test` function is removed. The runner-minute tradeoff (~80 min across 10 parallel jobs vs. ~25 min sequential) is documented in the workflow comment.

Update `docs/ci-patterns.md` to document when matrix strategy is appropriate (per-tool failure attribution is a requirement) vs. GHA group serialization (runner efficiency matters more).

---

Fixes #2394