### PR TITLE
fix(actions): use major-version-compatible matching for node_version in npm_exec

### DIFF
--- a/internal/actions/npm_exec.go
+++ b/internal/actions/npm_exec.go
@@ -263,12 +263,21 @@ func validateNodeVersion(constraint string, execPaths ...string) error {
 
 	// Parse version (format: v20.10.0)
 	versionStr := strings.TrimPrefix(strings.TrimSpace(string(output)), "v")
-	installedMajor, installedMinor, installedPatch, err := parseVersion(versionStr)
+	return checkVersionConstraint(versionStr, constraint)
+}
+
+// checkVersionConstraint checks if installedVersion satisfies the constraint string.
+// Supports ">=18.0.0", ">18.0.0", "18.x", or bare versions like "20.10.0".
+//
+// Bare version constraints (e.g. "25.9.0") use major-version-compatible matching:
+// the installed major must be >= the required major. Node.js guarantees backward
+// compatibility, so a plan generated with Node 25.9.0 runs correctly on Node 26.x.
+func checkVersionConstraint(installedVersion, constraint string) error {
+	installedMajor, installedMinor, installedPatch, err := parseVersion(installedVersion)
 	if err != nil {
-		return fmt.Errorf("failed to parse node version %s: %w", versionStr, err)
+		return fmt.Errorf("failed to parse node version %s: %w", installedVersion, err)
 	}
 
-	// Parse constraint
 	constraint = strings.TrimSpace(constraint)
 
 	// Handle "18.x" format
@@ -278,7 +287,7 @@ func validateNodeVersion(constraint string, execPaths ...string) error {
 			return fmt.Errorf("invalid version constraint: %s", constraint)
 		}
 		if installedMajor != requiredMajor {
-			return fmt.Errorf("node.js %s does not match constraint %s (major version mismatch)", versionStr, constraint)
+			return fmt.Errorf("node.js %s does not match constraint %s (major version mismatch)", installedVersion, constraint)
 		}
 		return nil
 	}
@@ -293,7 +302,7 @@ func validateNodeVersion(constraint string, execPaths ...string) error {
 
 		if !versionGTE(installedMajor, installedMinor, installedPatch,
 			requiredMajor, requiredMinor, requiredPatch) {
-			return fmt.Errorf("node.js %s does not satisfy constraint %s", versionStr, constraint)
+			return fmt.Errorf("node.js %s does not satisfy constraint %s", installedVersion, constraint)
 		}
 		return nil
 	}
@@ -308,19 +317,21 @@ func validateNodeVersion(constraint string, execPaths ...string) error {
 
 		if !versionGT(installedMajor, installedMinor, installedPatch,
 			requiredMajor, requiredMinor, requiredPatch) {
-			return fmt.Errorf("node.js %s does not satisfy constraint %s", versionStr, constraint)
+			return fmt.Errorf("node.js %s does not satisfy constraint %s", installedVersion, constraint)
 		}
 		return nil
 	}
 
-	// Handle exact version match
-	requiredMajor, requiredMinor, requiredPatch, err := parseVersion(constraint)
+	// Bare version (e.g. "25.9.0"): use major-version-compatible matching.
+	// The stored version was captured at eval time; Node.js backward compatibility
+	// means any installed major >= required major is acceptable.
+	requiredMajor, _, _, err := parseVersion(constraint)
 	if err != nil {
 		return fmt.Errorf("invalid version constraint: %s", constraint)
 	}
 
