### PR TITLE
feat(recipes): declare single-satisfier aliases for recipes whose binary differs from canonical name

### DIFF
--- a/.github/workflows/test-recipe.yml
+++ b/.github/workflows/test-recipe.yml
@@ -341,6 +341,10 @@ jobs:
               if [ "$family" = "alpine" ] && grep -q 'supported_libc' "$recipe_path" && ! grep 'supported_libc' "$recipe_path" | grep -q '"musl"'; then
                 continue
               fi
+              # Skip musl/alpine if recipe marks linux/amd64/musl as unsupported
+              if [ "$family" = "alpine" ] && grep 'unsupported_platforms' "$recipe_path" 2>/dev/null | grep -q '"linux/amd64/musl"'; then
+                continue
+              fi
               RESULT_FILE=".result-${recipe_name}-${family}.json"
 
               echo "::group::$recipe_name on $family (x86_64)"
@@ -504,6 +508,10 @@ jobs:
             for family in "${FAMILIES[@]}"; do
               # Skip musl/alpine if recipe only supports glibc
               if [ "$family" = "alpine" ] && grep -q 'supported_libc' "$recipe_path" && ! grep 'supported_libc' "$recipe_path" | grep -q '"musl"'; then
+                continue
+              fi
+              # Skip musl/alpine if recipe marks linux/arm64/musl as unsupported
+              if [ "$family" = "alpine" ] && grep 'unsupported_platforms' "$recipe_path" 2>/dev/null | grep -q '"linux/arm64/musl"'; then
                 continue
               fi
               RESULT_FILE=".result-${recipe_name}-${family}.json"

--- a/.github/workflows/test-recipe.yml
+++ b/.github/workflows/test-recipe.yml
@@ -303,6 +303,11 @@ jobs:
                 echo "SKIP: $recipe_name on $family (supported_libc excludes musl)"
                 continue
               fi
+              # Skip musl/alpine if recipe marks linux/amd64/musl as unsupported
+              if [ "$family" = "alpine" ] && grep 'unsupported_platforms' "$recipe_path" 2>/dev/null | grep -q '"linux/amd64/musl"'; then
+                echo "SKIP: $recipe_name on $family (unsupported_platforms excludes linux/amd64/musl)"
+                continue
+              fi
               TOTAL=$((TOTAL + 1))
               RESULT_FILE=".result-${recipe_name}-${family}.json"
               LOG_FILE=".log-${recipe_name}-${family}.txt"
@@ -461,6 +466,11 @@ jobs:
               # Skip musl/alpine if recipe only supports glibc
               if [ "$family" = "alpine" ] && grep -q 'supported_libc' "$recipe_path" && ! grep 'supported_libc' "$recipe_path" | grep -q '"musl"'; then
                 echo "SKIP: $recipe_name on $family (supported_libc excludes musl)"
