### PR TITLE
feat(recipes): add clerk CLI recipe

### DIFF
--- a/recipes/c/clerk.toml
+++ b/recipes/c/clerk.toml
@@ -3,26 +3,21 @@ name = "clerk"
 description = "Official Clerk CLI for managing authentication and user management"
 homepage = "https://clerk.com/docs/cli"
 version_format = "semver"
+# clerk's prebuilt linux binaries dynamically link libstdc++/libgcc, which glibc
+# distros ship by default but bare musl systems (Alpine) do not. Limit to glibc.
+supported_libc = ["glibc"]
 
 [version]
 github_repo = "clerk/cli"
 tag_prefix = "v"
 
-# Clerk ships prebuilt single-file binaries per platform. The plain linux
-# binaries are glibc-linked; Alpine and other musl systems need the -musl asset.
+# Clerk ships prebuilt single-file binaries per platform: clerk-{os}-{arch}.
+# Only amd64 needs mapping to the asset's x64 name; arm64 and the OS names match.
 [[steps]]
 action = "github_file"
-when = { os = ["linux"], libc = ["glibc"] }
+when = { os = ["linux"] }
 repo = "clerk/cli"
 asset_pattern = "clerk-linux-{arch}"
-arch_mapping = { amd64 = "x64" }
-binary = "clerk"
-
-[[steps]]
-action = "github_file"
-when = { os = ["linux"], libc = ["musl"] }
-repo = "clerk/cli"
-asset_pattern = "clerk-linux-{arch}-musl"
 arch_mapping = { amd64 = "x64" }
 binary = "clerk"
 

--- a/recipes/c/clerk.toml
+++ b/recipes/c/clerk.toml
@@ -1,0 +1,18 @@
+[metadata]
+name = "clerk"
+description = "Official Clerk CLI for managing authentication and user management"
+homepage = "https://clerk.com/docs/cli"
+version_format = "semver"
+
+# Clerk ships prebuilt single-file binaries per platform: clerk-{os}-{arch}.
+# Asset os names (linux, darwin) match tsuku defaults; only amd64 -> x64 needs mapping.
+[[steps]]
+action = "github_file"
+repo = "clerk/cli"
+asset_pattern = "clerk-{os}-{arch}"
+binary = "clerk"
+arch_mapping = { amd64 = "x64" }
+
+[verify]
+command = "clerk --version"
+pattern = "{version}"

--- a/recipes/c/clerk.toml
+++ b/recipes/c/clerk.toml
@@ -4,14 +4,35 @@ description = "Official Clerk CLI for managing authentication and user managemen
 homepage = "https://clerk.com/docs/cli"
 version_format = "semver"
 
-# Clerk ships prebuilt single-file binaries per platform: clerk-{os}-{arch}.
-# Asset os names (linux, darwin) match tsuku defaults; only amd64 -> x64 needs mapping.
+[version]
+github_repo = "clerk/cli"
+tag_prefix = "v"
+
+# Clerk ships prebuilt single-file binaries per platform. The plain linux
+# binaries are glibc-linked; Alpine and other musl systems need the -musl asset.
 [[steps]]
 action = "github_file"
+when = { os = ["linux"], libc = ["glibc"] }
 repo = "clerk/cli"
-asset_pattern = "clerk-{os}-{arch}"
-binary = "clerk"
+asset_pattern = "clerk-linux-{arch}"
 arch_mapping = { amd64 = "x64" }
+binary = "clerk"
+
+[[steps]]
+action = "github_file"
+when = { os = ["linux"], libc = ["musl"] }
+repo = "clerk/cli"
+asset_pattern = "clerk-linux-{arch}-musl"
+arch_mapping = { amd64 = "x64" }
+binary = "clerk"
+
+[[steps]]
+action = "github_file"
+when = { os = ["darwin"] }
+repo = "clerk/cli"
+asset_pattern = "clerk-darwin-{arch}"
+arch_mapping = { amd64 = "x64" }
+binary = "clerk"
 
 [verify]
 command = "clerk --version"


### PR DESCRIPTION
Add `recipes/c/clerk.toml`, a recipe for the official Clerk CLI. It fetches Clerk's prebuilt single-file release binaries from the `clerk/cli` GitHub repo via the `github_file` action: `clerk-linux-{arch}` on Linux and `clerk-darwin-{arch}` on macOS, covering amd64 and arm64. Only `amd64` needs mapping to the upstream `x64` asset name; `arm64` and the OS names already match tsuku defaults. The recipe declares `supported_libc = ["glibc"]` because Clerk's binaries dynamically link `libstdc++`/`libgcc`, which glibc distributions ship by default but bare musl systems (Alpine) do not.

---

## Why binaries over npm

Clerk documents several install paths (npm, Homebrew, a curl script, native binaries). The recipe uses the native GitHub binaries so installs stay self-contained and avoid pulling in Node.js, which `npm install -g clerk` would require. This mirrors the existing `hadolint` and `lefthook` recipes.

## Why glibc-only

Clerk publishes `-musl` binaries too, but they are not statically linked: they still depend on `libstdc++`/`libgcc`, which bare Alpine does not include, so `clerk --version` fails there under sandbox validation. Rather than layer a system-package dependency onto the recipe, it declares `supported_libc = ["glibc"]`, matching how many existing recipes handle glibc-only tools. glibc distros (Debian, RHEL, Arch, SUSE) all pass.

## Verification

- `tsuku eval` produces a deterministic plan per platform, resolving the `v` tag prefix and selecting the right asset: `clerk-linux-x64`/`clerk-linux-arm64` and `clerk-darwin-x64`/`clerk-darwin-arm64`.
- An isolated `tsuku install` on glibc succeeds (`clerk@1.5.0`) and the installed binary passes the `clerk --version` check.