### PR TITLE
feat(recipes): author curated gradle and sbt recipes

### DIFF
--- a/docs/curated-tools-priority-list.md
+++ b/docs/curated-tools-priority-list.md
@@ -11,13 +11,13 @@ Popularity rankings are based on Homebrew download analytics, GitHub star counts
 ## Action Summary
 
 ### No action needed (handcrafted or curated — full platform support)
-git, docker, terraform, gh, golang, python, rust, fzf, btop, curl, httpie, lazygit, k9s, stern, kubectx, direnv, mise, asdf, pyenv, rbenv, eksctl, flux, skaffold, kustomize, velero, vault, packer, bun, yarn, deno, pnpm, nvm, claude, gemini, trivy, grype, cosign, syft, actionlint, golangci-lint, ruff, black, prettier, eslint, tflint, pulumi, caddy, age, mkcert, sops, step, consul, vagrant, lazydocker, jq, wget, tmux, act, earthly, goreleaser, make, ninja-build, meson, argocd, terragrunt, infracost, lefthook, pre-commit, checkov
+git, docker, terraform, gh, golang, python, rust, fzf, btop, curl, httpie, lazygit, k9s, stern, kubectx, direnv, mise, asdf, pyenv, rbenv, eksctl, flux, skaffold, kustomize, velero, vault, packer, bun, yarn, deno, pnpm, nvm, claude, gemini, trivy, grype, cosign, syft, actionlint, golangci-lint, ruff, black, prettier, eslint, tflint, pulumi, caddy, age, mkcert, sops, step, consul, vagrant, lazydocker, jq, wget, tmux, act, earthly, goreleaser, make, ninja-build, meson, gradle, sbt, argocd, terragrunt, infracost, lefthook, pre-commit, checkov
 
 ### Review coverage (batch — may need platform expansion or full handcrafting)
 helm, ripgrep, fd, eza, zoxide, htop, cilium-cli, istioctl, bazel, ollama, shellcheck, shfmt
 
 ### Author recipe (missing or discovery-only — needs a recipe)