-	if installedMajor != requiredMajor || installedMinor != requiredMinor || installedPatch != requiredPatch {
-		return fmt.Errorf("node.js %s does not match required version %s", versionStr, constraint)
+	if installedMajor < requiredMajor {
+		return fmt.Errorf("node.js %s does not match required version %s", installedVersion, constraint)
 	}
 
 	return nil

--- a/internal/actions/npm_exec_test.go
+++ b/internal/actions/npm_exec_test.go
@@ -511,10 +511,10 @@ func TestNpmExecAction_Execute_NoPackageJSON(t *testing.T) {
 func TestCheckVersionConstraint(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name      string
-		installed string
-		constraint string
-		wantErr   bool
+		name        string
+		installed   string
+		constraint  string
+		wantErr     bool
 		errContains string
 	}{
 		// Bare version: major-version-compatible semantics

--- a/internal/actions/npm_exec_test.go
+++ b/internal/actions/npm_exec_test.go
@@ -508,6 +508,62 @@ func TestNpmExecAction_Execute_NoPackageJSON(t *testing.T) {
 	}
 }
 
+func TestCheckVersionConstraint(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		installed string
+		constraint string
+		wantErr   bool
+		errContains string
+	}{
+		// Bare version: major-version-compatible semantics
+		{"bare_same_version", "25.9.0", "25.9.0", false, ""},
+		{"bare_newer_minor", "25.10.0", "25.9.0", false, ""},
+		{"bare_newer_patch", "25.9.1", "25.9.0", false, ""},
+		{"bare_older_minor_same_major", "25.0.0", "25.9.0", false, ""},
+		{"bare_higher_major", "26.1.0", "25.9.0", false, ""},
+		{"bare_much_higher_major", "30.0.0", "25.9.0", false, ""},
+		{"bare_lower_major", "24.9.0", "25.9.0", true, "does not match required version"},
+
+		// >= constraint
+		{"gte_satisfied", "20.10.0", ">=18.0.0", false, ""},
+		{"gte_exact", "18.0.0", ">=18.0.0", false, ""},
+		{"gte_not_satisfied", "17.0.0", ">=18.0.0", true, "does not satisfy constraint"},
+
+		// > constraint
+		{"gt_satisfied", "20.0.0", ">18.0.0", false, ""},
+		{"gt_not_satisfied", "18.0.0", ">18.0.0", true, "does not satisfy constraint"},
+
+		// 18.x constraint
+		{"dotx_match", "18.5.0", "18.x", false, ""},
+		{"dotx_mismatch", "20.0.0", "18.x", true, "major version mismatch"},
+
+		// Invalid inputs
+		{"invalid_installed", "notaversion", "25.0.0", true, "failed to parse node version"},
+		{"invalid_constraint", "25.0.0", "notaconstraint", true, "invalid version constraint"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := checkVersionConstraint(tc.installed, tc.constraint)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tc.errContains)
+					return
+				}
+				if tc.errContains != "" && !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("error = %q, want error containing %q", err.Error(), tc.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
 func TestNpmExecAction_Execute_MissingCommand(t *testing.T) {
 	t.Parallel()
 	action := &NpmExecAction{}


### PR DESCRIPTION
Extract the version comparison logic from `validateNodeVersion` into a new `checkVersionConstraint(installedVersion, constraint string) error` helper, and change bare version constraints (e.g. `25.9.0`) from exact matching to major-version-compatible semantics: the installed Node.js major must be >= the required major.

Previously, `npm_install.Decompose()` captured the current Node.js version (e.g. `v25.9.0`) and stored it in the plan. When executing the plan later — after a Node.js upgrade — `npm_exec` compared the installed version against that stored value using exact matching, causing failures like `node version validation failed: node.js 26.1.0 does not match required version 25.9.0`. Node.js guarantees backward compatibility, so exact matching is too strict: a plan generated with Node 25 runs correctly on Node 26.

The fix changes the exact version case to accept any installed major >= the required major, while still rejecting lower majors. The `>=`, `>`, and `N.x` constraint formats are unchanged. Extracting `checkVersionConstraint` as a separate function also makes the comparison logic unit-testable without requiring a real `node` binary.

---

Fixes #2387

## Root Cause

`npm_install.Decompose()` stores the Node.js version at eval time as an exact version string (e.g. `v25.9.0`). `executePackageInstall` then strips the `v` prefix and passes `25.9.0` to `validateNodeVersion`, which uses exact matching. When the user later upgrades Node.js to a new major (e.g. 26.x), the exact match fails even though the newer Node.js is fully compatible.

## Implementation Notes

The `checkVersionConstraint` helper is now the single place that contains all constraint-matching logic. `validateNodeVersion` runs `node --version`, then delegates to it. This separation made it straightforward to add comprehensive unit tests (`TestCheckVersionConstraint`, 16 cases) without mocking the `node` binary.