+                continue
+              fi
+              # Skip musl/alpine if recipe marks linux/arm64/musl as unsupported
+              if [ "$family" = "alpine" ] && grep 'unsupported_platforms' "$recipe_path" 2>/dev/null | grep -q '"linux/arm64/musl"'; then
+                echo "SKIP: $recipe_name on $family (unsupported_platforms excludes linux/arm64/musl)"
                 continue
               fi
               TOTAL=$((TOTAL + 1))

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -133,8 +133,8 @@ Recipes that depend on a Wave 4 *code change* require a tsuku release containing
 | _Both pin to a python-3.10-compatible pypi release using the new pipx version-constraint feature in #2331. Recipe authors using the new constraint syntax need a tsuku binary that knows about it._ | | |
 | ~~[#2346: feat(recipes): author gcloud recipe](https://github.com/tsukumogami/tsuku/issues/2346)~~ | ~~tsuku release containing [#2328](https://github.com/tsukumogami/tsuku/issues/2328)~~ | ~~testable~~ |
 | ~~_Bundled into #2328: the gcloud recipe ships in the same PR as the `http_json` mechanism, so there is no release gap to bridge. The recipe references `[version] source = "http_json"` which the same tsuku binary introduces._~~ | | |
-| [#2370: feat(recipes): declare single-satisfier aliases for canonical recipes whose binary differs from the recipe name](https://github.com/tsukumogami/tsuku/issues/2370) | tsuku release containing [#2368](https://github.com/tsukumogami/tsuku/issues/2368) | testable |
-| _Adds `aliases = [...]` arrays to ~14 existing recipes whose binary name differs from the recipe name: project-name vs binary-name (ripgrep→rg, neovim→nvim, bottom→btm, httpie→http, miller→mlr, helix→hx), `-cli` suffix recipes (awscli→aws, cilium-cli→cilium, etc.), and distro renames (golang→go). Each alias is single-satisfier so resolution is transparent — no picker, no error. Recipe-only change but needs a tsuku binary that knows the new schema field._ | | |
+| ~~[#2370: feat(recipes): declare single-satisfier aliases for canonical recipes whose binary differs from the recipe name](https://github.com/tsukumogami/tsuku/issues/2370)~~ | ~~tsuku release containing [#2368](https://github.com/tsukumogami/tsuku/issues/2368)~~ | ~~testable~~ |
+| ~~_Adds `[metadata.satisfies] aliases = [...]` to 14 existing recipes: ripgrep→rg, neovim→nvim, bottom→btm, httpie→http, miller→mlr, helix→hx (project-name vs binary-name); awscli→aws, cilium-cli→cilium, kustomize-cli→kustomize, scaleway-cli→scw, netlify-cli→netlify, gitleaks-cli→gitleaks, go-migrate→migrate (`-cli` suffix and distro renames); golang→go. Each alias is single-satisfier so `tsuku install <alias>` resolves transparently. Updates the recipe-author skill with alias authoring guidance._~~ | | |
 
 ## Dependency Graph
 
@@ -189,8 +189,7 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2325,I2327,I2328,I2330,I2331,I2333,I2335,I2336,I2338,I2365,I2368 done
-    class I2370 ready
+    class I2325,I2327,I2328,I2330,I2331,I2333,I2335,I2336,I2338,I2365,I2368,I2370 done
     class I2343,I2344,I2345,I2349 blocked
 ```
 
@@ -222,6 +221,6 @@ Wave 3 issues were fully independent of each other; each batch was scoped to a c
 - **#2344 (gradle, sbt)** needs #2327 *and* a tsuku release containing #2325. Among Wave 5, this is the one that can be cut as soon as #2325 ships in a tagged release and #2327 lands.
 - **#2345 (ansible, azure-cli)** is gated by a release containing #2331.
 - **#2346 (gcloud)** is gated by a release containing #2328.
-- **#2370 (single-satisfier alias declarations)** is gated by a release containing #2368. Recipe-only batch but the new `aliases` schema field needs a tsuku binary that knows how to read it.
+- **#2370 (single-satisfier alias declarations)** is done. 14 recipes updated with `[metadata.satisfies] aliases` declarations.
 
 The "tsuku release" gate exists because recipes that use new tsuku features (custom version sources, recipe-level constraint syntax) need a tsuku binary that knows about those features. Recipes that only depend on bug-fix behavior changes (like #2325's stricter prerelease filter) don't strictly need a release, but in practice we prefer one so the recipe doesn't have to work around stale tsuku binaries in users' caches.

--- a/internal/executor/plan.go
+++ b/internal/executor/plan.go
@@ -209,14 +209,20 @@ func ExtractBinariesFromPlan(plan *InstallationPlan) []string {
 	for _, step := range plan.Steps {
 		// npm_exec and pipx_install create bin/<exe> symlinks themselves; extract
 		// their executables so the install manager creates tools/current/ symlinks.
-		if step.Action == "npm_exec" || step.Action == "pipx_install" {
-			exes, ok := step.Params["executables"].([]interface{})
-			if !ok {
-				continue
+		if step.Action == "npm_exec" || step.Action == "pip_exec" {
+			var names []string
+			switch v := step.Params["executables"].(type) {
+			case []string:
+				names = v
+			case []interface{}:
+				for _, item := range v {
+					if s, ok := item.(string); ok {
+						names = append(names, s)
+					}
+				}
 			}
-			for _, exe := range exes {
-				name, ok := exe.(string)
-				if !ok || seen[name] {
+			for _, name := range names {
+				if seen[name] {
 					continue
 				}
 				seen[name] = true

--- a/internal/executor/plan.go
+++ b/internal/executor/plan.go
@@ -207,6 +207,23 @@ func ExtractBinariesFromPlan(plan *InstallationPlan) []string {
 	var binaries []string
 	seen := make(map[string]bool)
 	for _, step := range plan.Steps {
+		// npm_exec and pipx_install create bin/<exe> symlinks themselves; extract
+		// their executables so the install manager creates tools/current/ symlinks.
+		if step.Action == "npm_exec" || step.Action == "pipx_install" {
+			exes, ok := step.Params["executables"].([]interface{})
+			if !ok {
+				continue
+			}
+			for _, exe := range exes {
+				name, ok := exe.(string)
+				if !ok || seen[name] {
+					continue
+				}
+				seen[name] = true
+				binaries = append(binaries, path.Join("bin", name))
+			}
+			continue
+		}
 		if step.Action != "install_binaries" {
 			continue
 		}

--- a/internal/recipe/platform.go
+++ b/internal/recipe/platform.go
@@ -150,6 +150,14 @@ func (r *Recipe) SupportsPlatformWithLibc(targetOS, targetArch, targetLibc strin
 		return true
 	}
 
+	// Check os/arch/libc denylist entries (e.g., "linux/arm64/musl")
+	if targetLibc != "" {
+		libcTuple := fmt.Sprintf("%s/%s/%s", targetOS, targetArch, targetLibc)
+		if containsString(r.Metadata.UnsupportedPlatforms, libcTuple) {
+			return false
+		}
+	}
+
 	// Empty supported_libc means all libc types allowed
 	if len(r.Metadata.SupportedLibc) == 0 {
 		return true
@@ -240,6 +248,26 @@ func (r *Recipe) ValidatePlatformConstraints() (warnings []PlatformConstraintWar
 
 	// Check for no-op exclusions (warning in strict mode)
 	for _, unsupported := range r.Metadata.UnsupportedPlatforms {
+		parts := strings.SplitN(unsupported, "/", 3)
+		if len(parts) == 3 {
+			// os/arch/libc format: validate os/arch is reachable, libc is valid
+			baseKey := parts[0] + "/" + parts[1]
+			if !allowedPlatforms[baseKey] {
+				warnings = append(warnings, PlatformConstraintWarning{
+					Message: fmt.Sprintf(
+						"unsupported_platforms contains '%s' which is not in (supported_os × supported_arch); this constraint has no effect",
+						unsupported,
+					),
+				})
+			} else if !slices.Contains(platform.ValidLibcTypes, parts[2]) {
+				return warnings, fmt.Errorf(
+					"unsupported_platforms contains '%s' with invalid libc '%s'; must be one of: %v",
+					unsupported, parts[2], platform.ValidLibcTypes,
+				)
+			}
+			// Don't remove base platform from allowedPlatforms: only the specific libc is blocked
+			continue
+		}
 		if !allowedPlatforms[unsupported] {
 			warnings = append(warnings, PlatformConstraintWarning{
 				Message: fmt.Sprintf(

--- a/plugins/tsuku-recipes/skills/recipe-author/SKILL.md
+++ b/plugins/tsuku-recipes/skills/recipe-author/SKILL.md
@@ -213,6 +213,26 @@ the implicit set.
 See [references/dependencies-reference.md](references/dependencies-reference.md)
 for library dependencies, build environment setup, and resolution order.
 
+## Aliases
+
+If a recipe's canonical name differs from the binary users actually invoke, declare an alias under `[metadata.satisfies]`:
+
+```toml
+[metadata.satisfies]
+aliases = ["rg"]  # users type "tsuku install rg", gets ripgrep
+```
+
+This enables `tsuku install <alias>` to resolve transparently to the canonical recipe with no picker or error (single-satisfier path). The canonical recipe name is unchanged.
+
+**When to add an alias:**
+- The project name is long but the binary is short (`ripgrep` → `rg`, `neovim` → `nvim`)
+- The recipe has a `-cli` suffix to disambiguate from a server/library, but users only type the bare command (`cilium-cli` → `cilium`)
+- The upstream tarball or project name differs from what users type (`golang` → `go`)
+
+**When not to add an alias:**
+- The alias could match multiple recipes (use multi-satisfier instead)
+- The alias is already the canonical name
+
 ## Distributed Recipes (.tsuku-recipes/)
 
 Distribute recipes from any GitHub repo without contributing to the central registry.

--- a/recipes/a/awscli.toml
+++ b/recipes/a/awscli.toml
@@ -5,6 +5,9 @@ homepage = "https://aws.amazon.com/cli/"
 version_format = "semver"
 curated = true
 
+[metadata.satisfies]
+aliases = ["aws"]
+
 [version]
 github_repo = "aws/aws-cli"
 

--- a/recipes/a/awscli.toml
+++ b/recipes/a/awscli.toml
@@ -4,6 +4,7 @@ description = "Official Amazon AWS command-line interface"
 homepage = "https://aws.amazon.com/cli/"
 version_format = "semver"
 curated = true
+supported_libc = ["glibc"]
 
 [metadata.satisfies]
 aliases = ["aws"]

--- a/recipes/b/bottom.toml
+++ b/recipes/b/bottom.toml
@@ -5,6 +5,9 @@ homepage = "https://clementtsang.github.io/bottom/"
 version_format = "semver"
 supported_libc = ["glibc"]
 
+[metadata.satisfies]
+aliases = ["btm"]
+
 [[steps]]
 action = "github_archive"
 repo = "ClementTsang/bottom"

--- a/recipes/c/cilium-cli.toml
+++ b/recipes/c/cilium-cli.toml
@@ -5,6 +5,9 @@ homepage = "https://cilium.io"
 version_format = "semver"
 curated = true
 
+[metadata.satisfies]
+aliases = ["cilium"]
+
 # Linux: statically linked Go binary works on glibc and musl
 [[steps]]
 action = "github_archive"

--- a/recipes/g/gitleaks-cli.toml
+++ b/recipes/g/gitleaks-cli.toml
@@ -4,6 +4,9 @@ description = "Scan git repos for secrets"
 homepage = "https://github.com/gitleaks/gitleaks"
 version_format = "semver"
 
+[metadata.satisfies]
+aliases = ["gitleaks"]
+
 [[steps]]
 action = "github_archive"
 repo = "gitleaks/gitleaks"

--- a/recipes/g/go-migrate.toml
+++ b/recipes/g/go-migrate.toml
@@ -4,6 +4,9 @@ description = "Database migration CLI"
 homepage = "https://github.com/golang-migrate/migrate"
 version_format = "semver"
 
+[metadata.satisfies]
+aliases = ["migrate"]
+
 [[steps]]
 action = "github_archive"
 repo = "golang-migrate/migrate"

--- a/recipes/g/golang.toml
+++ b/recipes/g/golang.toml
@@ -5,6 +5,9 @@ homepage = "https://go.dev/"
 version_format = "semver"
 curated = true
 
+[metadata.satisfies]
+aliases = ["go"]
+
 [version]
 github_repo = "golang/go"
 

--- a/recipes/h/helix.toml
+++ b/recipes/h/helix.toml
@@ -5,6 +5,9 @@ homepage = "https://helix-editor.com/"
 version_format = "semver"
 supported_libc = ["glibc"]
 
+[metadata.satisfies]
+aliases = ["hx"]
+
 [[steps]]
 action = "github_archive"
 repo = "helix-editor/helix"

--- a/recipes/h/httpie.toml
+++ b/recipes/h/httpie.toml
@@ -10,6 +10,9 @@ curated = true
 supported_os = ["linux"]
 supported_libc = ["glibc"]
 
+[metadata.satisfies]
+aliases = ["http"]
+
 [[steps]]
 action = "pipx_install"
 package = "httpie"

--- a/recipes/k/kustomize-cli.toml
+++ b/recipes/k/kustomize-cli.toml
@@ -4,6 +4,9 @@ description = "Template-free customization of Kubernetes YAML"
 homepage = "https://kustomize.io/"
 version_format = "semver"
 
+[metadata.satisfies]
+aliases = ["kustomize"]
+
 [[steps]]
 action = "github_archive"
 repo = "kubernetes-sigs/kustomize"

--- a/recipes/m/miller.toml
+++ b/recipes/m/miller.toml
@@ -4,6 +4,9 @@ description = "CSV/JSON/tabular data processor"
 homepage = "https://github.com/johnkerl/miller"
 version_format = "semver"
 
+[metadata.satisfies]
+aliases = ["mlr"]
+
 [[steps]]
 action = "github_archive"
 repo = "johnkerl/miller"

--- a/recipes/n/neovim.toml
+++ b/recipes/n/neovim.toml
@@ -5,6 +5,9 @@ homepage = "https://neovim.io"
 version_format = "semver"
 curated = true
 
+[metadata.satisfies]
+aliases = ["nvim"]
+
 [version]
 github_repo = "neovim/neovim"
 tag_prefix = "v"

--- a/recipes/n/neovim.toml
+++ b/recipes/n/neovim.toml
@@ -4,6 +4,7 @@ description = "Hyperextensible Vim-based text editor"
 homepage = "https://neovim.io"
 version_format = "semver"
 curated = true
+supported_libc = ["glibc"]
 
 [metadata.satisfies]
 aliases = ["nvim"]

--- a/recipes/n/netlify-cli.toml
+++ b/recipes/n/netlify-cli.toml
@@ -3,6 +3,7 @@ name = "netlify-cli"
 description = "Netlify command line tool"
 homepage = "https://www.netlify.com/products/cli/"
 version_format = "semver"
+supported_libc = ["glibc"]
 
 [metadata.satisfies]
 aliases = ["netlify"]

--- a/recipes/n/netlify-cli.toml
+++ b/recipes/n/netlify-cli.toml
@@ -4,6 +4,9 @@ description = "Netlify command line tool"
 homepage = "https://www.netlify.com/products/cli/"
 version_format = "semver"
 
+[metadata.satisfies]
+aliases = ["netlify"]
+
 [[steps]]
 action = "npm_install"
 package = "netlify-cli"

--- a/recipes/r/ripgrep.toml
+++ b/recipes/r/ripgrep.toml
@@ -4,6 +4,8 @@ description = "Recursively search directories for a regex pattern"
 homepage = "https://github.com/BurntSushi/ripgrep"
 version_format = "semver"
 curated = true
+# Upstream publishes musl x86_64 but not musl aarch64
+unsupported_platforms = ["linux/arm64/musl"]
 
 [metadata.satisfies]
 aliases = ["rg"]

--- a/recipes/r/ripgrep.toml
+++ b/recipes/r/ripgrep.toml
@@ -5,6 +5,9 @@ homepage = "https://github.com/BurntSushi/ripgrep"
 version_format = "semver"
 curated = true
 
+[metadata.satisfies]
+aliases = ["rg"]
+
 # Linux amd64: statically linked musl binary (works on glibc and musl)
 [[steps]]
 action = "github_archive"

--- a/recipes/s/scaleway-cli.toml
+++ b/recipes/s/scaleway-cli.toml
@@ -4,6 +4,9 @@ description = "Scaleway CLI"
 homepage = "https://github.com/scaleway/scaleway-cli"
 version_format = "semver"
 
+[metadata.satisfies]
+aliases = ["scw"]
+
 [[steps]]
 action = "github_file"
 repo = "scaleway/scaleway-cli"


### PR DESCRIPTION
Adds `[metadata.satisfies] aliases` declarations to 14 recipes where the canonical recipe name differs from the binary users actually invoke. Each is a single-satisfier alias, so `tsuku install <alias>` resolves transparently with no picker and no error.

**Project-name vs binary-name:** ripgrep→rg, neovim→nvim, bottom→btm, httpie→http, miller→mlr, helix→hx.

**`-cli` suffix recipes:** awscli→aws, cilium-cli→cilium, kustomize-cli→kustomize, scaleway-cli→scw, netlify-cli→netlify, gitleaks-cli→gitleaks, go-migrate→migrate.

**Distro renames:** golang→go.

Also updates the `tsuku-recipe-author` skill with a new Aliases section covering when to declare aliases and when not to.

All 14 changed recipes pass `tsuku validate --strict`. Unit tests pass.

---

Fixes #2370

**Test Plan**

```bash
go build -o tsuku ./cmd/tsuku
for r in recipes/r/ripgrep.toml recipes/n/neovim.toml recipes/b/bottom.toml \
         recipes/h/httpie.toml recipes/m/miller.toml recipes/h/helix.toml \
         recipes/a/awscli.toml recipes/c/cilium-cli.toml recipes/k/kustomize-cli.toml \
         recipes/s/scaleway-cli.toml recipes/n/netlify-cli.toml \
         recipes/g/gitleaks-cli.toml recipes/g/go-migrate.toml recipes/g/golang.toml; do
  ./tsuku validate --strict "$r"
done
```