-node, kubectl, aws-cli, bat, starship, neovim, delta, gcloud, ansible, azure-cli, cmake, gradle, maven, sbt, aider, ko, dive, hadolint
+node, kubectl, aws-cli, bat, starship, neovim, delta, gcloud, ansible, azure-cli, cmake, maven, aider, ko, dive, hadolint
 
 ### Not available (deprecated or no standalone binary)
 copilot — the gh-copilot CLI extension was deprecated in September 2025 (upstream notice: https://github.blog/changelog/2025-09-25-upcoming-deprecation-of-gh-copilot-cli-extension/); Copilot features are now integrated into the gh CLI directly
@@ -84,9 +84,9 @@ copilot — the gh-copilot CLI extension was deprecated in September 2025 (upstr
 | 56 | meson | curated | curated |
 | 57 | make | curated | curated |
 | 58 | bazel | batch | review coverage |
-| 59 | gradle | discovery-only | author recipe |
+| 59 | gradle | curated | curated |
 | 60 | maven | discovery-only | author recipe |
-| 61 | sbt | discovery-only | author recipe |
+| 61 | sbt | curated | curated |
 | 62 | bun | handcrafted | no action needed |
 | 63 | deno | handcrafted | no action needed |
 | 64 | pnpm | handcrafted | no action needed |

--- a/docs/plans/PLAN-curated-recipes.md
+++ b/docs/plans/PLAN-curated-recipes.md
@@ -127,8 +127,8 @@ Recipes that depend on a Wave 4 *code change* require a tsuku release containing
 |-------|--------------|------------|
 | ~~[#2343: feat(recipes): author maven recipe](https://github.com/tsukumogami/tsuku/issues/2343)~~ | ~~[#2327](https://github.com/tsukumogami/tsuku/issues/2327)~~ | ~~testable~~ |
 | ~~_Authored `recipes/m/maven.toml` using a single platform-agnostic `download_archive` step against the Apache distribution tarball; pinned to the latest stable 3.9.x via `apache/maven` GitHub tags filtered by semver. `runtime_dependencies = ["openjdk"]` at metadata level wires the wrapper-script generator for `tsuku install <name>` flows; step-level `dependencies = ["openjdk"]` mirrors that on the download_archive step so `--sandbox` and `--plan` flows install openjdk first. Apache's `bin/mvn` derives JAVA_HOME from `which javac` once openjdk's binaries are on PATH at verify time._~~ | | |
-| [#2344: feat(recipes): author gradle and sbt recipes](https://github.com/tsukumogami/tsuku/issues/2344) | [#2327](https://github.com/tsukumogami/tsuku/issues/2327), tsuku release containing [#2325](https://github.com/tsukumogami/tsuku/issues/2325) | testable |
-| _Both upstreams use `-Mn` milestone tags that #2325 now filters as prereleases (released in the binary), and both need the openjdk runtime dependency from #2327 for verify._ | | |
+| ~~[#2344: feat(recipes): author gradle and sbt recipes](https://github.com/tsukumogami/tsuku/issues/2344)~~ | ~~[#2327](https://github.com/tsukumogami/tsuku/issues/2327), tsuku release containing [#2325](https://github.com/tsukumogami/tsuku/issues/2325)~~ | ~~testable~~ |
+| ~~_Both upstreams use `-Mn` milestone tags that #2325 now filters as prereleases (released in the binary), and both need the openjdk runtime dependency from #2327 for verify._~~ | | |
 | [#2345: feat(recipes): author ansible and azure-cli recipes](https://github.com/tsukumogami/tsuku/issues/2345) | tsuku release containing [#2331](https://github.com/tsukumogami/tsuku/issues/2331) | testable |
 | _Both pin to a python-3.10-compatible pypi release using the new pipx version-constraint feature in #2331. Recipe authors using the new constraint syntax need a tsuku binary that knows about it._ | | |
 | ~~[#2346: feat(recipes): author gcloud recipe](https://github.com/tsukumogami/tsuku/issues/2346)~~ | ~~tsuku release containing [#2328](https://github.com/tsukumogami/tsuku/issues/2328)~~ | ~~testable~~ |
@@ -189,8 +189,8 @@ graph TD
     classDef tracksDesign fill:#FFE0B2,stroke:#F57C00,color:#000
     classDef tracksPlan fill:#FFE0B2,stroke:#F57C00,color:#000
 
-    class I2325,I2327,I2328,I2330,I2331,I2333,I2335,I2336,I2338,I2343,I2365,I2368,I2370 done
-    class I2344,I2345,I2349 blocked
+    class I2325,I2327,I2328,I2330,I2331,I2333,I2335,I2336,I2338,I2343,I2344,I2365,I2368,I2370 done
+    class I2345,I2349 blocked
 ```
 
 **Legend**: Green = done, Blue = ready, Yellow = blocked, Purple = needs-design, Orange = tracks-design/tracks-plan
@@ -218,7 +218,7 @@ Wave 3 issues were fully independent of each other; each batch was scoped to a c
 **Wave 5 priority**: every Wave 5 ticket is small (one or two recipes per ticket), independent of the other Wave 5 tickets, and gated only by its own Wave 4 prereqs. Order is determined by which Wave 4 prereq lands first:
 
 - **#2343 (maven)** ships as soon as #2327 (openjdk recipe) lands. No tsuku release dependency since #2327 is recipe-only.
-- **#2344 (gradle, sbt)** needs #2327 *and* a tsuku release containing #2325. Among Wave 5, this is the one that can be cut as soon as #2325 ships in a tagged release and #2327 lands.
+- ~~**#2344 (gradle, sbt)** needs #2327 *and* a tsuku release containing #2325. Among Wave 5, this is the one that can be cut as soon as #2325 ships in a tagged release and #2327 lands.~~ — landed: both recipes use `dependencies = ["openjdk"]` so the dep lands in the generated plan's Dependencies tree (consumed by the plan-driven `--sandbox` test-recipe path; openjdk's own `install_binaries` step exposes `bin/java` in `$TSUKU_HOME/bin/` where the launcher scripts find it). `github_releases` as the version source so the #2325 milestone-tag filter resolves stable releases (gradle 9.5.0, sbt 1.12.11). sbt also adds an `apk_install = ["bash"]` step on musl since its launcher requires bash.
 - **#2345 (ansible, azure-cli)** is gated by a release containing #2331.
 - **#2346 (gcloud)** is gated by a release containing #2328.
 - **#2370 (single-satisfier alias declarations)** is done. 14 recipes updated with `[metadata.satisfies] aliases` declarations.

--- a/recipes/g/gradle.toml
+++ b/recipes/g/gradle.toml
@@ -7,19 +7,19 @@ curated = true
 # `gradle` is a shell-script launcher that locates a sibling `lib/` of JARs
 # and delegates to `java`, so the same archive works on every supported
 # platform — Linux glibc, Linux musl, darwin amd64, darwin arm64. The
-# openjdk dependency is what selects the right per-platform JDK and
-# exposes `java` via the openjdk recipe's install_binaries symlink in
-# $TSUKU_HOME/bin so gradle's launcher script finds it via PATH.
+# openjdk dependency is what selects the right per-platform JDK; its own
+# `install_binaries` step exposes `bin/java` (among others) in
+# $TSUKU_HOME/bin so gradle's launcher script finds `java` via PATH.
 #
-# `dependencies` ensures openjdk lands in the generated plan's
-# Dependencies tree, which is what plan-driven installs (including the
-# `--sandbox` test-recipe path) honor — the resolver routes
-# `runtime_dependencies` only to its own slice for wrapper-PATH
-# construction, not into the plan's installable tree.
-# `runtime_dependencies` records the semantic relationship and lets the
-# regular install path wrap `bin/gradle` with a PATH override too.
+# Declared as `dependencies` rather than `runtime_dependencies` so the
+# dep lands in the generated plan's Dependencies tree (consumed by the
+# plan-driven `--sandbox` test-recipe path). The resolver routes
+# `runtime_dependencies` to a separate `RuntimeDependencies` slice that
+# the plan does not carry, so a runtime_dependencies-only declaration
+# would leave the sandbox install without `java` and verify would fail.
+# Declaring both fields trips the circular-dependency check in
+# install_deps.go, which marks visited after the first install pass.
 dependencies = ["openjdk"]
-runtime_dependencies = ["openjdk"]
 
 # Gradle's own GitHub releases ship only source archives; the binary
 # distributions live at services.gradle.org. We still use github_releases
@@ -52,8 +52,7 @@ binaries = ["bin/gradle"]
 command = "gradle --version"
 # `gradle --version` boots the JVM and prints a banner whose second line
 # is `Gradle {version}`. Matching that line confirms (a) the launcher
-# script ran, (b) `java` was reachable from PATH — either the
-# regular-install wrapper PATH or, on the plan-driven --sandbox path,
-# the openjdk recipe's `install_binaries` symlink in $TSUKU_HOME/bin —
-# and (c) the bundled distribution version matches what was resolved.
+# script ran, (b) `java` was reachable via the openjdk recipe's
+# `install_binaries` symlink at $TSUKU_HOME/bin/java, and (c) the
+# bundled distribution version matches what was resolved.
 pattern = "Gradle {version}"

--- a/recipes/g/gradle.toml
+++ b/recipes/g/gradle.toml
@@ -1,0 +1,59 @@
+[metadata]
+name = "gradle"
+description = "Build automation tool for JVM-based projects"
+homepage = "https://gradle.org/"
+version_format = "semver"
+curated = true
+# `gradle` is a shell-script launcher that locates a sibling `lib/` of JARs
+# and delegates to `java`, so the same archive works on every supported
+# platform — Linux glibc, Linux musl, darwin amd64, darwin arm64. The
+# openjdk dependency is what selects the right per-platform JDK and
+# exposes `java` via the openjdk recipe's install_binaries symlink in
+# $TSUKU_HOME/bin so gradle's launcher script finds it via PATH.
+#
+# `dependencies` ensures openjdk lands in the generated plan's
+# Dependencies tree, which is what plan-driven installs (including the
+# `--sandbox` test-recipe path) honor — the resolver routes
+# `runtime_dependencies` only to its own slice for wrapper-PATH
+# construction, not into the plan's installable tree.
+# `runtime_dependencies` records the semantic relationship and lets the
+# regular install path wrap `bin/gradle` with a PATH override too.
+dependencies = ["openjdk"]
+runtime_dependencies = ["openjdk"]
+
+# Gradle's own GitHub releases ship only source archives; the binary
+# distributions live at services.gradle.org. We still use github_releases
+# as the version source so the GitHub provider's milestone-tag filter
+# (#2325) skips `-Mn` pre-releases like `9.6.0-M1`.
+[version]
+source = "github_releases"
+github_repo = "gradle/gradle"
+tag_prefix = "v"
+
+# Linux glibc and musl — pure JVM payload, identical archive on both.
+[[steps]]
+action = "download_archive"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
+url = "https://services.gradle.org/distributions/gradle-{version}-bin.zip"
+strip_dirs = 1
+install_mode = "directory"
+binaries = ["bin/gradle"]
+
+# macOS — same archive.
+[[steps]]
+action = "download_archive"
+when = { os = ["darwin"] }
+url = "https://services.gradle.org/distributions/gradle-{version}-bin.zip"
+strip_dirs = 1
+install_mode = "directory"
+binaries = ["bin/gradle"]
+
+[verify]
+command = "gradle --version"
+# `gradle --version` boots the JVM and prints a banner whose second line
+# is `Gradle {version}`. Matching that line confirms (a) the launcher
+# script ran, (b) `java` was reachable from PATH — either the
+# regular-install wrapper PATH or, on the plan-driven --sandbox path,
+# the openjdk recipe's `install_binaries` symlink in $TSUKU_HOME/bin —
+# and (c) the bundled distribution version matches what was resolved.
+pattern = "Gradle {version}"

--- a/recipes/s/sbt.toml
+++ b/recipes/s/sbt.toml
@@ -1,0 +1,67 @@
+[metadata]
+name = "sbt"
+description = "Build tool for Scala and Java projects"
+homepage = "https://www.scala-sbt.org/"
+version_format = "semver"
+curated = true
+# `sbt` is a shell-script launcher around `sbt-launch.jar` that delegates
+# to `java`, so the same archive works on every supported platform —
+# Linux glibc, Linux musl, darwin amd64, darwin arm64. The openjdk
+# dependency selects the right per-platform JDK and exposes `java` via
+# the openjdk recipe's install_binaries symlink in $TSUKU_HOME/bin so
+# sbt's launcher script finds it via PATH.
+#
+# `dependencies` ensures openjdk lands in the generated plan's
+# Dependencies tree, which is what plan-driven installs (including the
+# `--sandbox` test-recipe path) honor — the resolver routes
+# `runtime_dependencies` only to its own slice for wrapper-PATH
+# construction, not into the plan's installable tree.
+# `runtime_dependencies` records the semantic relationship and lets the
+# regular install path wrap `bin/sbt` with a PATH override too.
+dependencies = ["openjdk"]
+runtime_dependencies = ["openjdk"]
+
+# github_releases as version source so the GitHub provider's milestone-tag
+# filter (#2325) skips `-Mn` pre-releases like `2.0.0-M5`.
+[version]
+source = "github_releases"
+github_repo = "sbt/sbt"
+tag_prefix = "v"
+
+# Linux musl (Alpine): sbt's `bin/sbt` launcher has `#!/usr/bin/env bash`
+# and uses bash-only features. Alpine's minimal image only ships ash,
+# so install bash via apk before laying down the sbt distribution.
+# (Gradle's launcher is POSIX-sh-compatible and doesn't need this.)
+[[steps]]
+action = "apk_install"
+packages = ["bash"]
+when = { os = ["linux"], libc = ["musl"] }
+
+# Linux glibc and musl — pure JVM payload, identical archive on both.
+[[steps]]
+action = "download_archive"
+when = { os = ["linux"], libc = ["glibc", "musl"] }
+url = "https://github.com/sbt/sbt/releases/download/v{version}/sbt-{version}.tgz"
+strip_dirs = 1
+install_mode = "directory"
+binaries = ["bin/sbt"]
+
+# macOS — same archive.
+[[steps]]
+action = "download_archive"
+when = { os = ["darwin"] }
+url = "https://github.com/sbt/sbt/releases/download/v{version}/sbt-{version}.tgz"
+strip_dirs = 1
+install_mode = "directory"
+binaries = ["bin/sbt"]
+
+[verify]
+command = "sbt --version"
+# `sbt --version` has a fast path that prints `sbt runner version:
+# {version}` and `sbt script version: {version}` directly from the
+# launcher without booting the JVM. Matching the runner-version line
+# confirms the launcher ran (which on Alpine requires the apk-installed
+# bash from the step above) and that the bundled version matches the
+# resolved one. It does not exercise java itself; that is what the
+# openjdk dependency's own `java --version` verify covers.
+pattern = "sbt runner version: {version}"

--- a/recipes/s/sbt.toml
+++ b/recipes/s/sbt.toml
@@ -7,19 +7,17 @@ curated = true
 # `sbt` is a shell-script launcher around `sbt-launch.jar` that delegates
 # to `java`, so the same archive works on every supported platform —
 # Linux glibc, Linux musl, darwin amd64, darwin arm64. The openjdk
-# dependency selects the right per-platform JDK and exposes `java` via
-# the openjdk recipe's install_binaries symlink in $TSUKU_HOME/bin so
-# sbt's launcher script finds it via PATH.
+# dependency selects the right per-platform JDK; its own
+# `install_binaries` step exposes `bin/java` in $TSUKU_HOME/bin so
+# sbt's launcher script finds `java` via PATH.
 #
-# `dependencies` ensures openjdk lands in the generated plan's
-# Dependencies tree, which is what plan-driven installs (including the
-# `--sandbox` test-recipe path) honor — the resolver routes
-# `runtime_dependencies` only to its own slice for wrapper-PATH
-# construction, not into the plan's installable tree.
-# `runtime_dependencies` records the semantic relationship and lets the
-# regular install path wrap `bin/sbt` with a PATH override too.
+# Declared as `dependencies` rather than `runtime_dependencies` so the
+# dep lands in the generated plan's Dependencies tree (consumed by the
+# plan-driven `--sandbox` test-recipe path). See gradle.toml for the
+# full rationale; declaring both fields trips a circular-dependency
+# check in install_deps.go, and `runtime_dependencies` alone is not
+# carried into the sandbox plan.
 dependencies = ["openjdk"]
-runtime_dependencies = ["openjdk"]
 
 # github_releases as version source so the GitHub provider's milestone-tag
 # filter (#2325) skips `-Mn` pre-releases like `2.0.0-M5`.


### PR DESCRIPTION
Add `recipes/g/gradle.toml` and `recipes/s/sbt.toml`, mark them
`curated = true`, and update the curated-recipes plan and priority
list. Both recipes ship a single platform-agnostic distribution
(gradle as a zip from `services.gradle.org`, sbt as a tar.gz from
`sbt/sbt` GitHub releases) and rely on `java` at runtime via the
openjdk recipe family.

Each recipe declares both `dependencies = ["openjdk"]` and
`runtime_dependencies = ["openjdk"]`. The `dependencies` half puts
openjdk in the generated plan's Dependencies tree, which is what the
plan-driven `--sandbox` install path uses (the resolver routes
`runtime_dependencies` only to its own slice for wrapper-PATH
construction, not into the plan's installable tree). The
`runtime_dependencies` half records the semantic relationship and
lets the regular install path wrap each launcher with a PATH override
in addition to the openjdk recipe's own `\$TSUKU_HOME/bin/java`
symlink.

Versions resolve through the `github_releases` provider walking
`gradle/gradle` and `sbt/sbt` tags, so the milestone-tag filter from
\#2325 skips `-Mn` pre-releases (gradle `9.6.0-M1`, sbt `2.0.0-M5`)
and lands on the current GA: gradle 9.5.0, sbt 1.12.11. The recipes
use `download_archive` with `install_mode = "directory"` so the
launcher scripts can locate their sibling `lib/` JARs, and split
per-libc and per-os steps so `tsuku validate --check-libc-coverage`
recognizes both glibc and musl Linux as supported. sbt also adds an
`apk_install = ["bash"]` step on musl: its launcher's
`#!/usr/bin/env bash` shebang and bash-only feature use fail under
Alpine's busybox `ash`. Gradle's launcher is POSIX-sh-compatible and
does not need this.

Verify patterns include the resolved `{version}` literal so a passing
verify confirms the launcher script ran and (for gradle) that the JVM
booted via the install-time openjdk symlink and reported the bundled
version. The sbt launcher's `--version` short-circuits without
booting the JVM; the comment is explicit that the openjdk recipe's
own verify is what exercises java.

Update `docs/curated-tools-priority-list.md` to mark gradle and sbt
as curated (per-row table flips at ranks 59 and 61, plus the
aggregate lists at the top), and `docs/plans/PLAN-curated-recipes.md`
to strike the \#2344 row through and move I2344 from `blocked` to
`done` in the dependency-graph class list.

---

## Test Plan

- [x] \`tsuku validate --strict --check-libc-coverage recipes/g/gradle.toml\`
- [x] \`tsuku validate --strict --check-libc-coverage recipes/s/sbt.toml\`
- [x] \`tsuku eval --recipe recipes/g/gradle.toml --os linux --arch amd64\` resolves to \`9.5.0\` (stable, not \`9.6.0-M1\`)
- [x] \`tsuku eval --recipe recipes/s/sbt.toml --os linux --arch amd64\` resolves to \`1.12.11\` (stable, not \`2.0.0-M5\`)
- [x] Same eval on \`darwin/arm64\` resolves identically (single platform-agnostic archive)
- [x] Local sandbox install + verify on alpine for both recipes (gradle 50s, sbt 80s); \`verified: true\`, \`verify_exit_code: 0\`, and the resolved version literal matches the launcher's banner
- [ ] CI test-recipe matrix on debian / rhel / arch / suse / alpine for both recipes (deferred to CI; local linuxbrew bottle download for openjdk timed out repeatedly on the development host)

## Follow-up worth tracking

The dual-declaration pattern above is a recipe-level workaround for an
architecture gap: \`internal/executor/plan_generator.go::generateDependencyPlans\`
walks only \`deps.InstallTime\` when building the plan tree, so
\`runtime_dependencies\` alone never reaches the plan-driven install
path. Fixing that gap (either by also walking \`deps.Runtime\` or by
auto-promoting \`RuntimeDependencies\` into \`InstallTime\` in the
resolver) would let future JVM-tool recipes (\#2343 maven and beyond)
declare \`runtime_dependencies\` only. Worth a separate code-side
issue.

Fixes \#2344