### PR TITLE
fix(recipes): add macOS support to curl and resolve rhel sandbox SIGSEGV

### DIFF
--- a/recipes/c/curl.toml
+++ b/recipes/c/curl.toml
@@ -4,15 +4,14 @@ description = "Command line tool for transferring data with URLs"
 homepage = "https://curl.se/"
 version_format = "semver"
 curated = true
-# macOS: homebrew curl bottle has RPATH references to libnghttp3.9.dylib from a
-# separate homebrew package; bundling transitive dylibs is not supported.
-# darwin coverage is excluded until runtime_dependencies supports dylib chaining.
-supported_os = ["linux"]
 dependencies = ["openssl", "zlib"]
-
-[version]
-source = "homebrew"
-formula = "curl"
+# The darwin homebrew bottle's binary load chain references libnghttp3,
+# libnghttp2, libngtcp2, libssh2, brotli, and zstd from sibling Homebrew
+# installs. The chain-walk RPATH machinery resolves these via the
+# metadata-level `runtime_dependencies` declaration. openssl and zlib are
+# omitted here because they live in `dependencies` and listing them in
+# both fields trips the circular-dependency check.
+runtime_dependencies = ["libnghttp3", "libnghttp2", "libngtcp2", "libssh2", "brotli", "zstd"]
 
 # Linux: build from source (configure_make works on both glibc and musl)
 [[steps]]
@@ -37,7 +36,7 @@ when = { os = ["linux"] }
 action = "configure_make"
 when = { os = ["linux"] }
 source_dir = "curl-{version}"
-configure_args = ["--with-openssl", "--with-zlib", "--disable-silent-rules", "--without-libpsl"]
+configure_args = ["--with-openssl", "--with-zlib", "--disable-silent-rules", "--without-libpsl", "--disable-shared", "--enable-static"]
 executables = ["curl"]
 
 # $ORIGIN-based RPATH is Linux-only (ELF); macOS is excluded above
@@ -50,6 +49,27 @@ rpath = "$ORIGIN/../lib:{libs_dir}/openssl-{deps.openssl.version}/lib:{libs_dir}
 [[steps]]
 action = "install_binaries"
 when = { os = ["linux"] }
+install_mode = "directory"
+outputs = ["bin/curl"]
+
+# macOS: Homebrew bottle. The bottle's binary load chain references
+# libnghttp3, libnghttp2, libngtcp2, libssh2, brotli, and zstd from
+# sibling Homebrew installs. The metadata-level `runtime_dependencies`
+# above declares them for the chain-walk RPATH machinery.
+#
+# The step-level `dependencies` list is repeated here (not just via the
+# metadata) so the homebrew action can resolve install-time deps during
+# decomposition; without the step entry, the macOS plan would not see
+# them at install time. Keep the two lists in sync.
+[[steps]]
+action = "homebrew"
+formula = "curl"
+when = { os = ["darwin"] }
+dependencies = ["libnghttp3", "libnghttp2", "libngtcp2", "libssh2", "brotli", "zstd"]
+
+[[steps]]
+action = "install_binaries"
+when = { os = ["darwin"] }
 install_mode = "directory"
 outputs = ["bin/curl"]
 


### PR DESCRIPTION
Add `--disable-shared --enable-static` to the linux source build's `configure_args` to fix a rhel-only SIGSEGV at verify time. Re-apply the darwin homebrew step that was reverted from #2337: drop `supported_os = ["linux"]` and the redundant `[version]` block, declare `runtime_dependencies = ["libnghttp3", "libnghttp2", "libngtcp2", "libssh2", "brotli", "zstd"]` at the metadata level so the chain-walk RPATH machinery wires the bottle's load chain to sibling tsuku-installed dylibs, and add darwin homebrew + install_binaries steps with the same dependency list at the step level mirroring `recipes/g/git.toml`.

---

## What this fixes

The rhel-only failure surfaced when PR #2337 first added darwin support: `install_exit_code = 0` but `passed = false` on the rhel sandbox container only; debian, arch, suse, and alpine all passed with the same recipe. Local sandbox reproduction (`tsuku install --sandbox --target-family rhel --recipe recipes/c/curl.toml --force --json`) confirmed `verify_exit_code: 139` — SIGSEGV at `curl --version`. Same shape as #2335's pcre2 rhel failure, which was resolved by switching to a uniform static-link source build.

The CI workflow's `.log-curl-rhel.txt` artifact captures stdout+stderr of the verify command; for a SIGSEGV the binary dies before writing anything to the redirected fd, so the artifact contains no diagnostic detail beyond the exit code already in the JSON result. Diagnosing further (e.g., strace inside the sandbox) was higher cost than applying the proven same-shape fix.

## Implementation notes

- **Why `--disable-shared --enable-static` works**: static-linking libcurl removes a layer of shared-library resolution between the binary and the sibling-installed openssl/zlib. The set_rpath step already ordered tsuku libs ahead of system libs, but the rhel container's specific glibc/loader interaction with dynamic libcurl was producing a crash that doesn't appear on debian/arch/suse/alpine. Static libcurl sidesteps the path entirely.
- **Why the dual-list pattern (metadata + step-level)** for darwin: `git.toml` (lines 36-44) documents that step-level `dependencies` is required for the homebrew action's install-time decomposition; metadata `runtime_dependencies` alone is read by the chain-walk RPATH machinery but not by the install planner. The two lists are kept identical for the darwin homebrew step.
- **Why `openssl` and `zlib` are not in `runtime_dependencies`**: they live in `dependencies`, and listing them in both fields trips the validator's circular-dependency check. PR #2337 originally hit this and had to remove them from runtime_deps before getting strict-validation green.

## Test plan

- [x] `tsuku validate --strict --check-libc-coverage recipes/c/curl.toml` passes
- [x] `tsuku eval --recipe recipes/c/curl.toml` passes on linux/{rhel,debian,alpine} and darwin/{arm64,amd64}
- [x] Local sandbox install on rhel: `passed: true` with the fix (was `passed: false, verify_exit_code: 139` without)
- [ ] CI test-recipe matrix green on debian, rhel, arch, suse, alpine, macOS arm64, macOS amd64

Closes #2338
