### PR TITLE
feat(recipes): add curated maven recipe

### DIFF
--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -125,8 +125,8 @@ Recipes that depend on a Wave 4 *code change* require a tsuku release containing
 
 | Issue | Dependencies | Complexity |
 |-------|--------------|------------|
-| [#2343: feat(recipes): author maven recipe](https://github.com/tsukumogami/tsuku/issues/2343) | [#2327](https://github.com/tsukumogami/tsuku/issues/2327) | testable |
-| _Recipe-only change. Maven ships a single platform-agnostic Apache distribution; the recipe needs an openjdk runtime dependency so `mvn --version` can verify._ | | |
+| ~~[#2343: feat(recipes): author maven recipe](https://github.com/tsukumogami/tsuku/issues/2343)~~ | ~~[#2327](https://github.com/tsukumogami/tsuku/issues/2327)~~ | ~~testable~~ |
+| ~~_Authored `recipes/m/maven.toml` using a single platform-agnostic `download_archive` step against the Apache distribution tarball; pinned to the latest stable 3.9.x via `apache/maven` GitHub tags filtered by semver. `runtime_dependencies = ["openjdk"]` at metadata level wires the wrapper-script generator for `tsuku install <name>` flows; step-level `dependencies = ["openjdk"]` mirrors that on the download_archive step so `--sandbox` and `--plan` flows install openjdk first. Apache's `bin/mvn` derives JAVA_HOME from `which javac` once openjdk's binaries are on PATH at verify time._~~ | | |
 | [#2344: feat(recipes): author gradle and sbt recipes](https://github.com/tsukumogami/tsuku/issues/2344) | [#2327](https://github.com/tsukumogami/tsuku/issues/2327), tsuku release containing [#2325](https://github.com/tsukumogami/tsuku/issues/2325) | testable |
 | _Both upstreams use `-Mn` milestone tags that #2325 now filters as prereleases (released in the binary), and both need the openjdk runtime dependency from #2327 for verify._ | | |
 | [#2345: feat(recipes): author ansible and azure-cli recipes](https://github.com/tsukumogami/tsuku/issues/2345) | tsuku release containing [#2331](https://github.com/tsukumogami/tsuku/issues/2331) | testable |
@@ -189,8 +189,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2325,I2327,I2328,I2330,I2331,I2333,I2335,I2336,I2338,I2365,I2368,I2370 done
-    class I2343,I2344,I2345,I2349 blocked
+    class I2325,I2327,I2328,I2330,I2331,I2333,I2335,I2336,I2338,I2343,I2365,I2368,I2370 done
+    class I2344,I2345,I2349 blocked
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan

--- a/recipes/m/maven.toml
+++ b/recipes/m/maven.toml
@@ -1,0 +1,46 @@
+[metadata]
+name = "maven"
+description = "Apache Maven build tool for Java projects"
+homepage = "https://maven.apache.org/"
+version_format = "semver"
+curated = true
+# Maven is pure-JVM; the `mvn` script needs `java` on PATH at runtime.
+# Declaring openjdk as a runtime dependency triggers tsuku's wrapper-script
+# generator to prepend `$TSUKU_HOME/tools/openjdk-<version>/bin` to PATH
+# before exec'ing `mvn`, so Apache's `bin/mvn` finds java via its
+# existing PATH walk without any JAVA_HOME plumbing.
+runtime_dependencies = ["openjdk"]
+
+[metadata.satisfies]
+homebrew = ["maven"]
+
+# Apache publishes maven tags on github.com/apache/maven with a `maven-`
+# prefix. The 4.0.0 series is currently in release-candidate stages
+# (maven-4.0.0-rc-5 and earlier); semver `version_format` filters those
+# prereleases out so the resolver lands on the latest stable 3.9.x tag.
+[version]
+github_repo = "apache/maven"
+tag_prefix = "maven-"
+
+# Apache Maven ships a single platform-agnostic Apache distribution
+# tarball that works on every OS and architecture (it's a pure-JVM
+# application). One step covers linux/{amd64,arm64} (glibc + musl) and
+# darwin/{amd64,arm64}.
+[[steps]]
+action = "download_archive"
+url = "https://archive.apache.org/dist/maven/maven-3/{version}/binaries/apache-maven-{version}-bin.tar.gz"
+strip_dirs = 1
+install_mode = "directory"
+binaries = ["bin/mvn", "bin/mvnDebug"]
+# Step-level `dependencies` mirrors metadata `runtime_dependencies` so the
+# install planner installs openjdk first when sandbox/--plan flows are
+# used (those skip the metadata-level read). Apache's `bin/mvn` script
+# derives JAVA_HOME from `which javac` when JAVA_HOME is unset, so once
+# openjdk's `bin/javac` is on PATH at verify time, mvn finds Java without
+# any explicit env-var plumbing.
+dependencies = ["openjdk"]
+when = { os = ["linux", "darwin"], libc = ["glibc", "musl"] }
+
+[verify]
+command = "mvn --version"
+pattern = "Apache Maven {version}"


### PR DESCRIPTION
Author `recipes/m/maven.toml` using a single `download_archive` step against the platform-agnostic Apache distribution tarball (`apache-maven-{version}-bin.tar.gz`). One step covers linux/{amd64,arm64} (glibc + musl) and darwin/{amd64,arm64} because maven is pure-JVM. Version pinning resolves against `apache/maven` GitHub tags with `tag_prefix = "maven-"`; `version_format = "semver"` filters out the in-progress 4.0.0 release candidates so the resolver lands on the latest stable 3.9.x tag (currently 3.9.15). Verify pattern is `Apache Maven {version}`, which matches the first line maven prints under `mvn --version`.

Updates `docs/plans/PLAN-curated-recipes.md` in the same PR: strikes through the #2343 row with the real implementation summary, moves `I2343` from `blocked` to `done` in the dependency graph.

---

## What this accomplishes

Maven is the third Wave 5 recipe to land (after `git` and `tmux`'s wave 4 entries) and the first that exercises the `runtime_dependencies` mechanism for a non-Homebrew tool. Maven is pure-JVM, so the recipe author's job is to wire openjdk as a runtime dependency rather than ship per-platform binaries.

## Implementation notes

- **Two declarations of openjdk, intentionally**:
  - Metadata-level `runtime_dependencies = ["openjdk"]` is read by `cmd/tsuku/install_deps.go` for the `tsuku install <name>` flow; it triggers tsuku's wrapper-script generator (`internal/install/manager.go`) to prepend openjdk's `bin/` to PATH before exec'ing `mvn`.
  - Step-level `dependencies = ["openjdk"]` on the `download_archive` step is read by the action's `Dependencies()` method during plan decomposition; it ensures openjdk gets installed before maven when sandbox/`--plan` flows are used (those skip the metadata-level read because they bypass `install_deps.go`).
  - Both lists are kept in sync. Mirrors the dual-list pattern in `recipes/g/git.toml` and `recipes/c/curl.toml` (where the dual list is metadata `runtime_dependencies` + step-level `dependencies` on the homebrew step).

- **No JAVA_HOME plumbing**: Apache's `bin/mvn` script falls back to `which javac` when JAVA_HOME is unset. Once openjdk's `bin/javac` is on PATH at verify time (via either the wrapper script or sandbox PATH setup pointing at `$TSUKU_HOME/tools/current`), mvn derives JAVA_HOME from javac's resolved path. No `set_env` step needed.

- **Version filtering**: `apache/maven`'s tag list currently shows `maven-4.0.0-rc-5` as the most recent maven-prefixed tag. Maven 4 is in active release candidates. `version_format = "semver"` correctly classifies anything after `-` as a prerelease, so the resolver picks the latest stable tag (3.9.15). When maven 4 ships stably, the recipe will start tracking it automatically.

- **Verify pattern**: `mvn --version` prints `Apache Maven 3.9.15 (...)` as its first line, so `pattern = "Apache Maven {version}"` binds both the distribution name and the resolved version. No `mode = "output"` override needed (`mvn --version` exits 0 on success).

## Test plan

- [x] `tsuku validate --strict --check-libc-coverage recipes/m/maven.toml` passes
- [x] `tsuku eval --recipe recipes/m/maven.toml` resolves the openjdk dependency chain correctly across all five target platforms
- [x] Plan correctly includes openjdk (and its patchelf dep) ahead of the maven steps
- [ ] CI test-recipe matrix green on debian, rhel, arch, suse, alpine, macOS arm64, macOS amd64
- [ ] CI build-essentials and validate-recipes workflows green

Closes #2343
