### PR TITLE
feat(recipes): add playwright recipe

### DIFF
--- a/recipes/p/playwright.toml
+++ b/recipes/p/playwright.toml
@@ -1,0 +1,70 @@
+[metadata]
+name = "playwright"
+description = "Browser automation CLI for Chromium, Firefox, and WebKit"
+homepage = "https://playwright.dev/python/"
+version_format = "semver"
+curated = true
+supported_libc = ["glibc"]
+unsupported_reason = "Playwright publishes manylinux and macOS wheels but no musllinux wheel, and upstream does not support Alpine"
+
+# This recipe installs the Python distribution into a pipx-isolated venv, which
+# puts the `playwright` CLI on PATH along with the Node driver bundled in the
+# wheel. It deliberately stops there and does not run `playwright install`:
+#
+#   - A fetched browser earns little even for CLI-only use, which is what this
+#     recipe serves. Browser builds are pinned per Playwright release, and on
+#     PyPI the pin moved on every one of the 17 minor releases between 1.40 and
+#     1.57 (chromium-1091 through chromium-1200); only the four patch releases
+#     in that range kept it. So all but a patch upgrade of this recipe would
+#     re-download, and each generation accretes several hundred MB in a cache
+#     `tsuku remove` cannot reclaim. (A project resolving Playwright from its
+#     own virtualenv would not match this build either, but that is a
+#     second-order point -- see the note on the library half below.)
+#   - Left alone, the download lands in ~/.cache/ms-playwright, outside
+#     {install_dir} where `tsuku remove playwright` cannot reverse it. Keeping
+#     it inside would mean exporting PLAYWRIGHT_BROWSERS_PATH from a shell init
+#     script, and that variable is process-wide: it would redirect browser
+#     lookup for every Playwright on the machine, including project virtualenvs
+#     on a different release, and point their `playwright install` at this
+#     tool's directory.
+#   - Playwright's browser builds need system libraries (libglib, libnss, libgbm
+#     and friends). A recipe can declare those with apt_install and friends, and
+#     the sandbox does bake them into its test images -- but on a user's machine
+#     those actions only check for the packages and fail with a sudo command to
+#     run. Declaring them would make `tsuku install playwright` sudo-gated on any
+#     minimal machine, which is the one thing tsuku promises never to require.
+#
+# Choose a browser after installing:
+#
+#   playwright install chromium   # fetches chromium, the headless shell and
+#                                 # ffmpeg: ~315 MB down, ~640 MB unpacked into
+#                                 # ~/.cache/ms-playwright, which is shared and
+#                                 # reference-counted across every Playwright on
+#                                 # the machine. Reclaim with
+#                                 # `playwright uninstall`.
+#   channel = "chrome"            # drive an installed Chrome/Edge, no download
+#
+# Note for Python projects: this recipe gives you the CLI, not an importable
+# module. `from playwright.sync_api import sync_playwright` still requires
+# `pip install playwright` inside the project's own virtualenv, because pipx
+# isolates the venv it creates here.
+[[steps]]
+action = "pipx_install"
+package = "playwright"
+executables = ["playwright"]
+
+# `--dry-run` exercises more than `playwright --version` does: it boots the
+# bundled Node driver and resolves the browser registry for the running
+# platform, printing the exact build and download URL a browser install would
+# fetch. It needs no network, so `tsuku verify playwright` works offline.
+#
+# It stops short of launching a browser. That is a consequence of shipping no
+# browser, not a limit of the test environment -- the sandbox could be given the
+# libraries. A launching verify would also run on user machines via
+# `tsuku verify`, where it would report failure for a perfectly healthy install
+# that simply has no browser yet.
+[verify]
+command = "playwright install --dry-run chromium"
+mode = "output"
+patterns = ["chromium", "Install location:", "Download url:"]
+reason = "Version mode was available -- `playwright --version` prints the release -- but this command is the stronger check because it boots the bundled Node driver and resolves the browser registry, and its output carries browser build numbers rather than the release version"


### PR DESCRIPTION
Add `recipes/p/playwright.toml`, a `pipx_install` recipe for the Playwright Python distribution. It installs the `playwright` CLI into a pipx-isolated venv along with the Node driver bundled in the wheel, following the same shape as poetry, aider, and black.

The recipe stops at the package and does not run `playwright install`. Browser builds are pinned per Playwright release, and on PyPI the pin moved on every one of the 17 minor releases between 1.40 and 1.57 (chromium-1091 through chromium-1200); only the four patch releases in that range kept it. So a browser fetched at this recipe's version is near-certain to be the wrong build for a project resolving Playwright from its own virtualenv, and all but a patch upgrade would re-download. The download is also large: `playwright install chromium` fetches chromium, the headless shell and ffmpeg — 316 MB on the wire, about 640 MB unpacked. And while a recipe can declare chromium's system libraries with `apt_install` and friends, on a user's machine those actions only check for the packages and fail with a sudo command to run, so declaring them would make `tsuku install playwright` sudo-gated on any minimal machine — the one thing tsuku promises never to require. Users pick a browser afterwards with `playwright install chromium` or by driving an existing Chrome through `channel="chrome"`.

Verification runs `playwright install --dry-run chromium` in output mode. That boots the bundled Node driver and resolves the browser registry for the running platform, which `playwright --version` does not do, and it needs no network so `tsuku verify` works offline. It stops short of launching a browser because the recipe ships no browser, not because CI couldn't host one.

`supported_libc = ["glibc"]` because Playwright ships manylinux and macOS wheels but no musllinux wheel, and upstream does not support Alpine.

