### PR TITLE
fix(recipes): expose socat binary on PATH

### DIFF
--- a/recipes/s/socat.toml
+++ b/recipes/s/socat.toml
@@ -8,6 +8,7 @@
   type = ""
   llm_validation = "skipped"
   unsupported_platforms = ["darwin/arm64", "darwin/amd64"]
+  supported_libc = ["glibc"]
   runtime_dependencies = ["openssl"]
 
 [version]
@@ -29,8 +30,8 @@
 
 [[steps]]
   action = "install_binaries"
-  binaries = ["bin/filan", "bin/procan", "bin/socat-broker.sh", "bin/socat-chain.sh", "bin/socat-mux.sh", "bin/socat1"]
+  binaries = ["bin/filan", "bin/procan", "bin/socat", "bin/socat-broker.sh", "bin/socat-chain.sh", "bin/socat-mux.sh", "bin/socat1"]
 
 [verify]
-  command = "filan --version"
+  command = "socat -V"
   pattern = ""


### PR DESCRIPTION
Add `bin/socat` to the socat recipe's `install_binaries` list, change
`[verify]` from `filan --version` to `socat -V`, and constrain the recipe to
`supported_libc = ["glibc"]`. The recipe previously installed the primary
program only under its versioned name `socat1`, so the canonical `socat`
command did not resolve on PATH after install. tsuku's `install_binaries`
copies files by following symlinks, so listing `bin/socat` (a `socat -> socat1`
symlink in the bottle) materializes a real, standalone `socat` executable
alongside `socat1`. `socat1` and every helper stay in the list, so nothing that
already worked regresses.

---

## What This Fixes

Installing socat left `socat1` on PATH but not `socat`, so anything invoking
the tool by its canonical name (`socat ...`, `exec.LookPath("socat")`) failed
to find it. The `[verify]` step ran `filan --version`, a different binary from
the same bottle, so CI never exercised the `socat` name and the gap went
unnoticed.

Root cause: the `install_binaries` list was seeded from an automated bottle
scan that kept the real file (`socat1`) and dropped the `socat` symlink name.

## Bottle Contents

Grounded in the actual artifact rather than assumption. Walking the real
Homebrew socat 1.8.1.3 `x86_64_linux` bottle, `bin/` contains:

```
filan            regular file
procan           regular file
socat            symlink -> socat1
socat-broker.sh  regular file
socat-chain.sh   regular file
socat-mux.sh     regular file
socat1           regular file
```

Upstream socat 1.8.x builds `socat1` and installs a `socat -> socat1` symlink;
the bottle preserves both. The extract step keeps the in-tree relative symlink
and the bottle relocation patches `socat1` before `install_binaries` runs, so
the copied `socat` inherits the correct RPATH/interpreter.

## Why Edit the Existing Recipe

The bottle already provides socat, and the fix is purely additive, so a new
recipe would only add duplication. Adding `bin/socat` to the shared recipe
regresses no existing consumer.

## Why Constrain to glibc

The stronger `socat -V` verify runs the socat binary itself, which surfaced a
pre-existing limitation: the Homebrew bottle is a glibc build, and its ELF
interpreter (`/lib64/ld-linux-x86-64.so.2`) does not exist on musl, so the
binaries cannot execute on Alpine. This is not a regression from this change --
the previous `filan` verify fails identically on Alpine (`filan: not found`,
exit 127); it was simply never exercised there. `supported_libc = ["glibc"]`
records the real constraint and makes the recipe-test harness skip the
Alpine/musl leg.

## Verification

Reproduced with tsuku's sandbox (`tsuku install --sandbox`) and a direct
install on Linux glibc:

- Direct glibc install succeeds; `socat` lands in the on-PATH tools directory,
  resolves via `command -v socat`, and `socat -V` prints `socat version 1.8.1.3`
  and exits 0. The installed `socat` is a real ELF executable, byte-identical to
  `socat1`.
- Sandbox install passes verify on debian, rhel, arch, and suse.
- On Alpine, both the new and the previous recipe fail verify with exit 127
  (glibc interpreter absent); `supported_libc = ["glibc"]` now skips that leg.

`tsuku validate recipes/s/socat.toml --strict` passes; `go build ./...` and
`go test ./...` pass. Linux glibc platform scoping and the `openssl` runtime
dependency are otherwise unchanged.
