### PR TITLE
fix(install): suppress PATH export hint when tool directory is already in PATH

### DIFF
--- a/cmd/tsuku/install.go
+++ b/cmd/tsuku/install.go
@@ -380,9 +380,33 @@ func isInteractive() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
+// isToolPathConfigured reports whether the user's PATH already contains
+// either $TSUKU_HOME/tools/current or $TSUKU_HOME/bin, indicating that
+// shell integration (via `tsuku hook install` or `eval $(tsuku shellenv)`)
+// is already set up.
+func isToolPathConfigured(cfg *config.Config) bool {
+	candidates := []string{
+		cfg.CurrentDir,
+		filepath.Join(cfg.HomeDir, "bin"),
+	}
+	pathEntries := filepath.SplitList(os.Getenv("PATH"))
+	for _, candidate := range candidates {
+		absCandidate, err := filepath.Abs(candidate)
+		if err != nil {
+			continue
+		}
+		for _, entry := range pathEntries {
+			absEntry, _ := filepath.Abs(entry)
+			if absEntry == absCandidate {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // suggestShellIntegration prints a one-time hint when shell integration
-// isn't set up. Checks if $TSUKU_HOME/tools/current is in PATH. Only
-// prints in interactive (TTY) mode and not in quiet/CI contexts.
+// isn't set up. Only prints in interactive (TTY) mode and not in quiet/CI contexts.
 func suggestShellIntegration() {
 	if quietFlag {
 		return
@@ -393,17 +417,8 @@ func suggestShellIntegration() {
 		return
 	}
 
-	currentDir := filepath.Join(cfg.HomeDir, "tools", "current")
-	absCurrentDir, err := filepath.Abs(currentDir)
-	if err != nil {
+	if isToolPathConfigured(cfg) {
 		return
-	}
-
-	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
-		absDir, _ := filepath.Abs(dir)
-		if absDir == absCurrentDir {
-			return // already in PATH
-		}
 	}
 
 	fmt.Fprintf(os.Stderr, "\nTip: enable shell integration for automatic update checks:\n")

--- a/cmd/tsuku/install_deps.go
+++ b/cmd/tsuku/install_deps.go
@@ -636,7 +636,7 @@ func installWithDependencies(toolName, reqVersion, versionConstraint string, isE
 		reporter.Log("Note: tsuku doesn't manage this dependency. It validated that it's installed.")
 	} else {
 		reporter.Log("✅ %s@%s", toolName, version)
-		if isExplicit && parent == "" {
+		if isExplicit && parent == "" && !isToolPathConfigured(cfg) {
 			reporter.DeferWarn("To use the installed tool, add this to your shell profile:\n  export PATH=\"%s:$PATH\"", cfg.CurrentDir)
 		}
 	}

--- a/cmd/tsuku/install_test.go
+++ b/cmd/tsuku/install_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tsukumogami/tsuku/internal/config"
 	"github.com/tsukumogami/tsuku/internal/registry"
 )
 
@@ -485,5 +486,54 @@ func TestInstallJSONFlag(t *testing.T) {
 	}
 	if flag.DefValue != "false" {
 		t.Errorf("--json default = %q, want %q", flag.DefValue, "false")
+	}
+}
+
+func TestIsToolPathConfigured(t *testing.T) {
+	cfg := &config.Config{
+		HomeDir:    "/home/user/.tsuku",
+		CurrentDir: "/home/user/.tsuku/tools/current",
+	}
+
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{
+			name: "tools/current in PATH",
+			path: "/usr/bin:/home/user/.tsuku/tools/current:/bin",
+			want: true,
+		},
+		{
+			name: "bin dir in PATH",
+			path: "/usr/bin:/home/user/.tsuku/bin:/bin",
+			want: true,
+		},
+		{
+			name: "neither dir in PATH",
+			path: "/usr/bin:/bin",
+			want: false,
+		},
+		{
+			name: "empty PATH",
+			path: "",
+			want: false,
+		},
+		{
+			name: "both dirs in PATH",
+			path: "/home/user/.tsuku/bin:/home/user/.tsuku/tools/current:/usr/bin",
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("PATH", tc.path)
+			got := isToolPathConfigured(cfg)
+			if got != tc.want {
+				t.Errorf("isToolPathConfigured() = %v, want %v (PATH=%q)", got, tc.want, tc.path)
+			}
+		})
 	}
 }

--- a/cmd/tsuku/plan_install.go
+++ b/cmd/tsuku/plan_install.go
@@ -144,8 +144,10 @@ func runPlanBasedInstall(planPath, toolName string) error {
 		printInfo()
 		printInfo("Installation successful!")
 		printInfo()
-		printInfof("To use the installed tool, add this to your shell profile:\n")
-		printInfof("  export PATH=\"%s:$PATH\"\n", cfg.CurrentDir)
+		if !isToolPathConfigured(cfg) {
+			printInfof("To use the installed tool, add this to your shell profile:\n")
+			printInfof("  export PATH=\"%s:$PATH\"\n", cfg.CurrentDir)
+		}
 	} else {
 		// System dependency validated successfully - no installation needed
 		printInfo()


### PR DESCRIPTION
Add `isToolPathConfigured()` which checks whether `$TSUKU_HOME/tools/current` or `$TSUKU_HOME/bin` is already present in the user's PATH. Gate the DeferWarn hint in `install_deps.go` and the printInfof hint in `plan_install.go` behind this check so the message is only shown to users who have not yet configured shell integration.

Refactor `suggestShellIntegration()` to call `isToolPathConfigured()` instead of duplicating the PATH-scan loop. Also extend the check to cover both tool directories — previously `suggestShellIntegration` only checked `tools/current`, but `eval $(tsuku shellenv)` adds both `tools/current` and `bin` to PATH, so checking only one could incorrectly show the hint for users with partial PATH setup.

---

Fixes #2388