---

## Recipe Changes Checklist

- [x] Tested on glibc (Debian/Ubuntu/Fedora)
- [x] Tested on musl (Alpine) OR added `supported_libc = ["glibc"]` with `unsupported_reason`
- [x] Library dependencies have musl paths (check with `tsuku validate --check-libc-coverage`)

## Why no browser download

Playwright is two things: a Python distribution, and a set of browser binaries it drives. A package-only install leaves you with a CLI that errors on first launch because no browser is present, so this needs a justification rather than being the lazy default.

Three options were on the table: run `playwright install chromium` as an install step, stay package-only and document the paths to a browser, or export `PLAYWRIGHT_BROWSERS_PATH` at `{install_dir}` and download there.

The third is mechanically possible — `install_shell_init` writes into `$TSUKU_HOME/share/shell.d/`, `RebuildShellCache` concatenates those files, and `$TSUKU_HOME/env` sources the result, so exports do reach the user's shell. It fails on scope rather than mechanism. `PLAYWRIGHT_BROWSERS_PATH` is process-wide, so the export only reaches processes that source tsuku's shell init: a terminal would resolve the redirected path while an IDE test runner, a cron job, or CI on the same machine resolves the default, giving a split-brain cache where `playwright install` succeeds in one and "browser not found" appears in the other. The `{install_dir}` variant is worse still, because other projects' `playwright install` runs would land browsers inside this tool's versioned directory, and `tsuku remove` (`os.RemoveAll`, `internal/install/remove.go:365`) would delete builds those projects still reference. Playwright's browser cache is reference-counted — `~/.cache/ms-playwright/.links/` holds one file per registered installation, and `playwright uninstall` garbage-collects only unreferenced builds — and `delete_dir` cannot participate in that.

That leaves downloading to `~/.cache/ms-playwright` versus not downloading. Against downloading: the version churn above makes the artifact near-useless to any consumer on a different release while costing 316 MB on all but a patch upgrade; it accretes several hundred MB per generation outside `{install_dir}` that `tsuku remove playwright` cannot reclaim; and no member of its comparison class pre-fetches what it manages — nvm, pyenv, rbenv, rustup, asdf, uv, mise, fnm, pipx, poetry and ghcup all install the manager and let the user pull payloads on demand.

For completeness, the one real cost of not downloading: on a machine that already has chromium's system libraries, `tsuku install playwright` alone does not give you a runnable browser. That is a genuine ergonomic loss, accepted because the alternative is worse on every other axis.

## What the verify block proves, and what it doesn't

`playwright install --dry-run chromium` runs the bundled Node driver end to end and makes it resolve the browser registry for the running platform, printing the concrete build and download URL:

```
Chrome for Testing 151.0.7922.34 (playwright chromium v1234)
  Install location:    ~/.cache/ms-playwright/chromium-1234
  Download url:        https://cdn.playwright.dev/builds/cft/151.0.7922.34/linux64/chrome-linux64.zip
```

That catches the failure modes that actually happen with this package: a wheel that doesn't match the platform, a driver that won't boot, a browser registry with no build for this architecture. It needs no network — confirmed by running it with all egress pointed at a dead proxy — so `tsuku verify playwright` works offline months later.

It does not prove a browser launches, and the honest reason is that the recipe ships no browser. CI is not the obstacle: `DeriveContainerSpec` (`internal/sandbox/container_spec.go:71`) bakes recipe-declared system packages into the sandbox image, tmux, vulkan-loader and mesa-vulkan-drivers already use that path, and a headless chromium launch does succeed in the exact `debian:trixie-slim` CI base once those packages are declared. The reason not to declare them is what happens off CI: `apt_install` on a user machine only checks and then fails with `sudo apt-get install -y ...` (`internal/actions/apt_actions.go:47-74`), and `tsuku verify` runs the verify command on user machines too, so a launching verify would report failure for a perfectly healthy install that simply has no browser yet.

A full browser drive does work on a normal machine: against system Chrome at `/usr/bin/google-chrome`, `p.chromium.launch(channel="chrome", headless=True)` loads a page and reports `HeadlessChrome/151.0.0.0`. That's the path the recipe's comments point toward, and it needs no download.

## What this delivers to a Python consumer

The recipe delivers the CLI, and nothing else. `pipx_install` builds an isolated venv under `$TSUKU_HOME/tools/playwright-<version>/venvs/playwright/` and symlinks one executable onto `PATH`. It does not and cannot put an importable `playwright` module into another project's virtualenv.

So a project doing `from playwright.sync_api import sync_playwright` still needs `pip install playwright` (or its own extra) inside its own virtualenv. That is scope disclosure rather than a gap: tsuku's self-contained promise is about installing tools without sudo or system dependencies, and the Python doctrine here is an isolated venv per CLI application. What the entry buys is the CLI for `playwright install`, `playwright codegen` and `playwright open`, pinned and reproducible like any other tsuku tool, without a global `pip install --user`.

## Testing

- `tsuku validate --strict` and `tsuku validate --check-libc-coverage` — clean.
- `tsuku install --recipe` against an isolated `TSUKU_HOME` (resolves 1.62.0 against bundled python-standalone), then `tsuku verify playwright` — passes all five steps.
- `tsuku install --sandbox --target-family {debian,rhel,arch,suse}`, which is what PR CI runs — `passed: true`, `verified: true` on all four. Alpine is skipped by `supported_libc`.
- `go test -short ./...` — clean.
