### PR TITLE
feat(recipes): add libcap library recipe

### DIFF
--- a/recipes/l/libcap.toml
+++ b/recipes/l/libcap.toml
@@ -1,0 +1,32 @@
+# libcap - POSIX 1003.1e capabilities library
+#
+# Runtime dependency for bubblewrap (bwrap links libcap.so.2).
+# Linux-only: capabilities are a Linux kernel feature.
+
+[metadata]
+name = "libcap"
+description = "POSIX 1003.1e capabilities library"
+homepage = "https://sites.google.com/site/fullycapable/"
+type = "library"
+
+[metadata.satisfies]
+homebrew = ["libcap"]
+
+# glibc Linux: Homebrew bottle. Directory mode with no outputs installs the
+# whole extracted tree, guaranteeing the shared objects (libcap.so.2) are
+# present for soname resolution regardless of the exact versioned filename.
+[[steps]]
+action = "homebrew"
+formula = "libcap"
+when = { os = ["linux"], libc = ["glibc"] }
+
+[[steps]]
+action = "install_binaries"
+install_mode = "directory"
+when = { os = ["linux"], libc = ["glibc"] }
+
+# musl Linux: Alpine package
+[[steps]]
+action = "apk_install"
+packages = ["libcap-dev"]
+when = { os = ["linux"], libc = ["musl"] }


### PR DESCRIPTION
Add a recipe for **libcap**, the POSIX 1003.1e capabilities library.

It installs the prebuilt Homebrew bottle on glibc Linux and the Alpine package on musl, and is Linux-only. The recipe uses `install_binaries` directory mode with no `outputs`, installing the whole extracted tree so the versioned soname (`libcap.so.2.NN`) and its `libcap.so.2` symlink stay intact for soname resolution without hardcoding a version-specific filename.

This lands as its own recipe so tools that link `libcap.so.2` can declare it as a runtime dependency. The first consumer is the bubblewrap recipe in #2432, which depends on this merging first.

---

## Testing

- `tsuku validate --strict --check-libc-coverage recipes/l/libcap.toml` passes.
- Installed via a locally built `tsuku-test`: extracts the bottle and provides `lib/libcap.so.2`; a downstream tool (bubblewrap) RPATH-links against it successfully.