### PR TITLE
fix(updates): stop background update checks from silently failing

### DIFF
--- a/internal/notices/notices.go
+++ b/internal/notices/notices.go
@@ -15,11 +15,16 @@ import (
 // the Kind field was introduced. KindAutoApplyResult identifies notices written
 // by the background auto-apply subprocess. KindVersionFallback and
 // KindShellInitChange are single-view notices removed after display.
+// KindCheckFailure identifies a persistent version-check failure (as opposed
+// to an install/update *apply* failure): the background checker was unable to
+// resolve a tool's latest version for several checks in a row, so the tool
+// never became a candidate for auto-apply at all.
 const (
 	KindUpdateResult    = ""
 	KindAutoApplyResult = "auto_apply_result"
 	KindVersionFallback = "version_fallback"
 	KindShellInitChange = "shell_init_change"
+	KindCheckFailure    = "check_failure"
 )
 
 // Notice represents a failed auto-update for a single tool.

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -192,6 +192,34 @@ func TestKnownKeysFieldsPopulated(t *testing.T) {
 	}
 }
 
+func TestGetResolvesGitHubTokenFromGHTokenFallback(t *testing.T) {
+	// GITHUB_TOKEN unset, only the GH_TOKEN alias (the gh CLI / GitHub
+	// Actions convention) is set.
+	t.Setenv("GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "gh-cli-token")
+
+	val, err := Get("github_token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "gh-cli-token" {
+		t.Errorf("expected 'gh-cli-token', got %q", val)
+	}
+}
+
+func TestGetPrefersGitHubTokenOverGHToken(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "primary")
+	t.Setenv("GH_TOKEN", "fallback")
+
+	val, err := Get("github_token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "primary" {
+		t.Errorf("expected GITHUB_TOKEN to take priority ('primary'), got %q", val)
+	}
+}
+
 func TestGoogleKeyHasMultipleEnvVars(t *testing.T) {
 	keys := KnownKeys()
 

--- a/internal/secrets/specs.go
+++ b/internal/secrets/specs.go
@@ -21,7 +21,7 @@ var knownKeys = map[string]KeySpec{
 		Desc:    "Google API key for Gemini",
 	},
 	"github_token": {
-		EnvVars: []string{"GITHUB_TOKEN"},
+		EnvVars: []string{"GITHUB_TOKEN", "GH_TOKEN"},
 		Desc:    "GitHub personal access token",
 	},
 	"tavily_api_key": {

--- a/internal/updates/cache.go
+++ b/internal/updates/cache.go
@@ -47,6 +47,14 @@ type UpdateCheckEntry struct {
 
 	// Error records a non-empty string if the check failed for this tool.
 	Error string `json:"error,omitempty"`
+
+	// ConsecutiveCheckFailures counts how many background checks in a row have
+	// failed for this tool (reset to 0 on a successful check). Distinct from
+	// notices.Notice.ConsecutiveFailures, which tracks failed *apply* attempts:
+	// this counts failed *checks* -- a tool whose check keeps erroring (e.g. a
+	// GitHub rate limit) never reaches the apply stage at all, so without this
+	// counter the failure has no persisted trail. See RunUpdateCheck.
+	ConsecutiveCheckFailures int `json:"consecutive_check_failures,omitempty"`
 }
 
 // ReadEntry reads a single tool's update check cache entry.

--- a/internal/updates/checker.go
+++ b/internal/updates/checker.go
@@ -10,10 +10,18 @@ import (
 	"github.com/tsukumogami/tsuku/internal/install"
 	"github.com/tsukumogami/tsuku/internal/installevents"
 	"github.com/tsukumogami/tsuku/internal/log"
+	"github.com/tsukumogami/tsuku/internal/notices"
 	"github.com/tsukumogami/tsuku/internal/recipe"
 	"github.com/tsukumogami/tsuku/internal/userconfig"
 	"github.com/tsukumogami/tsuku/internal/version"
 )
+
+// checkFailureNoticeThreshold is how many consecutive failed checks a tool
+// must accumulate before a KindCheckFailure notice surfaces to the user.
+// A single failed check is often a transient blip (a rate limit, a flaky
+// network); only a run of failures indicates the tool has silently stopped
+// being considered for auto-update.
+const checkFailureNoticeThreshold = 3
 
 // RecipeLoader loads recipes for tools. This interface allows testing without
 // depending on the global loader in cmd/tsuku.
@@ -66,11 +74,22 @@ func RunUpdateCheck(ctx context.Context, cfg *config.Config, userCfg *userconfig
 
 	res := version.New()
 	factory := version.NewProviderFactory()
+	noticesDir := notices.NoticesDir(cfg.HomeDir)
 
 	for _, tool := range tools {
 		// Check context deadline
 		if ctx.Err() != nil {
 			break
+		}
+
+		// mgr.List() returns one row per retained version directory, not one
+		// per tool: a tool with several old versions still on disk (pending
+		// garbage collection) would otherwise be checked -- and would burn a
+		// version-resolution network call -- once per stale directory. Only
+		// the active version's result can ever become an auto-apply
+		// candidate, so skip the rest.
+		if !tool.IsActive {
+			continue
 		}
 
 		var requested string
@@ -86,6 +105,8 @@ func RunUpdateCheck(ctx context.Context, cfg *config.Config, userCfg *userconfig
 		}
 
 		entry := checkTool(ctx, tool, requested, state, cfg, loader, res, factory)
+		recordConsecutiveCheckFailures(cacheDir, noticesDir, entry)
+
 		// Write result (best effort, matching version cache pattern)
 		_ = WriteEntry(cacheDir, entry)
 	}
@@ -98,6 +119,42 @@ func RunUpdateCheck(ctx context.Context, cfg *config.Config, userCfg *userconfig
 	// Touch sentinel after all tools processed
 	_ = TouchSentinel(cacheDir)
 	return nil
+}
+
+// recordConsecutiveCheckFailures updates entry.ConsecutiveCheckFailures from
+// the prior cached entry for the same tool and, once a run of failures
+// crosses checkFailureNoticeThreshold, writes a KindCheckFailure notice so
+// the failure is no longer invisible: a checkTool error alone never reaches
+// notices (IsPendingEntry excludes it from auto-apply, and nothing else
+// looks at the check-cache directory), so without this a tool can silently
+// stop being considered for auto-update indefinitely. A check that recovers
+// clears any standing KindCheckFailure notice -- but only one of our own;
+// an unrelated pending notice (e.g. an apply failure awaiting review) is
+// left alone.
+func recordConsecutiveCheckFailures(cacheDir, noticesDir string, entry *UpdateCheckEntry) {
+	if prior, _ := ReadEntry(cacheDir, entry.Tool); prior != nil {
+		entry.ConsecutiveCheckFailures = prior.ConsecutiveCheckFailures
+	}
+
+	if entry.Error == "" {
+		entry.ConsecutiveCheckFailures = 0
+		if n, _ := notices.ReadNotice(noticesDir, entry.Tool); n != nil && n.Kind == notices.KindCheckFailure {
+			_ = notices.RemoveNotice(noticesDir, entry.Tool)
+		}
+		return
+	}
+
+	entry.ConsecutiveCheckFailures++
+	if entry.ConsecutiveCheckFailures >= checkFailureNoticeThreshold {
+		_ = notices.WriteNotice(noticesDir, &notices.Notice{
+			Tool:                entry.Tool,
+			Error:               entry.Error,
+			Kind:                notices.KindCheckFailure,
+			ConsecutiveFailures: entry.ConsecutiveCheckFailures,
+			Timestamp:           entry.CheckedAt,
+			Shown:               false,
+		})
+	}
 }
 
 // checkTool checks a single tool and returns an UpdateCheckEntry.
@@ -147,7 +204,15 @@ func checkTool(
 		entry.LatestWithinPin = withinPin.Version
 	}
 
-	// Resolve latest overall
+	// Resolve latest overall. When there is no pin (or the pin is "latest"),
+	// ResolveWithinBoundary above already called provider.ResolveLatest and
+	// withinPin *is* the overall latest -- reuse it instead of making an
+	// identical second network request for the same answer.
+	if requested == "" || requested == "latest" {
+		entry.LatestOverall = withinPin.Version
+		return entry
+	}
+
 	overall, err := provider.ResolveLatest(ctx)
 	if err != nil {
 		// Non-fatal: we have within-pin, just skip overall

--- a/internal/updates/checker_test.go
+++ b/internal/updates/checker_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/tsukumogami/tsuku/internal/config"
 	"github.com/tsukumogami/tsuku/internal/install"
+	"github.com/tsukumogami/tsuku/internal/notices"
 	"github.com/tsukumogami/tsuku/internal/recipe"
 	"github.com/tsukumogami/tsuku/internal/userconfig"
 	"github.com/tsukumogami/tsuku/internal/version"
@@ -19,9 +20,18 @@ import (
 type testRecipeLoader struct {
 	recipes map[string]*recipe.Recipe
 	err     error
+
+	// calls counts LoadRecipe invocations per tool name, for asserting how
+	// many times a tool was actually checked.
+	calls map[string]int
 }
 
 func (l *testRecipeLoader) LoadRecipe(_ context.Context, toolName string, _ *install.State, _ *config.Config) (*recipe.Recipe, error) {
+	if l.calls == nil {
+		l.calls = make(map[string]int)
+	}
+	l.calls[toolName]++
+
 	if l.err != nil {
 		return nil, l.err
 	}
@@ -164,5 +174,184 @@ func TestRunUpdateCheckWritesEntries(t *testing.T) {
 	// Cache should no longer be stale
 	if IsCheckStale(cacheDir, 24*time.Hour) {
 		t.Error("cache should be fresh after RunUpdateCheck")
+	}
+}
+
+// TestRunUpdateCheckSkipsInactiveVersionDirectories guards against a
+// regression to the mgr.List()-returns-one-row-per-version-directory bug:
+// a tool with several old versions still on disk (pending garbage
+// collection) must only be checked once, for its active version -- not once
+// per retained directory. Each check makes real version-resolution network
+// calls, so redundant checks needlessly multiply GitHub API usage and can
+// starve other tools of their share of an unauthenticated rate limit.
+func TestRunUpdateCheckSkipsInactiveVersionDirectories(t *testing.T) {
+	dir := t.TempDir()
+	toolsDir := filepath.Join(dir, "tools")
+	cfg := &config.Config{HomeDir: dir, ToolsDir: toolsDir}
+
+	for _, v := range []string{"1.0.0", "2.0.0"} {
+		if err := os.MkdirAll(cfg.ToolDir("multi", v), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stateJSON := `{"installed":{"multi":{"active_version":"2.0.0","versions":{
+		"1.0.0":{"requested":""},
+		"2.0.0":{"requested":""}
+	}}}}`
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte(stateJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	userCfg := userconfig.DefaultConfig()
+	loader := &testRecipeLoader{recipes: map[string]*recipe.Recipe{}}
+
+	if err := RunUpdateCheck(context.Background(), cfg, userCfg, loader, nil); err != nil {
+		t.Fatalf("RunUpdateCheck: %v", err)
+	}
+
+	if got := loader.calls["multi"]; got != 1 {
+		t.Errorf("LoadRecipe called %d times for tool %q, want 1 (only the active version should be checked)", got, "multi")
+	}
+}
+
+// TestRunUpdateCheckSurfacesPersistentCheckFailure guards the observability
+// gap that let koto silently stop being considered for auto-update: a check
+// error alone (e.g. a rate limit) is invisible -- IsPendingEntry excludes it
+// from auto-apply and nothing else looks at the check-cache directory. A run
+// of consecutive failures must surface via the standard notices mechanism so
+// a stuck tool doesn't go unnoticed indefinitely.
+func TestRunUpdateCheckSurfacesPersistentCheckFailure(t *testing.T) {
+	dir := t.TempDir()
+	toolsDir := filepath.Join(dir, "tools")
+	cfg := &config.Config{HomeDir: dir, ToolsDir: toolsDir}
+
+	if err := os.MkdirAll(cfg.ToolDir("flaky", "1.0.0"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	stateJSON := `{"installed":{"flaky":{"active_version":"1.0.0","versions":{"1.0.0":{"requested":""}}}}}`
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte(stateJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	userCfg := userconfig.DefaultConfig()
+	noticesDir := notices.NoticesDir(cfg.HomeDir)
+	cacheDir := CacheDir(cfg.HomeDir)
+
+	// Recipe load always fails: simulates a check that can never resolve
+	// (e.g. GitHub rate limit) rather than a one-off blip. This needs no
+	// network access -- checkTool returns before creating a version provider.
+	failingLoader := &testRecipeLoader{err: fmt.Errorf("resolve within pin: rate limit exceeded")}
+
+	for i := 1; i <= checkFailureNoticeThreshold; i++ {
+		_ = os.Remove(filepath.Join(cacheDir, SentinelFile))
+		if err := RunUpdateCheck(context.Background(), cfg, userCfg, failingLoader, nil); err != nil {
+			t.Fatalf("RunUpdateCheck (attempt %d): %v", i, err)
+		}
+
+		n, err := notices.ReadNotice(noticesDir, "flaky")
+		if err != nil {
+			t.Fatalf("ReadNotice (attempt %d): %v", i, err)
+		}
+		if i < checkFailureNoticeThreshold {
+			if n != nil {
+				t.Errorf("attempt %d: expected no notice before threshold, got %+v", i, n)
+			}
+			continue
+		}
+		if n == nil {
+			t.Fatalf("attempt %d: expected a KindCheckFailure notice at threshold, got none", i)
+		}
+		if n.Kind != notices.KindCheckFailure {
+			t.Errorf("Kind = %q, want %q", n.Kind, notices.KindCheckFailure)
+		}
+		if n.ConsecutiveFailures != checkFailureNoticeThreshold {
+			t.Errorf("ConsecutiveFailures = %d, want %d", n.ConsecutiveFailures, checkFailureNoticeThreshold)
+		}
+	}
+}
+
+// TestRecordConsecutiveCheckFailures exercises the escalate/recover state
+// machine directly with synthetic entries, since driving a real successful
+// check through RunUpdateCheck requires live version-resolution network
+// access that unit tests can't rely on.
+func TestRecordConsecutiveCheckFailures(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := CacheDir(dir)
+	noticesDir := notices.NoticesDir(dir)
+
+	// Fewer failures than the threshold: no notice yet, but the count persists.
+	for i := 1; i < checkFailureNoticeThreshold; i++ {
+		entry := &UpdateCheckEntry{Tool: "flaky", Error: "boom", CheckedAt: time.Now()}
+		recordConsecutiveCheckFailures(cacheDir, noticesDir, entry)
+		if entry.ConsecutiveCheckFailures != i {
+			t.Fatalf("attempt %d: ConsecutiveCheckFailures = %d, want %d", i, entry.ConsecutiveCheckFailures, i)
+		}
+		if n, _ := notices.ReadNotice(noticesDir, "flaky"); n != nil {
+			t.Fatalf("attempt %d: expected no notice below threshold, got %+v", i, n)
+		}
+		if err := WriteEntry(cacheDir, entry); err != nil {
+			t.Fatalf("WriteEntry: %v", err)
+		}
+	}
+
+	// The threshold-th failure escalates to a notice.
+	entry := &UpdateCheckEntry{Tool: "flaky", Error: "boom", CheckedAt: time.Now()}
+	recordConsecutiveCheckFailures(cacheDir, noticesDir, entry)
+	if entry.ConsecutiveCheckFailures != checkFailureNoticeThreshold {
+		t.Fatalf("ConsecutiveCheckFailures = %d, want %d", entry.ConsecutiveCheckFailures, checkFailureNoticeThreshold)
+	}
+	n, err := notices.ReadNotice(noticesDir, "flaky")
+	if err != nil {
+		t.Fatalf("ReadNotice: %v", err)
+	}
+	if n == nil || n.Kind != notices.KindCheckFailure {
+		t.Fatalf("expected a KindCheckFailure notice at threshold, got %+v", n)
+	}
+	if err := WriteEntry(cacheDir, entry); err != nil {
+		t.Fatalf("WriteEntry: %v", err)
+	}
+
+	// A successful check clears the standing notice and resets the counter.
+	recovered := &UpdateCheckEntry{Tool: "flaky", Error: "", CheckedAt: time.Now()}
+	recordConsecutiveCheckFailures(cacheDir, noticesDir, recovered)
+	if recovered.ConsecutiveCheckFailures != 0 {
+		t.Errorf("ConsecutiveCheckFailures = %d, want 0 after recovery", recovered.ConsecutiveCheckFailures)
+	}
+	if n, err := notices.ReadNotice(noticesDir, "flaky"); err != nil {
+		t.Fatalf("ReadNotice: %v", err)
+	} else if n != nil {
+		t.Errorf("expected the check-failure notice to be cleared after a successful check, got %+v", n)
+	}
+}
+
+// TestRecordConsecutiveCheckFailuresPreservesUnrelatedNotice guards against
+// an over-eager clear: recovering from a check failure must not delete a
+// different, still-pending notice for the same tool (e.g. an apply failure
+// awaiting the user's review via `tsuku notices`).
+func TestRecordConsecutiveCheckFailuresPreservesUnrelatedNotice(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := CacheDir(dir)
+	noticesDir := notices.NoticesDir(dir)
+
+	applyFailure := &notices.Notice{
+		Tool:  "flaky",
+		Error: "install failed: checksum mismatch",
+		Kind:  notices.KindUpdateResult,
+		Shown: false,
+	}
+	if err := notices.WriteNotice(noticesDir, applyFailure); err != nil {
+		t.Fatalf("WriteNotice: %v", err)
+	}
+
+	entry := &UpdateCheckEntry{Tool: "flaky", Error: "", CheckedAt: time.Now()}
+	recordConsecutiveCheckFailures(cacheDir, noticesDir, entry)
+
+	n, err := notices.ReadNotice(noticesDir, "flaky")
+	if err != nil {
+		t.Fatalf("ReadNotice: %v", err)
+	}
+	if n == nil || n.Kind != notices.KindUpdateResult || n.Error != applyFailure.Error {
+		t.Errorf("expected the unrelated apply-failure notice to survive, got %+v", n)
 	}
 }

--- a/internal/updates/notify.go
+++ b/internal/updates/notify.go
@@ -100,6 +100,10 @@ func renderUnshownNotices(noticesDir string) {
 			for _, msg := range n.Messages {
 				fmt.Fprintf(os.Stderr, "  %s\n", msg)
 			}
+		case n.Kind == notices.KindCheckFailure:
+			fmt.Fprintf(os.Stderr, "\nWarning: update checks for %s have failed %d times in a row: %s\n",
+				n.Tool, n.ConsecutiveFailures, n.Error)
+			fmt.Fprintf(os.Stderr, "  %s is not being considered for auto-update until a check succeeds. Run 'tsuku outdated' to retry.\n", n.Tool)
 		case strings.HasPrefix(n.Tool, notices.LibraryNoticePrefix):
 			renderLibraryNotice(n)
 		case n.Tool == SelfToolName:

--- a/internal/version/provider_tap_test.go
+++ b/internal/version/provider_tap_test.go
@@ -500,6 +500,7 @@ func TestTapProvider_GitHubTokenAuth(t *testing.T) {
 	// Test without token
 	t.Run("without token", func(t *testing.T) {
 		t.Setenv("GITHUB_TOKEN", "")
+		t.Setenv("GH_TOKEN", "")
 
 		receivedAuth = ""
 		_, err := provider.ResolveLatest(context.Background())


### PR DESCRIPTION
Add GH_TOKEN as a fallback credential for GitHub API requests in the version resolver, since only GITHUB_TOKEN was previously recognized and unauthenticated GitHub requests are capped at 60 per hour. Change the background update checker (`internal/updates`) to check each tool's active version once instead of once per retained version directory still on disk, and to reuse the already-resolved latest version instead of issuing an identical second request for unpinned tools. Track consecutive check failures per tool and, once a run of failures crosses a small threshold, write a notice through the existing notices system so a tool whose checks keep failing is no longer invisible; a later successful check clears the notice again.

---

## What This Fixes

The background update checker could silently stop updating a tool with no visible signal. When resolving a tool's latest version failed (for example due to GitHub rate limiting), the error was written to a per-tool cache file that nothing else ever read: install/update *apply* failures already surface to the user through the notices system, but *check* failures did not. Three things combined to make this easy to hit and impossible to notice:

1. The version resolver only recognized `GITHUB_TOKEN` for GitHub API auth, not the equally common `GH_TOKEN` convention used by the GitHub CLI and GitHub Actions — so an environment with only `GH_TOKEN` set ran fully unauthenticated against GitHub's 60-requests/hour limit.
2. The checker iterated one row per retained version directory rather than one per tool, and made two separate requests for the same "what's the latest version" answer when a tool had no pin — both needlessly burning through that shared budget.
3. A check failure was never escalated anywhere. A tool could fail every check for weeks and the only trace was a cache file that got silently overwritten on each subsequent (also failing) attempt.

This surfaced concretely with `koto` (github.com/tsukumogami/koto): it stayed pinned well behind its latest release for weeks with nothing indicating a problem.

## Changes

- `internal/secrets/specs.go`: accept `GH_TOKEN` as a fallback alias for the `github_token` secret, checked after `GITHUB_TOKEN`
- `internal/updates/checker.go`: only check a tool's active version, not every retained version directory; reuse the within-pin resolution instead of a redundant `ResolveLatest` call for unpinned tools; track consecutive check failures and escalate to a notice at threshold
- `internal/notices/notices.go`: add a `KindCheckFailure` notice kind
- `internal/updates/notify.go`: render `KindCheckFailure` notices to the user

## Test Plan

- `go test ./...`, `go vet ./...`, `gofmt -l .`
- Added/updated unit tests covering the `GH_TOKEN` fallback and its priority relative to `GITHUB_TOKEN`, active-version-only checking, and the escalate-to-notice / clear-on-recovery behavior (including that recovery doesn't clobber an unrelated pending notice for the same tool)
- Verified against `koto`: a build without this fix reproduces `GitHub API rate limit exceeded ... 60/60 requests used (unauthenticated)` when checking koto's version in an environment with only `GH_TOKEN` set; after upgrading koto with the fix applied, koto's own `scripts/verify-native-workflows.sh` passes end to end
