### PR TITLE
feat(recipes): add shirabe binary recipe

### DIFF
--- a/recipes/s/shirabe.toml
+++ b/recipes/s/shirabe.toml
@@ -3,6 +3,8 @@ name = "shirabe"
 description = "Doc-format and lifecycle validation CLI for tsukumogami-style artifact repos"
 homepage = "https://github.com/tsukumogami/shirabe"
 version_format = "semver"
+supported_libc = ["glibc"]
+unsupported_reason = "Upstream publishes a glibc-dynamically-linked binary only; no musl build."
 
 [version]
 source = "github_releases"

--- a/recipes/s/shirabe.toml
+++ b/recipes/s/shirabe.toml
@@ -1,0 +1,46 @@
+[metadata]
+name = "shirabe"
+description = "Doc-format and lifecycle validation CLI for tsukumogami-style artifact repos"
+homepage = "https://github.com/tsukumogami/shirabe"
+version_format = "semver"
+
+[version]
+source = "github_releases"
+github_repo = "tsukumogami/shirabe"
+tag_prefix = "v"
+
+[[steps]]
+action = "download"
+when = { os = ["linux"] }
+url = "https://github.com/tsukumogami/shirabe/releases/download/v{version}/shirabe-{os}-{arch}"
+checksum_url = "https://github.com/tsukumogami/shirabe/releases/download/v{version}/checksums.txt"
+
+[[steps]]
+action = "chmod"
+when = { os = ["linux"] }
+files = ["shirabe-{os}-{arch}"]
+
+[[steps]]
+action = "install_binaries"
+when = { os = ["linux"] }
+outputs = [{ src = "shirabe-{os}-{arch}", dest = "bin/shirabe" }]
+
+[[steps]]
+action = "download"
+when = { os = ["darwin"] }
+url = "https://github.com/tsukumogami/shirabe/releases/download/v{version}/shirabe-{os}-{arch}"
+checksum_url = "https://github.com/tsukumogami/shirabe/releases/download/v{version}/checksums.txt"
+
+[[steps]]
+action = "chmod"
+when = { os = ["darwin"] }
+files = ["shirabe-{os}-{arch}"]
+
+[[steps]]
+action = "install_binaries"
+when = { os = ["darwin"] }
+outputs = [{ src = "shirabe-{os}-{arch}", dest = "bin/shirabe" }]
+
+[verify]
+command = "shirabe --version"
+pattern = "{version}"


### PR DESCRIPTION
Adds recipes/s/shirabe.toml, distributing the shirabe CLI (tsukumogami/shirabe) through the tsuku registry. The recipe downloads the platform binary from GitHub releases (linux and darwin, amd64 and arm64), verifies it against the release's shared checksums.txt, and installs it to bin/shirabe. Version resolution uses the github_releases provider with tag_prefix "v", tested against v0.15.0.

---

## Test plan

- `tsuku validate recipes/s/shirabe.toml` and `tsuku validate --strict recipes/s/shirabe.toml` both pass.
- `tsuku eval --recipe recipes/s/shirabe.toml` resolves the correct download URL and a distinct sha256 checksum for all four linux/darwin x amd64/arm64 combinations against the shared checksums.txt.
- Ran a real local install with an isolated `TSUKU_HOME`: `tsuku install --recipe recipes/s/shirabe.toml --force` succeeded, the built-in post-install verify step passed, and the installed binary reports `shirabe v0.15.0`.
- Ran `tsuku install --sandbox` against all five Linux test families (debian, rhel, arch, suse, alpine). debian, rhel, and arch pass. alpine fails because the binary is dynamically linked against glibc with no musl build, so the recipe now declares `supported_libc = ["glibc"]`, which the Test Recipe workflow uses to skip musl testing. suse (openSUSE Leap 15.6) fails at verify time with `GLIBC_2.39' not found` — the release binary requires a newer glibc than that image ships. There's no recipe-schema mechanism to express a minimum glibc version or exclude one distro family while keeping others, and rebuilding the upstream binary is out of scope for this change, so that failure is expected to persist in the Test Recipe workflow (not one of this PR's required checks).

## Implementation notes

- Uses `download` with `checksum_url`, not `github_file`, since `github_file`'s `Decompose()` only forwards checksums for `github_archive`/`download_archive`.
- No `extract` step: the release assets are bare per-platform binaries, no archive.
- No Windows target: upstream doesn't publish one.
