### PR TITLE
fix(sandbox): bump debian family base image to trixie-slim

### DIFF
--- a/container-images.json
+++ b/container-images.json
@@ -1,6 +1,6 @@
 {
   "debian": {
-    "image": "docker.io/library/debian:bookworm-slim@sha256:98f4b71de414932439ac6ac690d7060df1f27161073c5036a7553723881bffbe",
+    "image": "docker.io/library/debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e",
     "infra_packages": {
       "core": [],
       "network": ["ca-certificates", "curl"],

--- a/internal/containerimages/container-images.json
+++ b/internal/containerimages/container-images.json
@@ -1,6 +1,6 @@
 {
   "debian": {
-    "image": "docker.io/library/debian:bookworm-slim@sha256:98f4b71de414932439ac6ac690d7060df1f27161073c5036a7553723881bffbe",
+    "image": "docker.io/library/debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e",
     "infra_packages": {
       "core": [],
       "network": ["ca-certificates", "curl"],

--- a/internal/containerimages/containerimages_test.go
+++ b/internal/containerimages/containerimages_test.go
@@ -9,7 +9,7 @@ func TestImageForFamily_KnownFamilies(t *testing.T) {
 	t.Parallel()
 
 	expected := map[string]string{
-		"debian": "docker.io/library/debian:bookworm-slim@sha256:98f4b71de414932439ac6ac690d7060df1f27161073c5036a7553723881bffbe",
+		"debian": "docker.io/library/debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e",
 		"rhel":   "docker.io/library/fedora:41@sha256:f1a3fab47bcb3c3ddf3135d5ee7ba8b7b25f2e809a47440936212a3a50957f3d",
 		"arch":   "docker.io/library/archlinux:base@sha256:e25a13ea0e2a36df12f3593fe4bc1063605cfd2ab46c704f72c9e1c3514138ce",
 		"alpine": "docker.io/library/alpine:3.21@sha256:c3f8e73fdb79deaebaa2037150150191b9dcbfba68b4a46d70103204c53f4709",
@@ -54,8 +54,8 @@ func TestDefaultImage(t *testing.T) {
 	t.Parallel()
 
 	got := DefaultImage()
-	if got != "docker.io/library/debian:bookworm-slim@sha256:98f4b71de414932439ac6ac690d7060df1f27161073c5036a7553723881bffbe" {
-		t.Errorf("DefaultImage() = %q, want %q", got, "docker.io/library/debian:bookworm-slim@sha256:98f4b71de414932439ac6ac690d7060df1f27161073c5036a7553723881bffbe")
+	if got != "docker.io/library/debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e" {
+		t.Errorf("DefaultImage() = %q, want %q", got, "docker.io/library/debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e")
 	}
 }
 

--- a/internal/sandbox/container_spec_test.go
+++ b/internal/sandbox/container_spec_test.go
@@ -35,7 +35,7 @@ func TestDeriveContainerSpec(t *testing.T) {
 			name:          "debian family - apt",
 			packages:      map[string][]string{"apt": {"curl", "jq"}},
 			wantFamily:    "debian",
-			wantBaseImage: "docker.io/library/debian:bookworm-slim@sha256:98f4b71de414932439ac6ac690d7060df1f27161073c5036a7553723881bffbe",
+			wantBaseImage: "docker.io/library/debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e",
 			wantErr:       false,
 		},
 		{

--- a/internal/sandbox/requirements_test.go
+++ b/internal/sandbox/requirements_test.go
@@ -323,7 +323,7 @@ func TestComputeSandboxRequirements_TargetFamily(t *testing.T) {
 		wantImage    string
 	}{
 		{"empty defaults to debian", "", containerimages.DefaultImage()},
-		{"debian", "debian", "docker.io/library/debian:bookworm-slim@sha256:98f4b71de414932439ac6ac690d7060df1f27161073c5036a7553723881bffbe"},
+		{"debian", "debian", "docker.io/library/debian:trixie-slim@sha256:4e401d95de7083948053197a9c3913343cd06b706bf15eb6a0c3ccd26f436a0e"},
 		{"alpine", "alpine", "docker.io/library/alpine:3.21@sha256:c3f8e73fdb79deaebaa2037150150191b9dcbfba68b4a46d70103204c53f4709"},
 		{"rhel", "rhel", "docker.io/library/fedora:41@sha256:f1a3fab47bcb3c3ddf3135d5ee7ba8b7b25f2e809a47440936212a3a50957f3d"},
 		{"arch", "arch", "docker.io/library/archlinux:base@sha256:e25a13ea0e2a36df12f3593fe4bc1063605cfd2ab46c704f72c9e1c3514138ce"},


### PR DESCRIPTION
Bump the debian-family sandbox base image from debian:bookworm-slim (GLIBC 2.36) to debian:trixie-slim (GLIBC 2.41), pinned by digest.

Tools that bundle gcc-libs (the Homebrew gcc bottle, currently gcc 16) carry a libstdc++.so.6 built against GLIBC_2.38. When such a tool is installed in the sandbox and its post-install verify step runs the binary, the dynamic linker cannot resolve GLIBC_2.38 against bookworm's older glibc:

```
node.real: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by .../lib/libstdc++.so.6)
```

trixie is current Debian stable and provides a glibc new enough for the bundled gcc-libs runtime. The embedded copy is regenerated via go:generate; config-asserting tests are updated to the new digest.

---

## Reviewer context

### Root cause

The "Sandbox Tests" workflow case `archive_nodejs_checksum` started failing once `nodejs` resolved to the brand-new `26.3.1` release (the last green run predated it). The failure surfaced only as "sandbox verification failed with exit code 1" because the human-readable sandbox output does not print `VerifyOutput` on failure (the `--json` path does).

Capturing the verify command's stderr via `tsuku install --plan ... --sandbox --json` revealed:

```
/workspace/tsuku/tools/nodejs-26.3.1/bin/node.real: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by .../lib/libstdc++.so.6)
```

The node binary itself is fine on the sandbox glibc (it only needs GLIBC_2.28). The failing component is the **bundled libstdc++.so.6** that comes from the `gcc-libs` runtime dependency (Homebrew gcc 16 bottle, `libstdc++.so.6.0.35`), which requires GLIBC_2.38. The nodejs recipe's wrapper forces `node.real` to load that bundled libstdc++ via `LD_LIBRARY_PATH`, so the verify step runs the modern libstdc++ against the container's glibc.

The nodejs plan resolves to `linux_family = debian`, so the sandbox container is built from the `debian` family entry in `container-images.json` -- which was `debian:bookworm-slim` (GLIBC 2.36 < 2.38). This is why the initial glibc hypothesis pointed at the wrong image (the source-build `ubuntu:22.04` constant is not on this code path).

### Why this image, this scope

- Confirmed end-to-end with Docker: `node.real --version` returns `v26.3.1` on `debian:trixie-slim` (GLIBC 2.41) with the bundled libs, and fails on bookworm/22.04/24.04-mismatched paths exactly as the CI log shows.
- Verified no regression by running the other debian-family and default-image matrix cases locally in the sandbox: golang, perl, argo-cd, bombardier, ruff -- all pass.
- Kept the change minimal: only the `debian` family entry moves. The `SourceBuildSandboxImage`/`SourceBuildValidationImage` (ubuntu) and `DefaultValidationImage` constants are not on the failing code path and are left untouched.

Local checks: `gofmt`, `go vet ./...`, `go build ./...`, `go test ./...`, and the lint test target (`TestGolangCILint`/`GoFmt`/`GoModTidy`/`GoVet`/`Govulncheck`) all pass.

This unblocks PR #2423's CI: that PR only touches internal/notices + internal/updates, but its sandbox-tests run was failing on this unrelated, latest-version-triggered nodejs regression. This fix must land on its own first.