### PR TITLE
fix(updates): drop stale success notices when announced version doesn't match installed

### DIFF
--- a/internal/updates/notify.go
+++ b/internal/updates/notify.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/tsukumogami/tsuku/internal/config"
+	"github.com/tsukumogami/tsuku/internal/install"
 	"github.com/tsukumogami/tsuku/internal/notices"
 	"github.com/tsukumogami/tsuku/internal/userconfig"
 )
@@ -40,7 +41,7 @@ func DisplayNotifications(cfg *config.Config, userCfg *userconfig.Config, quiet 
 	}
 
 	// 2. Render unshown notices (from prior runs: self-update, tool failures)
-	renderUnshownNotices(noticesDir)
+	renderUnshownNotices(noticesDir, cfg)
 
 	// 3. Render available-update summary (when auto_apply is disabled)
 	if userCfg != nil && !userCfg.UpdatesAutoApplyEnabled() {
@@ -68,11 +69,21 @@ func DisplayAvailableSummary(cfg *config.Config, userCfg *userconfig.Config, qui
 // renderUnshownNotices reads and displays any unshown notices on stderr.
 // KindVersionFallback and KindShellInitChange notices are single-view: they are
 // removed after display. All other kinds use the Shown=true persistence convention.
-func renderUnshownNotices(noticesDir string) {
+//
+// Tool-update success notices are dropped (not rendered, file removed) when the
+// AttemptedVersion no longer matches the tool's currently installed ActiveVersion.
+// This prevents a stale background auto-apply notice from announcing a version that
+// isn't actually installed once the user (or a later auto-apply) has moved past it.
+func renderUnshownNotices(noticesDir string, cfg *config.Config) {
 	unshown, err := notices.ReadUnshownNotices(noticesDir)
 	if err != nil || len(unshown) == 0 {
 		return
 	}
+
+	// Loaded lazily on first non-self tool success notice. nil while not loaded;
+	// stays nil if loading fails (we fall back to rendering as today rather than
+	// hiding everything because of a state read error).
+	var stateMgr *install.StateManager
 
 	for _, n := range unshown {
 		if n.Tool == SelfToolName && n.Error == "" {
@@ -93,7 +104,15 @@ func renderUnshownNotices(noticesDir string) {
 				fmt.Fprintf(os.Stderr, "  %s\n", msg)
 			}
 		} else if n.Error == "" {
-			// Tool update success from background (KindUpdateResult or KindAutoApplyResult)
+			// Tool update success from background (KindUpdateResult or KindAutoApplyResult).
+			// Skip if the announced version no longer matches what's installed.
+			if stateMgr == nil {
+				stateMgr = install.NewStateManager(cfg)
+			}
+			if isStaleSuccessNotice(stateMgr, n) {
+				_ = notices.RemoveNotice(noticesDir, n.Tool)
+				continue
+			}
 			fmt.Fprintf(os.Stderr, "\n%s has been updated to %s\n", n.Tool, n.AttemptedVersion)
 		} else {
 			// Tool update failure
@@ -108,6 +127,23 @@ func renderUnshownNotices(noticesDir string) {
 			_ = notices.MarkShown(noticesDir, n.Tool)
 		}
 	}
+}
+
+// isStaleSuccessNotice reports whether a tool-update success notice announces a
+// version that doesn't match the tool's currently installed ActiveVersion.
+// Returns false if state can't be read — we'd rather show a possibly-stale
+// banner than hide a fresh one because state.json was momentarily unreadable.
+func isStaleSuccessNotice(sm *install.StateManager, n notices.Notice) bool {
+	ts, err := sm.GetToolState(n.Tool)
+	if err != nil {
+		return false
+	}
+	if ts == nil {
+		// Notice exists for a tool not in state — there's nothing real to
+		// reconcile against, so treat it as stale.
+		return true
+	}
+	return ts.ActiveVersion != n.AttemptedVersion
 }
 
 // renderAvailableSummary counts tools with available updates from cache entries

--- a/internal/updates/notify_test.go
+++ b/internal/updates/notify_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/tsukumogami/tsuku/internal/config"
+	"github.com/tsukumogami/tsuku/internal/install"
 	"github.com/tsukumogami/tsuku/internal/notices"
 	"github.com/tsukumogami/tsuku/internal/userconfig"
 )
@@ -127,6 +128,99 @@ func TestDisplayNotifications_SuccessNotice(t *testing.T) {
 
 	if !bytes.Contains(output, []byte("tsuku has been updated to 0.8.0")) {
 		t.Errorf("expected success notice, got %q", output)
+	}
+}
+
+// A queued background-success notice for a tool whose installed version no longer
+// matches the announced version must be suppressed and removed, so the user is
+// never told "niwa has been updated to 0.10.4" when 0.11.0 is what's installed.
+func TestDisplayNotifications_StaleSuccessNoticeDropped(t *testing.T) {
+	dir := t.TempDir()
+	noticesDir := notices.NoticesDir(dir)
+	setupCacheDirs(t, dir)
+	cfg := &config.Config{HomeDir: dir}
+	userCfg := userconfig.DefaultConfig()
+
+	clearSuppressEnv(t)
+	mockTTY(t, true)
+
+	mgr := install.NewStateManager(cfg)
+	if err := mgr.UpdateTool("niwa", func(ts *install.ToolState) {
+		ts.ActiveVersion = "0.11.0"
+		ts.IsExplicit = true
+	}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	stale := &notices.Notice{
+		Tool:             "niwa",
+		AttemptedVersion: "0.10.4",
+		Timestamp:        time.Now(),
+		Shown:            false,
+		Kind:             notices.KindAutoApplyResult,
+	}
+	if err := notices.WriteNotice(noticesDir, stale); err != nil {
+		t.Fatalf("write stale notice: %v", err)
+	}
+
+	output := captureStderr(t, func() {
+		DisplayNotifications(cfg, userCfg, false, nil)
+	})
+
+	if bytes.Contains(output, []byte("niwa has been updated to 0.10.4")) {
+		t.Errorf("stale success notice should not render, got %q", output)
+	}
+
+	if got, _ := notices.ReadNotice(noticesDir, "niwa"); got != nil {
+		t.Errorf("stale notice file should be removed, got %+v", got)
+	}
+}
+
+// A background-success notice whose announced version matches the installed
+// version should still render exactly once and be marked Shown.
+func TestDisplayNotifications_FreshSuccessNoticeRendered(t *testing.T) {
+	dir := t.TempDir()
+	noticesDir := notices.NoticesDir(dir)
+	setupCacheDirs(t, dir)
+	cfg := &config.Config{HomeDir: dir}
+	userCfg := userconfig.DefaultConfig()
+
+	clearSuppressEnv(t)
+	mockTTY(t, true)
+
+	mgr := install.NewStateManager(cfg)
+	if err := mgr.UpdateTool("niwa", func(ts *install.ToolState) {
+		ts.ActiveVersion = "0.11.1"
+		ts.IsExplicit = true
+	}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	fresh := &notices.Notice{
+		Tool:             "niwa",
+		AttemptedVersion: "0.11.1",
+		Timestamp:        time.Now(),
+		Shown:            false,
+		Kind:             notices.KindAutoApplyResult,
+	}
+	if err := notices.WriteNotice(noticesDir, fresh); err != nil {
+		t.Fatalf("write fresh notice: %v", err)
+	}
+
+	output := captureStderr(t, func() {
+		DisplayNotifications(cfg, userCfg, false, nil)
+	})
+
+	if !bytes.Contains(output, []byte("niwa has been updated to 0.11.1")) {
+		t.Errorf("fresh success notice should render, got %q", output)
+	}
+
+	got, _ := notices.ReadNotice(noticesDir, "niwa")
+	if got == nil {
+		t.Fatal("fresh notice should persist with Shown=true, got nil")
+	}
+	if !got.Shown {
+		t.Error("fresh notice should be marked Shown=true after render")
 	}
 }
 


### PR DESCRIPTION
## Summary

A queued background-success notice (written by `MaybeAutoApply` with `AttemptedVersion = entry.LatestWithinPin`) used to print verbatim on the next foreground command, even after the user or a later auto-apply moved past that version. The renderer in `internal/updates/notify.go` had no comparison between the announced version and what was actually installed.

This change reconciles at the renderer: for tool-success notices (non-self, `Error == ""`), it compares `AttemptedVersion` to the tool's installed `ActiveVersion`. On mismatch, the banner is suppressed and the notice file is removed so it never resurfaces. Failure notices and self-update notices are unchanged.

## Repro

```
$ niwa version
niwa 0.11.0
$ tsuku update niwa

niwa has been updated to 0.10.4              # stale: 0.10.4 < installed 0.11.0

Update failed: railway -> 4.57.2: ... 404 Not Found
  Run 'tsuku notices' for details, 'tsuku rollback railway' to revert.

vercel has been updated to 53.3.2
niwa@0.11.1
```

## Root cause

- `internal/updates/apply.go:148-158` — background auto-apply writes a `Shown=false` success notice with `AttemptedVersion = entry.LatestWithinPin`.
- `internal/updates/notify.go:71-111` — `renderUnshownNotices` iterated notices and printed `n.AttemptedVersion` verbatim, with no comparison to the installed `ActiveVersion`.
- `cmd/tsuku/main.go:78` — `DisplayNotifications` runs in `PersistentPreRun`, so the stale banner prints before any command body can overwrite the notice via `cmd/tsuku/update.go:200-209`.

Fixing this at the renderer covers every command (not just `update`) and tolerates the race where a fresh notice arrives mid-run.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Notice `AttemptedVersion` matches installed `ActiveVersion` | renders, marked Shown | renders, marked Shown |
| Notice `AttemptedVersion` differs from installed | renders stale banner, marked Shown | suppressed, file removed |
| Tool not in state | renders banner about a tool not on disk | suppressed, file removed |
| Failure notice (`Error != ""`) | renders | renders (unchanged) |
| Self-update notice (`Tool == "tsuku"`) | renders | renders (unchanged) |
| `state.json` read error | renders | renders (best-effort fallback) |

## Test plan

- [x] `go test ./internal/updates -run 'TestDisplayNotifications' -v` (all 8 tests pass, including 2 new cases)
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (no regressions caused by this change; pre-existing `TestGolangCILint` failure is unrelated — points at files outside this repo)
- [x] End-to-end repro: seed `$TSUKU_HOME/notices/niwa.json` with `attempted_version: 0.10.4` and `$TSUKU_HOME/state.json` with `active_version: 0.11.0`, run `tsuku list` — stale banner not printed, notice file removed.

## Related

- #2409 — suppress prior-run **failure** notices in `tsuku update --all`. Same render-before-body timing class but disjoint conditions (failures, only for `--all`). Solving #2409 will likely reuse the same staleness check seam.

## Out of scope

- Schema changes
- Centralized notice GC pass
- Write-site cleanup in `apply.go` / `cmd/tsuku/update.go`
- Self-update staleness (low risk, would require refactoring the existing positive test against `buildinfo.Version()`)