### PR TITLE
fix(actions): make set_env actually export variables

### DIFF
--- a/internal/actions/action.go
+++ b/internal/actions/action.go
@@ -128,6 +128,35 @@ type NetworkValidator interface {
 	RequiresNetwork() bool
 }
 
+// PhaseDeclarer is implemented by actions that must run in a lifecycle phase
+// other than "install" when the recipe does not name one. An action declares
+// this when it needs state the install phase cannot provide -- ToolInstallDir,
+// for instance, is only populated once the tool has reached its permanent
+// directory, so an action reading it during the install phase would silently
+// see an empty path.
+//
+// A phase named by the recipe always wins. The executor resolves this through
+// the action registry at execution time, so plans stored before an action
+// started declaring a phase still route to the right one.
+type PhaseDeclarer interface {
+	DefaultPhase() string
+}
+
+// DefaultPhase returns the phase an action runs in when the recipe does not
+// name one. Actions that do not implement PhaseDeclarer run in "install".
+func DefaultPhase(name string) string {
+	action := Get(name)
+	if action == nil {
+		return "install"
+	}
+	if d, ok := action.(PhaseDeclarer); ok {
+		if phase := d.DefaultPhase(); phase != "" {
+			return phase
+		}
+	}
+	return "install"
+}
+
 // BaseAction provides default implementations for Action metadata methods.
 // Embed this in action types to inherit defaults:
 //   - IsDeterministic() returns false (safe default)

--- a/internal/actions/preflight.go
+++ b/internal/actions/preflight.go
@@ -120,6 +120,10 @@ func (v *registryValidator) RegisteredNames() []string {
 	return RegisteredNames()
 }
 
+func (v *registryValidator) DefaultPhase(name string) string {
+	return DefaultPhase(name)
+}
+
 func (v *registryValidator) ValidateAction(name string, params map[string]interface{}) *recipe.ActionValidationResult {
 	result := ValidateAction(name, params)
 	return &recipe.ActionValidationResult{

--- a/internal/actions/preflight_test.go
+++ b/internal/actions/preflight_test.go
@@ -35,8 +35,8 @@ func TestValidateAction_ActionWithPreflight(t *testing.T) {
 
 func TestValidateAction_ActionWithoutPreflight(t *testing.T) {
 	// Actions that don't implement Preflight pass validation
-	// set_env is an example that doesn't require specific params in Preflight
-	result := ValidateAction("set_env", nil)
+	// set_rpath is an example that declares no Preflight method
+	result := ValidateAction("set_rpath", nil)
 	if result.HasErrors() {
 		t.Errorf("expected no errors for action that passes Preflight validation, got: %v", result.Errors)
 	}

--- a/internal/actions/set_env.go
+++ b/internal/actions/set_env.go
@@ -20,6 +20,12 @@ var envVarNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 // `export NAME=value` syntax. fish would need `set -gx` and is not supported.
 var envShells = []string{"bash", "zsh"}
 
+// EnvFilePrefix is reserved for the shell.d files set_env writes. The shell
+// cache concatenates share/shell.d in alphabetical order, so this prefix is
+// what keeps a recipe's exports ahead of that tool's own init script. No other
+// action may claim it -- see the sort in shellenv.RebuildShellCache.
+const EnvFilePrefix = "00-env-"
+
 // SetEnvAction exports environment variables into the user's shell by writing
 // $TSUKU_HOME/share/shell.d/00-env-{tool}.{shell}, which RebuildShellCache
 // concatenates into the init cache that $TSUKU_HOME/env sources.
@@ -36,6 +42,14 @@ func (SetEnvAction) IsDeterministic() bool { return true }
 // Name returns the action name
 func (a *SetEnvAction) Name() string {
 	return "set_env"
+}
+
+// DefaultPhase puts set_env in the post-install phase when the recipe does not
+// name one. {install_dir} has to expand to ToolInstallDir, and that is only
+// populated once the tool reaches its permanent directory; during the install
+// phase it is empty.
+func (a *SetEnvAction) DefaultPhase() string {
+	return "post-install"
 }
 
 // Preflight validates parameters without side effects.
@@ -59,7 +73,10 @@ func (a *SetEnvAction) Preflight(params map[string]interface{}) *PreflightResult
 	}
 
 	for _, envVar := range envVars {
-		if err := validateEnvVar(envVar); err != nil {
+		if err := validateEnvName(envVar.Name); err != nil {
+			result.AddErrorf("set_env: %v", err)
+		}
+		if err := validateEnvValue(envVar.Name, envVar.Value); err != nil {
 			result.AddErrorf("set_env: %v", err)
 		}
 	}
@@ -72,7 +89,7 @@ func (a *SetEnvAction) Preflight(params map[string]interface{}) *PreflightResult
 // Parameters:
 //   - vars (required): List of environment variables [{name: "JAVA_HOME", value: "{install_dir}"}]
 //
-// This action runs in the post-install phase (see executor.StepPhase) so that
+// This action runs in the post-install phase (see DefaultPhase) so that
 // {install_dir} expands to the tool's final install directory rather than the
 // staging directory that is deleted once the install finishes.
 func (a *SetEnvAction) Execute(ctx *ExecutionContext, params map[string]interface{}) error {
@@ -97,19 +114,20 @@ func (a *SetEnvAction) Execute(ctx *ExecutionContext, params map[string]interfac
 	}
 
 	for _, envVar := range envVars {
-		if err := validateEnvVar(envVar); err != nil {
+		if err := validateEnvName(envVar.Name); err != nil {
 			return fmt.Errorf("set_env: %w", err)
 		}
 	}
 
 	if ctx.ToolInstallDir == "" {
-		// Reached when a step-execution path never runs the post-install phase.
-		// Today that means dependency recipes (Executor.installSingleDependency
-		// executes every step inline with no phases). Failing loudly beats
-		// writing an export that points nowhere.
-		return fmt.Errorf("set_env is not supported here: it needs the tool's final install " +
-			"directory, which is only available in the post-install phase. Recipes installed as " +
-			"a dependency of another tool cannot use set_env")
+		// Reached whenever the step runs outside the post-install phase: a
+		// recipe that overrode the phase, or a step-execution path with no
+		// phases at all (Executor.installSingleDependency runs every step of a
+		// dependency recipe inline). Failing loudly beats writing an export that
+		// points nowhere.
+		return fmt.Errorf("set_env ran outside the post-install phase, so the tool's final " +
+			"install directory is not known yet. Remove any 'phase' override from the step; " +
+			"note that a recipe installed as another tool's dependency cannot use set_env")
 	}
 
 	target, err := envTargetName(ctx)
@@ -147,17 +165,18 @@ func (a *SetEnvAction) Execute(ctx *ExecutionContext, params map[string]interfac
 	content := []byte(buf.String())
 
 	for _, shell := range envShells {
-		relPath := fmt.Sprintf("share/shell.d/%s.%s", target, shell)
 		destPath := filepath.Join(shellDDir, fmt.Sprintf("%s.%s", target, shell))
 
-		// A recipe may carry more than one set_env step. They all target the
-		// same file, so later steps append rather than truncate — otherwise the
-		// earlier steps' exports would vanish without a word.
+		// A recipe may carry more than one set_env step, and they all target the
+		// same file. Later steps append to what this install already wrote --
+		// otherwise the earlier steps' exports would vanish without a word. A
+		// file left by a previous version is not ours to keep, so the first step
+		// of each install truncates.
 		written := content
-		if idx := findCleanupAction(ctx, relPath); idx >= 0 {
+		if cleanupRecorded(ctx, target, shell) {
 			existing, err := os.ReadFile(destPath)
 			if err != nil {
-				return fmt.Errorf("set_env: failed to read %s for append: %w", destPath, err)
+				return fmt.Errorf("set_env: failed to read %s to append to: %w", destPath, err)
 			}
 			written = append(existing, content...)
 		}
@@ -167,26 +186,10 @@ func (a *SetEnvAction) Execute(ctx *ExecutionContext, params map[string]interfac
 		}
 		reporter.Status(fmt.Sprintf("   Installed environment exports: %s", destPath))
 
-		hash := contentHash(written)
-		if idx := findCleanupAction(ctx, relPath); idx >= 0 {
-			ctx.CleanupActions[idx].ContentHash = hash
-		} else {
-			recordCleanup(ctx, target, shell, hash)
-		}
+		upsertCleanup(ctx, target, shell, contentHash(written))
 	}
 
 	return nil
-}
-
-// findCleanupAction returns the index of the cleanup action recorded for
-// relPath, or -1 when this execution has not written that file yet.
-func findCleanupAction(ctx *ExecutionContext, relPath string) int {
-	for i, ca := range ctx.CleanupActions {
-		if ca.Path == relPath {
-			return i
-		}
-	}
-	return -1
 }
 
 // envTargetName builds the shell.d basename for this recipe's exports.
@@ -199,19 +202,24 @@ func envTargetName(ctx *ExecutionContext) (string, error) {
 	if name != filepath.Base(name) || name == "." || name == ".." || strings.ContainsAny(name, `/\`) {
 		return "", fmt.Errorf("recipe name %q is not a valid path segment", name)
 	}
-	return "00-env-" + name, nil
+	return EnvFilePrefix + name, nil
 }
 
-// validateEnvVar checks a variable name and its unexpanded value.
-func validateEnvVar(envVar recipe.EnvVar) error {
-	if !envVarNamePattern.MatchString(envVar.Name) {
-		return fmt.Errorf("invalid variable name %q (must match [A-Za-z_][A-Za-z0-9_]*)", envVar.Name)
+// validateEnvName rejects names that would not survive being written to an
+// `export` line verbatim.
+func validateEnvName(name string) error {
+	if !envVarNamePattern.MatchString(name) {
+		return fmt.Errorf("invalid variable name %q (must match [A-Za-z_][A-Za-z0-9_]*)", name)
 	}
-	return validateEnvValue(envVar.Name, envVar.Value)
+	return nil
 }
 
 // validateEnvValue rejects values that cannot be represented on a single
 // `export` line. Everything else is made safe by shellQuote.
+//
+// Execute checks values after {version} and the other placeholders have been
+// substituted, since that is what actually reaches the file; Preflight checks
+// the recipe's literal, which is all it has.
 func validateEnvValue(name, value string) error {
 	if strings.ContainsAny(value, "\n\r\x00") {
 		return fmt.Errorf("value for %q must not contain newlines or NUL bytes", name)

--- a/internal/actions/set_env.go
+++ b/internal/actions/set_env.go
@@ -103,8 +103,13 @@ func (a *SetEnvAction) Execute(ctx *ExecutionContext, params map[string]interfac
 	}
 
 	if ctx.ToolInstallDir == "" {
-		return fmt.Errorf("set_env requires ToolInstallDir to be set in ExecutionContext; " +
-			"the step must run in the post-install phase")
+		// Reached when a step-execution path never runs the post-install phase.
+		// Today that means dependency recipes (Executor.installSingleDependency
+		// executes every step inline with no phases). Failing loudly beats
+		// writing an export that points nowhere.
+		return fmt.Errorf("set_env is not supported here: it needs the tool's final install " +
+			"directory, which is only available in the post-install phase. Recipes installed as " +
+			"a dependency of another tool cannot use set_env")
 	}
 
 	target, err := envTargetName(ctx)
@@ -142,15 +147,46 @@ func (a *SetEnvAction) Execute(ctx *ExecutionContext, params map[string]interfac
 	content := []byte(buf.String())
 
 	for _, shell := range envShells {
+		relPath := fmt.Sprintf("share/shell.d/%s.%s", target, shell)
 		destPath := filepath.Join(shellDDir, fmt.Sprintf("%s.%s", target, shell))
-		if err := os.WriteFile(destPath, content, 0600); err != nil {
+
+		// A recipe may carry more than one set_env step. They all target the
+		// same file, so later steps append rather than truncate — otherwise the
+		// earlier steps' exports would vanish without a word.
+		written := content
+		if idx := findCleanupAction(ctx, relPath); idx >= 0 {
+			existing, err := os.ReadFile(destPath)
+			if err != nil {
+				return fmt.Errorf("set_env: failed to read %s for append: %w", destPath, err)
+			}
+			written = append(existing, content...)
+		}
+
+		if err := os.WriteFile(destPath, written, 0600); err != nil {
 			return fmt.Errorf("set_env: failed to write %s: %w", destPath, err)
 		}
 		reporter.Status(fmt.Sprintf("   Installed environment exports: %s", destPath))
-		recordCleanup(ctx, target, shell, contentHash(content))
+
+		hash := contentHash(written)
+		if idx := findCleanupAction(ctx, relPath); idx >= 0 {
+			ctx.CleanupActions[idx].ContentHash = hash
+		} else {
+			recordCleanup(ctx, target, shell, hash)
+		}
 	}
 
 	return nil
+}
+
+// findCleanupAction returns the index of the cleanup action recorded for
+// relPath, or -1 when this execution has not written that file yet.
+func findCleanupAction(ctx *ExecutionContext, relPath string) int {
+	for i, ca := range ctx.CleanupActions {
+		if ca.Path == relPath {
+			return i
+		}
+	}
+	return -1
 }
 
 // envTargetName builds the shell.d basename for this recipe's exports.

--- a/internal/actions/set_env.go
+++ b/internal/actions/set_env.go
@@ -4,11 +4,30 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/tsukumogami/tsuku/internal/recipe"
 )
 
-// SetEnvAction implements environment variable setting
+// envVarNamePattern is the set of names accepted by set_env. The generated file
+// is sourced by the user's shell, so anything outside a plain identifier is
+// rejected rather than escaped.
+var envVarNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// envShells are the shells set_env writes exports for. These are the two shells
+// $TSUKU_HOME/env sources (see config.EnvFileContent) and the two that share
+// `export NAME=value` syntax. fish would need `set -gx` and is not supported.
+var envShells = []string{"bash", "zsh"}
+
+// SetEnvAction exports environment variables into the user's shell by writing
+// $TSUKU_HOME/share/shell.d/00-env-{tool}.{shell}, which RebuildShellCache
+// concatenates into the init cache that $TSUKU_HOME/env sources.
+//
+// The "00-env-" prefix is load-bearing: the cache builder concatenates shell.d
+// in alphabetical order, and a tool's own init script often reads the variables
+// its recipe exports (nvm.sh only honors NVM_DIR when it is already set). The
+// numeric prefix keeps exports ahead of every plausible init filename.
 type SetEnvAction struct{ BaseAction }
 
 // IsDeterministic returns true because set_env produces identical results.
@@ -19,11 +38,52 @@ func (a *SetEnvAction) Name() string {
 	return "set_env"
 }
 
-// Execute sets environment variables
+// Preflight validates parameters without side effects.
+func (a *SetEnvAction) Preflight(params map[string]interface{}) *PreflightResult {
+	result := &PreflightResult{}
+
+	varsRaw, ok := params["vars"]
+	if !ok {
+		result.AddError("set_env action requires 'vars' parameter")
+		return result
+	}
+
+	envVars, err := a.parseVars(varsRaw)
+	if err != nil {
+		result.AddErrorf("set_env: failed to parse vars: %v", err)
+		return result
+	}
+
+	if len(envVars) == 0 {
+		result.AddError("set_env: 'vars' must not be empty")
+	}
+
+	for _, envVar := range envVars {
+		if err := validateEnvVar(envVar); err != nil {
+			result.AddErrorf("set_env: %v", err)
+		}
+	}
+
+	return result
+}
+
+// Execute writes the recipe's environment variables into shell.d.
 //
 // Parameters:
 //   - vars (required): List of environment variables [{name: "JAVA_HOME", value: "{install_dir}"}]
+//
+// This action runs in the post-install phase (see executor.StepPhase) so that
+// {install_dir} expands to the tool's final install directory rather than the
+// staging directory that is deleted once the install finishes.
 func (a *SetEnvAction) Execute(ctx *ExecutionContext, params map[string]interface{}) error {
+	reporter := ctx.GetReporter()
+
+	// When --no-shell-init is set, skip entirely: no files, no CleanupActions.
+	if ctx.NoShellInit {
+		reporter.Log("   Skipping environment exports (--no-shell-init)")
+		return nil
+	}
+
 	// Get vars list (required)
 	varsRaw, ok := params["vars"]
 	if !ok {
@@ -36,32 +96,97 @@ func (a *SetEnvAction) Execute(ctx *ExecutionContext, params map[string]interfac
 		return fmt.Errorf("failed to parse vars: %w", err)
 	}
 
-	// Build standard vars for substitution
-	vars := GetStandardVars(ctx.Version, ctx.InstallDir, ctx.WorkDir, ctx.LibsDir)
+	for _, envVar := range envVars {
+		if err := validateEnvVar(envVar); err != nil {
+			return fmt.Errorf("set_env: %w", err)
+		}
+	}
 
-	reporter := ctx.GetReporter()
+	if ctx.ToolInstallDir == "" {
+		return fmt.Errorf("set_env requires ToolInstallDir to be set in ExecutionContext; " +
+			"the step must run in the post-install phase")
+	}
+
+	target, err := envTargetName(ctx)
+	if err != nil {
+		return fmt.Errorf("set_env: %w", err)
+	}
+
+	// {install_dir} must resolve to the tool's permanent directory, not the
+	// staging directory that ctx.InstallDir points at.
+	vars := GetStandardVars(ctx.Version, ctx.ToolInstallDir, ctx.WorkDir, ctx.LibsDir)
+
+	// Derive $TSUKU_HOME from ToolsDir (which is $TSUKU_HOME/tools)
+	tsukuHome := filepath.Dir(ctx.ToolsDir)
+	shellDDir := filepath.Join(tsukuHome, "share", "shell.d")
+
+	if err := os.MkdirAll(shellDDir, 0700); err != nil {
+		return fmt.Errorf("set_env: failed to create shell.d directory: %w", err)
+	}
+	// Ensure restrictive permissions even if the directory already existed
+	if err := os.Chmod(shellDDir, 0700); err != nil {
+		return fmt.Errorf("set_env: failed to set permissions on shell.d directory: %w", err)
+	}
+
 	reporter.Log("   Setting %d environment variable(s)", len(envVars))
 
-	// Create env file
-	envFilePath := filepath.Join(ctx.InstallDir, "env.sh")
-	envFile, err := os.Create(envFilePath)
-	if err != nil {
-		return fmt.Errorf("failed to create env file: %w", err)
-	}
-	defer envFile.Close()
-
-	// Write environment variables
+	var buf strings.Builder
 	for _, envVar := range envVars {
 		value := ExpandVars(envVar.Value, vars)
-
-		// Write to env file
-		fmt.Fprintf(envFile, "export %s=%s\n", envVar.Name, value)
-
+		if err := validateEnvValue(envVar.Name, value); err != nil {
+			return fmt.Errorf("set_env: %w", err)
+		}
+		fmt.Fprintf(&buf, "export %s=%s\n", envVar.Name, shellQuote(value))
 		reporter.Log("   %s=%s", envVar.Name, value)
 	}
+	content := []byte(buf.String())
 
-	reporter.Log("   Environment file: %s", envFilePath)
+	for _, shell := range envShells {
+		destPath := filepath.Join(shellDDir, fmt.Sprintf("%s.%s", target, shell))
+		if err := os.WriteFile(destPath, content, 0600); err != nil {
+			return fmt.Errorf("set_env: failed to write %s: %w", destPath, err)
+		}
+		reporter.Status(fmt.Sprintf("   Installed environment exports: %s", destPath))
+		recordCleanup(ctx, target, shell, contentHash(content))
+	}
+
 	return nil
+}
+
+// envTargetName builds the shell.d basename for this recipe's exports.
+// The "00-env-" prefix keeps exports sorted ahead of tool init scripts.
+func envTargetName(ctx *ExecutionContext) (string, error) {
+	if ctx.Recipe == nil || ctx.Recipe.Metadata.Name == "" {
+		return "", fmt.Errorf("recipe name is not available in ExecutionContext")
+	}
+	name := ctx.Recipe.Metadata.Name
+	if name != filepath.Base(name) || name == "." || name == ".." || strings.ContainsAny(name, `/\`) {
+		return "", fmt.Errorf("recipe name %q is not a valid path segment", name)
+	}
+	return "00-env-" + name, nil
+}
+
+// validateEnvVar checks a variable name and its unexpanded value.
+func validateEnvVar(envVar recipe.EnvVar) error {
+	if !envVarNamePattern.MatchString(envVar.Name) {
+		return fmt.Errorf("invalid variable name %q (must match [A-Za-z_][A-Za-z0-9_]*)", envVar.Name)
+	}
+	return validateEnvValue(envVar.Name, envVar.Value)
+}
+
+// validateEnvValue rejects values that cannot be represented on a single
+// `export` line. Everything else is made safe by shellQuote.
+func validateEnvValue(name, value string) error {
+	if strings.ContainsAny(value, "\n\r\x00") {
+		return fmt.Errorf("value for %q must not contain newlines or NUL bytes", name)
+	}
+	return nil
+}
+
+// shellQuote wraps a value in single quotes, escaping embedded single quotes
+// the POSIX way, so no metacharacter in the value is interpreted by the shell.
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", `'\''`) + "'"
 }
 
 // parseVars parses the vars parameter

--- a/internal/actions/set_env_test.go
+++ b/internal/actions/set_env_test.go
@@ -3,10 +3,41 @@ package actions
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
+
+	"github.com/tsukumogami/tsuku/internal/config"
+	"github.com/tsukumogami/tsuku/internal/recipe"
+	"github.com/tsukumogami/tsuku/internal/shellenv"
 )
+
+// setEnvHome builds a $TSUKU_HOME skeleton and returns the home directory plus
+// an ExecutionContext wired to it, with the tool installed at
+// $TSUKU_HOME/tools/<name>-<version>.
+func setEnvHome(t *testing.T, name, version string) (string, *ExecutionContext) {
+	t.Helper()
+
+	home := t.TempDir()
+	toolsDir := filepath.Join(home, "tools")
+	toolInstallDir := filepath.Join(toolsDir, name+"-"+version)
+	if err := os.MkdirAll(toolInstallDir, 0755); err != nil {
+		t.Fatalf("failed to create tool install dir: %v", err)
+	}
+
+	ctx := &ExecutionContext{
+		Context:        context.Background(),
+		WorkDir:        t.TempDir(),
+		InstallDir:     filepath.Join(toolsDir, ".install"),
+		ToolInstallDir: toolInstallDir,
+		ToolsDir:       toolsDir,
+		Version:        version,
+		Recipe:         &recipe.Recipe{Metadata: recipe.MetadataSection{Name: name}},
+	}
+	return home, ctx
+}
 
 func TestSetEnvAction_Name(t *testing.T) {
 	t.Parallel()
@@ -16,54 +47,367 @@ func TestSetEnvAction_Name(t *testing.T) {
 	}
 }
 
-func TestSetEnvAction_Execute(t *testing.T) {
+// TestSetEnvAction_ReachesUserShell is the end-to-end check the action was
+// missing: it installs exports plus a tool init script that consumes them,
+// rebuilds the shell cache, then sources $TSUKU_HOME/env in a real bash
+// subshell and reads the variable back. Asserting on the generated file alone
+// is what let the "set_env does nothing" bug survive.
+func TestSetEnvAction_ReachesUserShell(t *testing.T) {
 	t.Parallel()
-	action := &SetEnvAction{}
-	tmpDir := t.TempDir()
 
-	ctx := &ExecutionContext{
-		WorkDir:    tmpDir,
-		InstallDir: tmpDir,
-		Version:    "1.0.0",
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available")
 	}
 
-	err := action.Execute(ctx, map[string]interface{}{
+	home, ctx := setEnvHome(t, "nvm", "0.40.6")
+
+	if err := os.WriteFile(filepath.Join(home, "env"), []byte(config.EnvFileContent), 0644); err != nil {
+		t.Fatalf("failed to write env file: %v", err)
+	}
+
+	// The recipe exports NVM_DIR pointing at the tool install directory.
+	action := &SetEnvAction{}
+	if err := action.Execute(ctx, map[string]interface{}{
 		"vars": []interface{}{
-			map[string]interface{}{"name": "JAVA_HOME", "value": "{install_dir}"},
-			map[string]interface{}{"name": "VERSION", "value": "{version}"},
+			map[string]interface{}{"name": "NVM_DIR", "value": "{install_dir}"},
+			map[string]interface{}{"name": "NVM_VERSION", "value": "{version}"},
 		},
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("Execute() error = %v", err)
 	}
 
-	// Verify env.sh was created
-	envFile := filepath.Join(tmpDir, "env.sh")
-	content, err := os.ReadFile(envFile)
-	if err != nil {
-		t.Fatalf("Failed to read env.sh: %v", err)
+	// The tool ships an init script that self-locates only when the variable is
+	// unset -- the nvm.sh pattern. It records what it saw at source time, so the
+	// assertion below fails if the export is concatenated after it rather than
+	// before. Checking only the final value would pass either way, since a later
+	// export simply overwrites.
+	initScript := filepath.Join(ctx.ToolInstallDir, "nvm.sh")
+	selfLocated := filepath.Join(home, "share", "shell.d")
+	if err := os.WriteFile(initScript, []byte(
+		"export NVM_DIR_AT_INIT=\"${NVM_DIR-<unset>}\"\n"+
+			"if [ -z \"${NVM_DIR-}\" ]; then\n  NVM_DIR="+selfLocated+"\n  export NVM_DIR\nfi\n"), 0644); err != nil {
+		t.Fatalf("failed to write init script: %v", err)
+	}
+	shellInit := &InstallShellInitAction{}
+	// install_shell_init copies source_file from InstallDir, so point it at the
+	// directory holding the script for this test.
+	shellCtx := *ctx
+	shellCtx.InstallDir = ctx.ToolInstallDir
+	if err := shellInit.Execute(&shellCtx, map[string]interface{}{
+		"source_file": "nvm.sh",
+		"target":      "nvm",
+		"shells":      []interface{}{"bash"},
+	}); err != nil {
+		t.Fatalf("install_shell_init Execute() error = %v", err)
 	}
 
-	contentStr := string(content)
-	if !strings.Contains(contentStr, "export JAVA_HOME="+tmpDir) {
-		t.Errorf("env.sh should contain JAVA_HOME=%s, got: %s", tmpDir, contentStr)
+	if err := shellenv.RebuildShellCache(home, "bash"); err != nil {
+		t.Fatalf("RebuildShellCache() error = %v", err)
 	}
-	if !strings.Contains(contentStr, "export VERSION=1.0.0") {
-		t.Errorf("env.sh should contain VERSION=1.0.0, got: %s", contentStr)
+
+	read := func(varName string) string {
+		t.Helper()
+		cmd := exec.Command(bashPath, "--norc", "--noprofile", "-c",
+			`. "$TSUKU_HOME/env"; printf %s "${`+varName+`-}"`)
+		cmd.Env = []string{"TSUKU_HOME=" + home, "HOME=" + home, "PATH=/usr/bin:/bin"}
+		out, err := cmd.Output()
+		if err != nil {
+			t.Fatalf("sourcing env for %s failed: %v", varName, err)
+		}
+		return string(out)
+	}
+
+	if got := read("NVM_DIR"); got != ctx.ToolInstallDir {
+		t.Errorf("NVM_DIR = %q, want %q (the tool install dir, not the self-located %q)",
+			got, ctx.ToolInstallDir, selfLocated)
+	}
+	if got := read("NVM_DIR_AT_INIT"); got != ctx.ToolInstallDir {
+		t.Errorf("the tool init script saw NVM_DIR = %q, want %q; the exports must be "+
+			"concatenated into the shell cache before the tool's own init script", got, ctx.ToolInstallDir)
+	}
+	if got := read("NVM_VERSION"); got != "0.40.6" {
+		t.Errorf("NVM_VERSION = %q, want %q", got, "0.40.6")
+	}
+}
+
+// TestSetEnvAction_SortsBeforeToolInit pins the ordering guarantee the
+// "00-env-" prefix exists for: the shell cache concatenates shell.d
+// alphabetically, so exports must sort ahead of the tool's own init script.
+func TestSetEnvAction_SortsBeforeToolInit(t *testing.T) {
+	t.Parallel()
+
+	_, ctx := setEnvHome(t, "nvm", "0.40.6")
+	target, err := envTargetName(ctx)
+	if err != nil {
+		t.Fatalf("envTargetName() error = %v", err)
+	}
+
+	names := []string{"nvm.bash", target + ".bash"}
+	sort.Strings(names)
+	if names[0] != target+".bash" {
+		t.Errorf("sorted order = %v, want %q first so exports load before the tool init script", names, target+".bash")
+	}
+}
+
+func TestSetEnvAction_WritesShellDFiles(t *testing.T) {
+	t.Parallel()
+
+	home, ctx := setEnvHome(t, "demo", "2.1.0")
+
+	action := &SetEnvAction{}
+	if err := action.Execute(ctx, map[string]interface{}{
+		"vars": []interface{}{
+			map[string]interface{}{"name": "DEMO_HOME", "value": "{install_dir}"},
+		},
+	}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	shellDDir := filepath.Join(home, "share", "shell.d")
+	for _, shell := range []string{"bash", "zsh"} {
+		path := filepath.Join(shellDDir, "00-env-demo."+shell)
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("reading %s: %v", path, err)
+		}
+		want := "export DEMO_HOME='" + ctx.ToolInstallDir + "'\n"
+		if string(content) != want {
+			t.Errorf("%s content = %q, want %q", path, content, want)
+		}
+
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		if perm := info.Mode().Perm(); perm != 0600 {
+			t.Errorf("%s permissions = %o, want 0600", path, perm)
+		}
+	}
+
+	// The staging directory must never appear in what the shell reads.
+	if strings.Contains(ctx.ToolInstallDir, ".install") {
+		t.Fatal("test setup error: tool install dir contains the staging marker")
+	}
+	if _, err := os.Stat(filepath.Join(ctx.ToolInstallDir, "env.sh")); !os.IsNotExist(err) {
+		t.Error("set_env should no longer write env.sh into the tool directory")
+	}
+}
+
+func TestSetEnvAction_RecordsCleanupActions(t *testing.T) {
+	t.Parallel()
+
+	home, ctx := setEnvHome(t, "demo", "2.1.0")
+
+	action := &SetEnvAction{}
+	if err := action.Execute(ctx, map[string]interface{}{
+		"vars": []interface{}{
+			map[string]interface{}{"name": "DEMO_HOME", "value": "{install_dir}"},
+		},
+	}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if len(ctx.CleanupActions) != 2 {
+		t.Fatalf("recorded %d cleanup actions, want 2 (bash and zsh)", len(ctx.CleanupActions))
+	}
+	for _, ca := range ctx.CleanupActions {
+		if ca.Action != "delete_file" {
+			t.Errorf("cleanup action = %q, want delete_file", ca.Action)
+		}
+		if !strings.HasPrefix(ca.Path, "share/shell.d/00-env-demo.") {
+			t.Errorf("cleanup path = %q, want a share/shell.d/00-env-demo.* entry", ca.Path)
+		}
+		content, err := os.ReadFile(filepath.Join(home, ca.Path))
+		if err != nil {
+			t.Fatalf("reading recorded path %s: %v", ca.Path, err)
+		}
+		if got := contentHash(content); got != ca.ContentHash {
+			t.Errorf("recorded hash for %s = %q, want %q", ca.Path, ca.ContentHash, got)
+		}
+	}
+}
+
+func TestSetEnvAction_NoShellInit(t *testing.T) {
+	t.Parallel()
+
+	home, ctx := setEnvHome(t, "demo", "2.1.0")
+	ctx.NoShellInit = true
+
+	action := &SetEnvAction{}
+	if err := action.Execute(ctx, map[string]interface{}{
+		"vars": []interface{}{
+			map[string]interface{}{"name": "DEMO_HOME", "value": "{install_dir}"},
+		},
+	}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(home, "share", "shell.d")); !os.IsNotExist(err) {
+		t.Error("--no-shell-init should not create shell.d")
+	}
+	if len(ctx.CleanupActions) != 0 {
+		t.Errorf("--no-shell-init recorded %d cleanup actions, want 0", len(ctx.CleanupActions))
+	}
+}
+
+func TestSetEnvAction_RequiresToolInstallDir(t *testing.T) {
+	t.Parallel()
+
+	_, ctx := setEnvHome(t, "demo", "2.1.0")
+	ctx.ToolInstallDir = ""
+
+	action := &SetEnvAction{}
+	err := action.Execute(ctx, map[string]interface{}{
+		"vars": []interface{}{
+			map[string]interface{}{"name": "DEMO_HOME", "value": "{install_dir}"},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "post-install") {
+		t.Errorf("Execute() error = %v, want an error naming the post-install phase", err)
+	}
+}
+
+func TestSetEnvAction_QuotesValues(t *testing.T) {
+	t.Parallel()
+
+	bashPath, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available")
+	}
+
+	home, ctx := setEnvHome(t, "demo", "2.1.0")
+
+	action := &SetEnvAction{}
+	if err := action.Execute(ctx, map[string]interface{}{
+		"vars": []interface{}{
+			map[string]interface{}{"name": "WITH_SPACES", "value": "a b c"},
+			map[string]interface{}{"name": "WITH_QUOTE", "value": "it's"},
+			map[string]interface{}{"name": "WITH_META", "value": "$(touch pwned);`id`"},
+		},
+	}); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	script := filepath.Join(home, "share", "shell.d", "00-env-demo.bash")
+	cmd := exec.Command(bashPath, "--norc", "--noprofile", "-c",
+		`. "`+script+`"; printf '%s|%s|%s' "$WITH_SPACES" "$WITH_QUOTE" "$WITH_META"`)
+	cmd.Dir = home
+	cmd.Env = []string{"HOME=" + home, "PATH=/usr/bin:/bin"}
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("sourcing generated script failed: %v", err)
+	}
+
+	want := "a b c|it's|$(touch pwned);`id`"
+	if string(out) != want {
+		t.Errorf("sourced values = %q, want %q", out, want)
+	}
+	if _, err := os.Stat(filepath.Join(home, "pwned")); !os.IsNotExist(err) {
+		t.Error("command substitution in a value was executed by the shell")
+	}
+}
+
+func TestSetEnvAction_RejectsUnsafeVars(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		varName     string
+		varValue    string
+		errContains string
+	}{
+		{"name with semicolon", "FOO;rm -rf /", "bar", "invalid variable name"},
+		{"name with space", "FOO BAR", "bar", "invalid variable name"},
+		{"name starting with digit", "1FOO", "bar", "invalid variable name"},
+		{"empty name", "", "bar", "invalid variable name"},
+		{"value with newline", "FOO", "bar\nexport EVIL=1", "newlines"},
+		{"value with carriage return", "FOO", "bar\rbaz", "newlines"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			home, ctx := setEnvHome(t, "demo", "2.1.0")
+			params := map[string]interface{}{
+				"vars": []interface{}{
+					map[string]interface{}{"name": tt.varName, "value": tt.varValue},
+				},
+			}
+
+			action := &SetEnvAction{}
+			err := action.Execute(ctx, params)
+			if err == nil || !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("Execute() error = %v, want an error containing %q", err, tt.errContains)
+			}
+			if _, statErr := os.Stat(filepath.Join(home, "share", "shell.d", "00-env-demo.bash")); statErr == nil {
+				t.Error("a rejected variable should not have been written")
+			}
+
+			if result := action.Preflight(params); !result.HasErrors() {
+				t.Errorf("Preflight() accepted %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestSetEnvAction_Preflight(t *testing.T) {
+	t.Parallel()
+
+	action := &SetEnvAction{}
+
+	if result := action.Preflight(map[string]interface{}{
+		"vars": []interface{}{
+			map[string]interface{}{"name": "JAVA_HOME", "value": "{install_dir}"},
+		},
+	}); result.HasErrors() {
+		t.Errorf("Preflight() rejected a valid recipe: %v", result.Errors)
+	}
+
+	if result := action.Preflight(map[string]interface{}{}); !result.HasErrors() {
+		t.Error("Preflight() should reject a missing 'vars' parameter")
+	}
+
+	if result := action.Preflight(map[string]interface{}{"vars": []interface{}{}}); !result.HasErrors() {
+		t.Error("Preflight() should reject an empty 'vars' list")
+	}
+}
+
+func TestSetEnvAction_RequiresRecipeName(t *testing.T) {
+	t.Parallel()
+
+	_, ctx := setEnvHome(t, "demo", "2.1.0")
+	ctx.Recipe = nil
+
+	action := &SetEnvAction{}
+	err := action.Execute(ctx, map[string]interface{}{
+		"vars": []interface{}{
+			map[string]interface{}{"name": "DEMO_HOME", "value": "{install_dir}"},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "recipe name") {
+		t.Errorf("Execute() error = %v, want an error about the missing recipe name", err)
+	}
+}
+
+func TestEnvTargetName_RejectsPathSegments(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"../escape", "a/b", ".", ".."} {
+		ctx := &ExecutionContext{Recipe: &recipe.Recipe{Metadata: recipe.MetadataSection{Name: name}}}
+		if _, err := envTargetName(ctx); err == nil {
+			t.Errorf("envTargetName() accepted recipe name %q", name)
+		}
 	}
 }
 
 func TestSetEnvAction_Execute_MissingVars(t *testing.T) {
 	t.Parallel()
+
+	_, ctx := setEnvHome(t, "demo", "1.0.0")
+
 	action := &SetEnvAction{}
-	tmpDir := t.TempDir()
-
-	ctx := &ExecutionContext{
-		WorkDir:    tmpDir,
-		InstallDir: tmpDir,
-		Version:    "1.0.0",
-	}
-
 	err := action.Execute(ctx, map[string]interface{}{})
 	if err == nil {
 		t.Error("Execute() should fail when 'vars' parameter is missing")
@@ -169,13 +513,8 @@ func TestSetEnvAction_ParseVars_Errors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			_, ctx := setEnvHome(t, "demo", "1.0.0")
 			action := &SetEnvAction{}
-			ctx := &ExecutionContext{
-				Context:    context.Background(),
-				WorkDir:    t.TempDir(),
-				InstallDir: t.TempDir(),
-				Version:    "1.0.0",
-			}
 			err := action.Execute(ctx, map[string]any{"vars": tt.vars})
 			if err == nil || !strings.Contains(err.Error(), tt.errContains) {
 				t.Errorf("Expected error containing %q, got %v", tt.errContains, err)

--- a/internal/actions/set_env_test.go
+++ b/internal/actions/set_env_test.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 
@@ -131,22 +130,26 @@ func TestSetEnvAction_ReachesUserShell(t *testing.T) {
 	}
 }
 
-// TestSetEnvAction_SortsBeforeToolInit pins the ordering guarantee the
-// "00-env-" prefix exists for: the shell cache concatenates shell.d
-// alphabetically, so exports must sort ahead of the tool's own init script.
-func TestSetEnvAction_SortsBeforeToolInit(t *testing.T) {
+// The "00-env-" prefix is what keeps exports ahead of a tool's init script in
+// the shell cache, so no other action may claim it.
+func TestInstallShellInit_RejectsReservedEnvPrefix(t *testing.T) {
 	t.Parallel()
 
-	_, ctx := setEnvHome(t, "nvm", "0.40.6")
-	target, err := envTargetName(ctx)
-	if err != nil {
-		t.Fatalf("envTargetName() error = %v", err)
+	action := &InstallShellInitAction{}
+	result := action.Preflight(map[string]interface{}{
+		"source_file": "init.sh",
+		"target":      EnvFilePrefix + "nvm",
+	})
+	if !result.HasErrors() {
+		t.Errorf("Preflight() accepted a target claiming the %q prefix reserved for set_env", EnvFilePrefix)
 	}
 
-	names := []string{"nvm.bash", target + ".bash"}
-	sort.Strings(names)
-	if names[0] != target+".bash" {
-		t.Errorf("sorted order = %v, want %q first so exports load before the tool init script", names, target+".bash")
+	result = action.Preflight(map[string]interface{}{
+		"source_file": "init.sh",
+		"target":      "nvm",
+	})
+	if result.HasErrors() {
+		t.Errorf("Preflight() rejected an ordinary target: %v", result.Errors)
 	}
 }
 
@@ -479,88 +482,40 @@ func TestSetEnvAction_parseVars(t *testing.T) {
 	}
 }
 
+// Malformed vars must be rejected by parseVars itself and by Execute, which
+// wraps it -- a recipe reaching Execute with bad vars must not write a file.
 func TestSetEnvAction_parseVars_InvalidFormat(t *testing.T) {
 	t.Parallel()
-	action := &SetEnvAction{}
 
-	tests := []struct {
-		name  string
-		input interface{}
-	}{
-		{
-			name:  "not an array",
-			input: "string",
-		},
-		{
-			name:  "array item not a map",
-			input: []interface{}{"string"},
-		},
-		{
-			name:  "missing name",
-			input: []interface{}{map[string]interface{}{"value": "bar"}},
-		},
-		{
-			name:  "missing value",
-			input: []interface{}{map[string]interface{}{"name": "FOO"}},
-		},
-		{
-			name:  "name not string",
-			input: []interface{}{map[string]interface{}{"name": 123, "value": "bar"}},
-		},
-		{
-			name:  "value not string",
-			input: []interface{}{map[string]interface{}{"name": "FOO", "value": 123}},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			_, err := action.parseVars(tt.input)
-			if err == nil {
-				t.Errorf("parseVars(%v) should fail", tt.input)
-			}
-		})
-	}
-}
-
-// TestSetEnvAction_ParseVars_Errors tests parseVars error paths via Execute
-func TestSetEnvAction_ParseVars_Errors(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name        string
-		vars        any
+		input       interface{}
 		errContains string
 	}{
-		{
-			name:        "missing name",
-			vars:        []any{map[string]any{"value": "bar"}},
-			errContains: "name",
-		},
-		{
-			name:        "missing value",
-			vars:        []any{map[string]any{"name": "FOO"}},
-			errContains: "value",
-		},
-		{
-			name:        "non-array",
-			vars:        "not an array",
-			errContains: "array",
-		},
-		{
-			name:        "non-map entry",
-			vars:        []any{"not a map"},
-			errContains: "map",
-		},
+		{"not an array", "string", "array"},
+		{"array item not a map", []interface{}{"string"}, "map"},
+		{"missing name", []interface{}{map[string]interface{}{"value": "bar"}}, "name"},
+		{"missing value", []interface{}{map[string]interface{}{"name": "FOO"}}, "value"},
+		{"name not string", []interface{}{map[string]interface{}{"name": 123, "value": "bar"}}, "name"},
+		{"value not string", []interface{}{map[string]interface{}{"name": "FOO", "value": 123}}, "value"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, ctx := setEnvHome(t, "demo", "1.0.0")
 			action := &SetEnvAction{}
-			err := action.Execute(ctx, map[string]any{"vars": tt.vars})
+
+			if _, err := action.parseVars(tt.input); err == nil {
+				t.Errorf("parseVars(%v) should fail", tt.input)
+			}
+
+			home, ctx := setEnvHome(t, "demo", "1.0.0")
+			err := action.Execute(ctx, map[string]interface{}{"vars": tt.input})
 			if err == nil || !strings.Contains(err.Error(), tt.errContains) {
-				t.Errorf("Expected error containing %q, got %v", tt.errContains, err)
+				t.Errorf("Execute() error = %v, want an error containing %q", err, tt.errContains)
+			}
+			if _, statErr := os.Stat(filepath.Join(home, "share", "shell.d")); !os.IsNotExist(statErr) {
+				t.Error("malformed vars should not have produced any shell.d output")
 			}
 		})
 	}

--- a/internal/actions/set_env_test.go
+++ b/internal/actions/set_env_test.go
@@ -228,6 +228,49 @@ func TestSetEnvAction_RecordsCleanupActions(t *testing.T) {
 	}
 }
 
+// A recipe may carry several set_env steps; they all target one file, so a
+// later step must not silently drop the earlier one's exports.
+func TestSetEnvAction_MultipleStepsAppend(t *testing.T) {
+	t.Parallel()
+
+	home, ctx := setEnvHome(t, "demo", "2.1.0")
+	action := &SetEnvAction{}
+
+	for _, name := range []string{"FIRST", "SECOND"} {
+		if err := action.Execute(ctx, map[string]interface{}{
+			"vars": []interface{}{
+				map[string]interface{}{"name": name, "value": "{install_dir}"},
+			},
+		}); err != nil {
+			t.Fatalf("Execute() for %s error = %v", name, err)
+		}
+	}
+
+	path := filepath.Join(home, "share", "shell.d", "00-env-demo.bash")
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	want := "export FIRST='" + ctx.ToolInstallDir + "'\nexport SECOND='" + ctx.ToolInstallDir + "'\n"
+	if string(content) != want {
+		t.Errorf("content = %q, want %q", content, want)
+	}
+
+	// One cleanup action per shell, and its hash must cover the merged file.
+	if len(ctx.CleanupActions) != 2 {
+		t.Fatalf("recorded %d cleanup actions, want 2", len(ctx.CleanupActions))
+	}
+	for _, ca := range ctx.CleanupActions {
+		merged, err := os.ReadFile(filepath.Join(home, ca.Path))
+		if err != nil {
+			t.Fatalf("reading %s: %v", ca.Path, err)
+		}
+		if got := contentHash(merged); got != ca.ContentHash {
+			t.Errorf("hash for %s = %q, want %q (must cover the merged file)", ca.Path, ca.ContentHash, got)
+		}
+	}
+}
+
 func TestSetEnvAction_NoShellInit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/actions/shell_init.go
+++ b/internal/actions/shell_init.go
@@ -55,8 +55,13 @@ func (a *InstallShellInitAction) Preflight(params map[string]interface{}) *Prefl
 	}
 
 	// target is required
-	if _, ok := GetString(params, "target"); !ok {
+	if target, ok := GetString(params, "target"); !ok {
 		result.AddError("install_shell_init requires 'target' parameter")
+	} else if strings.HasPrefix(target, EnvFilePrefix) {
+		// Taking this prefix would put an init script ahead of the exports
+		// set_env writes, which is the ordering that prefix exists to guarantee.
+		result.AddErrorf("install_shell_init: target %q may not start with %q (reserved for set_env)",
+			target, EnvFilePrefix)
 	}
 
 	// Validate shells if provided
@@ -138,10 +143,48 @@ func contentHash(data []byte) string {
 	return hex.EncodeToString(h[:])
 }
 
+// shellDCleanupPath is the $TSUKU_HOME-relative path recorded for a shell.d
+// file. It is the single place that formula lives; anything matching against
+// recorded cleanup paths must build them here.
+func shellDCleanupPath(target, shell string) string {
+	return fmt.Sprintf("share/shell.d/%s.%s", target, shell)
+}
+
 // recordCleanup appends a CleanupAction for a shell.d file to the execution context.
 // The path is stored relative to $TSUKU_HOME. The hash is the SHA-256 of the file content.
 func recordCleanup(ctx *ExecutionContext, target, shell, hash string) {
-	relPath := fmt.Sprintf("share/shell.d/%s.%s", target, shell)
+	ctx.CleanupActions = append(ctx.CleanupActions, CleanupAction{
+		Action:      "delete_file",
+		Path:        shellDCleanupPath(target, shell),
+		ContentHash: hash,
+	})
+}
+
+// cleanupRecorded reports whether this execution already recorded a cleanup
+// action for a shell.d file, which means the file on disk is this install's own
+// output rather than a leftover from a previous version.
+func cleanupRecorded(ctx *ExecutionContext, target, shell string) bool {
+	relPath := shellDCleanupPath(target, shell)
+	for _, ca := range ctx.CleanupActions {
+		if ca.Path == relPath {
+			return true
+		}
+	}
+	return false
+}
+
+// upsertCleanup records a cleanup action for a shell.d file, refreshing the
+// content hash when this execution already recorded that path. Only actions
+// that may write the same path more than once in a single install need this;
+// the append-only recordCleanup is right for everything else.
+func upsertCleanup(ctx *ExecutionContext, target, shell, hash string) {
+	relPath := shellDCleanupPath(target, shell)
+	for i := range ctx.CleanupActions {
+		if ctx.CleanupActions[i].Path == relPath {
+			ctx.CleanupActions[i].ContentHash = hash
+			return
+		}
+	}
 	ctx.CleanupActions = append(ctx.CleanupActions, CleanupAction{
 		Action:      "delete_file",
 		Path:        relPath,

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -600,10 +600,25 @@ func (e *Executor) ExecutePlan(ctx context.Context, plan *InstallationPlan) erro
 	return nil
 }
 
+// defaultPostInstallActions lists actions that run in the post-install phase
+// unless the recipe says otherwise. These actions need ToolInstallDir, which is
+// only populated between ExecutePlan and ExecutePhase("post-install") — running
+// them in the install phase would silently give them an empty path.
+//
+// The classification lives here rather than in plan generation so that plans
+// stored before an action joined this list still route correctly.
+var defaultPostInstallActions = map[string]bool{
+	"set_env": true,
+}
+
 // StepPhase returns the effective phase of a ResolvedStep.
-// Empty phase is treated as "install" for backward compatibility.
+// A step with no explicit phase runs in "install" unless its action is one of
+// the actions that default to post-install.
 func StepPhase(step ResolvedStep) string {
 	if step.Phase == "" {
+		if defaultPostInstallActions[step.Action] {
+			return "post-install"
+		}
 		return "install"
 	}
 	return step.Phase

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -600,32 +600,23 @@ func (e *Executor) ExecutePlan(ctx context.Context, plan *InstallationPlan) erro
 	return nil
 }
 
-// defaultPostInstallActions lists actions that run in the post-install phase
-// unless the recipe says otherwise. These actions need ToolInstallDir, which is
-// only populated between ExecutePlan and ExecutePhase("post-install") — running
-// them in the install phase would silently give them an empty path.
-//
-// The classification lives here rather than in plan generation so that plans
-// stored before an action joined this list still route correctly.
-var defaultPostInstallActions = map[string]bool{
-	"set_env": true,
-}
-
 // StepPhase returns the effective phase of a ResolvedStep.
-// A step with no explicit phase runs in "install" unless its action is one of
-// the actions that default to post-install.
+//
+// A phase named by the recipe wins. Otherwise the action decides: most run in
+// "install", but an action implementing actions.PhaseDeclarer can ask for a
+// later phase because it needs state the install phase cannot provide. The
+// lookup goes through the action registry rather than the stored plan, so plans
+// written before an action started declaring a phase still route correctly.
 func StepPhase(step ResolvedStep) string {
 	if step.Phase == "" {
-		if defaultPostInstallActions[step.Action] {
-			return "post-install"
-		}
-		return "install"
+		return actions.DefaultPhase(step.Action)
 	}
 	return step.Phase
 }
 
 // ExecutePhase executes only the steps matching the given phase from an installation plan.
-// Steps with an empty Phase field are treated as "install" phase.
+// Steps with an empty Phase field fall back to their action's default (see StepPhase),
+// which is "install" for all but a few actions.
 // The execution context (e.ctx) must already be set up by a prior call to ExecutePlan.
 func (e *Executor) ExecutePhase(ctx context.Context, plan *InstallationPlan, phase string) error {
 	if e.ctx == nil {

--- a/internal/executor/executor_test.go
+++ b/internal/executor/executor_test.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
+	"sort"
 	"testing"
 
 	"github.com/tsukumogami/tsuku/internal/actions"
@@ -1856,6 +1858,83 @@ func TestExecutePlan_TwoPhaseSequence(t *testing.T) {
 	shellDFile := filepath.Join(tsukuHome, "share", "shell.d", "test-tool.bash")
 	if _, err := os.Stat(shellDFile); os.IsNotExist(err) {
 		t.Errorf("expected shell init file at %s, but it does not exist", shellDFile)
+	}
+}
+
+// TestExecutePlan_SetEnvRunsInPostInstall exercises the chain a set_env step
+// actually travels: a plan step with no explicit phase, ExecutePlan skipping it,
+// SetToolInstallDir, then ExecutePhase("post-install") writing the exports and
+// recording cleanup. Testing SetEnvAction.Execute directly would pass even if
+// the routing were wrong and no install ever ran the action.
+func TestExecutePlan_SetEnvRunsInPostInstall(t *testing.T) {
+	r := &recipe.Recipe{
+		Metadata: recipe.MetadataSection{Name: "test-tool"},
+	}
+
+	exec, err := New(r)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer exec.Cleanup()
+
+	tsukuHome := t.TempDir()
+	exec.SetToolsDir(filepath.Join(tsukuHome, "tools"))
+
+	plan := &InstallationPlan{
+		FormatVersion: PlanFormatVersion,
+		Tool:          "test-tool",
+		Version:       "1.0.0",
+		Platform:      Platform{OS: runtime.GOOS, Arch: runtime.GOARCH},
+		Steps: []ResolvedStep{
+			{
+				// No Phase set -- exactly how a recipe writes it.
+				Action: "set_env",
+				Params: map[string]interface{}{
+					"vars": []interface{}{
+						map[string]interface{}{"name": "TEST_TOOL_HOME", "value": "{install_dir}"},
+					},
+				},
+			},
+		},
+	}
+
+	shellDFile := filepath.Join(tsukuHome, "share", "shell.d", "00-env-test-tool.bash")
+
+	// ExecutePlan must skip the step rather than run it against an unset
+	// ToolInstallDir, which would fail the install.
+	if err := exec.ExecutePlan(context.Background(), plan); err != nil {
+		t.Fatalf("ExecutePlan() error = %v", err)
+	}
+	if _, err := os.Stat(shellDFile); !os.IsNotExist(err) {
+		t.Fatal("set_env ran during the install phase, before ToolInstallDir was known")
+	}
+
+	finalInstallDir := filepath.Join(tsukuHome, "tools", "test-tool-1.0.0")
+	exec.SetToolInstallDir(finalInstallDir)
+
+	if err := exec.ExecutePhase(context.Background(), plan, "post-install"); err != nil {
+		t.Fatalf("ExecutePhase(post-install) error = %v", err)
+	}
+
+	content, err := os.ReadFile(shellDFile)
+	if err != nil {
+		t.Fatalf("reading %s: %v", shellDFile, err)
+	}
+	want := "export TEST_TOOL_HOME='" + finalInstallDir + "'\n"
+	if string(content) != want {
+		t.Errorf("exports = %q, want %q", content, want)
+	}
+
+	// The cleanup actions the caller reads back to rebuild shell caches and to
+	// record removal state must include the export files.
+	var paths []string
+	for _, ca := range exec.GetCleanupActions() {
+		paths = append(paths, ca.Path)
+	}
+	sort.Strings(paths)
+	wantPaths := []string{"share/shell.d/00-env-test-tool.bash", "share/shell.d/00-env-test-tool.zsh"}
+	if !reflect.DeepEqual(paths, wantPaths) {
+		t.Errorf("cleanup action paths = %v, want %v", paths, wantPaths)
 	}
 }
 

--- a/internal/executor/phase_test.go
+++ b/internal/executor/phase_test.go
@@ -18,6 +18,22 @@ func TestStepPhase_PreservesExplicitPhase(t *testing.T) {
 	}
 }
 
+// set_env expands {install_dir} from ToolInstallDir, which is only populated
+// for the post-install phase, so it must default there rather than to install.
+func TestStepPhase_SetEnvDefaultsToPostInstall(t *testing.T) {
+	step := ResolvedStep{Action: "set_env"}
+	if phase := StepPhase(step); phase != "post-install" {
+		t.Errorf("expected set_env to default to 'post-install', got %q", phase)
+	}
+}
+
+func TestStepPhase_ExplicitPhaseBeatsDefault(t *testing.T) {
+	step := ResolvedStep{Action: "set_env", Phase: "install"}
+	if phase := StepPhase(step); phase != "install" {
+		t.Errorf("expected explicit 'install' to win, got %q", phase)
+	}
+}
+
 func TestPhaseFiltering(t *testing.T) {
 	steps := []ResolvedStep{
 		{Action: "download_file", Phase: ""},

--- a/internal/executor/plan.go
+++ b/internal/executor/plan.go
@@ -112,8 +112,11 @@ type ResolvedStep struct {
 	// Action is the action name (e.g., "download", "extract", "install_binaries")
 	Action string `json:"action"`
 
-	// Phase is the lifecycle phase for this step: "install" (default), "post-install", etc.
-	// Empty string is treated as "install" for backward compatibility.
+	// Phase is the lifecycle phase for this step: "install", "post-install", etc.
+	// Empty string means the recipe did not name one, in which case the action
+	// decides -- see StepPhase. Do not resolve it here at plan-generation time:
+	// the resolved value would be frozen into stored plans, so a later change to
+	// an action's phase would not reach plans already written to state.json.
 	Phase string `json:"phase,omitempty"`
 
 	// Params contains the resolved action parameters

--- a/internal/recipe/types.go
+++ b/internal/recipe/types.go
@@ -380,8 +380,11 @@ func (w *WhenClause) Matches(target Matchable) bool {
 // Step represents a single action step
 // We use interface{} for the full step data and extract fields manually
 type Step struct {
-	Action       string
-	Phase        string // Lifecycle phase: "install" (default), "post-install", "pre-remove", "pre-update"
+	Action string
+	// Phase names a lifecycle phase: "install", "post-install", "pre-remove",
+	// "pre-update". Leave it empty unless the action needs overriding -- the
+	// action picks its own default (see executor.StepPhase).
+	Phase        string
 	When         *WhenClause
 	Note         string
 	Description  string

--- a/internal/recipe/validator.go
+++ b/internal/recipe/validator.go
@@ -505,6 +505,16 @@ func validateSteps(result *ValidationResult, r *Recipe) {
 				"set_env is not supported in library recipes (libraries have no shell integration)")
 		}
 
+		// An action that asks for a later phase does so because it needs state
+		// the install phase cannot give it. Overriding that produces a step that
+		// can never work, so catch it here rather than at install time.
+		if step.Phase != "" && av != nil {
+			if want := av.DefaultPhase(step.Action); want != "" && want != "install" && step.Phase != want {
+				result.addError(stepField+".phase",
+					fmt.Sprintf("%s must run in the %q phase, not %q", step.Action, want, step.Phase))
+			}
+		}
+
 		// Validate action via registered ActionValidator (avoids circular import)
 		if av != nil {
 			actionResult := av.ValidateAction(step.Action, step.Params)

--- a/internal/recipe/validator.go
+++ b/internal/recipe/validator.go
@@ -497,6 +497,14 @@ func validateSteps(result *ValidationResult, r *Recipe) {
 			continue
 		}
 
+		// set_env delivers exports through the post-install phase, which the
+		// library install path never runs. Rejecting it here beats installing a
+		// library whose exports silently never appear.
+		if step.Action == "set_env" && r.IsLibrary() {
+			result.addError(stepField+".action",
+				"set_env is not supported in library recipes (libraries have no shell integration)")
+		}
+
 		// Validate action via registered ActionValidator (avoids circular import)
 		if av != nil {
 			actionResult := av.ValidateAction(step.Action, step.Params)

--- a/internal/recipe/validator_test.go
+++ b/internal/recipe/validator_test.go
@@ -1474,6 +1474,62 @@ patterns = ["lib/*.so*"]
 	}
 }
 
+// set_env is delivered by the post-install phase, which the library install
+// path never runs. Validation has to reject it rather than let a library ship
+// exports that never appear.
+func TestValidateBytes_SetEnvRejectedInLibraryRecipe(t *testing.T) {
+	recipe := `
+[metadata]
+name = "test-lib"
+type = "library"
+
+[[steps]]
+action = "install_libraries"
+patterns = ["lib/*.so*"]
+
+[[steps]]
+action = "set_env"
+vars = [{name = "TEST_LIB_HOME", value = "{install_dir}"}]
+`
+	result := ValidateBytes([]byte(recipe))
+
+	if result.Valid {
+		t.Fatal("expected set_env in a library recipe to be rejected")
+	}
+	var found bool
+	for _, e := range result.Errors {
+		if strings.Contains(e.Message, "set_env is not supported in library recipes") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected an error naming the library restriction, got: %v", result.Errors)
+	}
+}
+
+func TestValidateBytes_SetEnvAllowedInToolRecipe(t *testing.T) {
+	recipe := `
+[metadata]
+name = "test-tool"
+description = "Test tool"
+homepage = "https://example.com"
+
+[[steps]]
+action = "set_env"
+vars = [{name = "TEST_TOOL_HOME", value = "{install_dir}"}]
+
+[verify]
+command = "test -d {install_dir}"
+mode = "output"
+reason = "no binary to run"
+`
+	result := ValidateBytes([]byte(recipe))
+
+	if !result.Valid {
+		t.Errorf("expected set_env to be valid in a tool recipe, got errors: %v", result.Errors)
+	}
+}
+
 func TestValidateBytes_ApplyPatchWithURLMissingChecksum(t *testing.T) {
 	recipe := `
 [metadata]

--- a/internal/recipe/validator_test.go
+++ b/internal/recipe/validator_test.go
@@ -21,6 +21,15 @@ func (m *mockActionValidator) RegisteredNames() []string {
 	return names
 }
 
+// DefaultPhase mirrors the real registry: set_env is the one action that runs
+// somewhere other than the install phase by default.
+func (m *mockActionValidator) DefaultPhase(name string) string {
+	if name == "set_env" {
+		return "post-install"
+	}
+	return "install"
+}
+
 func (m *mockActionValidator) ValidateAction(name string, params map[string]interface{}) *ActionValidationResult {
 	result := &ActionValidationResult{}
 	if !m.actions[name] {
@@ -1504,6 +1513,66 @@ vars = [{name = "TEST_LIB_HOME", value = "{install_dir}"}]
 	}
 	if !found {
 		t.Errorf("expected an error naming the library restriction, got: %v", result.Errors)
+	}
+}
+
+// A phase override on set_env can never work -- ToolInstallDir is unset before
+// post-install -- so it has to fail at validation, not at install time.
+func TestValidateBytes_SetEnvPhaseOverrideRejected(t *testing.T) {
+	recipe := `
+[metadata]
+name = "test-tool"
+description = "Test tool"
+homepage = "https://example.com"
+
+[[steps]]
+action = "set_env"
+phase = "install"
+vars = [{name = "TEST_TOOL_HOME", value = "{install_dir}"}]
+
+[verify]
+command = "test -d {install_dir}"
+mode = "output"
+reason = "no binary to run"
+`
+	result := ValidateBytes([]byte(recipe))
+
+	if result.Valid {
+		t.Fatal("expected a phase override on set_env to be rejected")
+	}
+	var found bool
+	for _, e := range result.Errors {
+		if strings.Contains(e.Message, `set_env must run in the "post-install" phase`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected an error naming the required phase, got: %v", result.Errors)
+	}
+}
+
+// Naming the phase the action already wants is redundant but harmless.
+func TestValidateBytes_SetEnvRedundantPhaseAccepted(t *testing.T) {
+	recipe := `
+[metadata]
+name = "test-tool"
+description = "Test tool"
+homepage = "https://example.com"
+
+[[steps]]
+action = "set_env"
+phase = "post-install"
+vars = [{name = "TEST_TOOL_HOME", value = "{install_dir}"}]
+
+[verify]
+command = "test -d {install_dir}"
+mode = "output"
+reason = "no binary to run"
+`
+	result := ValidateBytes([]byte(recipe))
+
+	if !result.Valid {
+		t.Errorf("expected an explicit post-install phase to be accepted, got: %v", result.Errors)
 	}
 }
 

--- a/internal/recipe/version_validator.go
+++ b/internal/recipe/version_validator.go
@@ -70,6 +70,11 @@ type ActionValidator interface {
 	// ValidateAction checks if an action exists and validates its parameters.
 	// Returns an ActionValidationResult containing errors (fatal) and warnings (non-fatal).
 	ValidateAction(name string, params map[string]interface{}) *ActionValidationResult
+
+	// DefaultPhase returns the lifecycle phase an action runs in when a recipe
+	// step does not name one. Most actions answer "install"; an action answers
+	// otherwise when it needs state an earlier phase cannot provide.
+	DefaultPhase(name string) string
 }
 
 var (

--- a/internal/shellenv/cache.go
+++ b/internal/shellenv/cache.go
@@ -101,7 +101,13 @@ func RebuildShellCache(tsukuHome string, shell string, contentHashes ...map[stri
 		return nil
 	}
 
-	// Sort alphabetically for deterministic output
+	// Sort alphabetically. This is not only for reproducible output: the order
+	// is a contract. Files are sourced in this order, and a tool's init script
+	// often reads variables its recipe exported -- nvm.sh, for one, only honors
+	// NVM_DIR when it is already set. The set_env action relies on that by
+	// naming its files "00-env-<tool>.<shell>" so they sort ahead of the tool's
+	// own entry. Changing this ordering, or letting a tool install a name that
+	// sorts before "00-env-", breaks those recipes.
 	sort.Strings(files)
 
 	// Concatenate file contents with hash verification and error isolation.

--- a/internal/shellenv/cache_test.go
+++ b/internal/shellenv/cache_test.go
@@ -534,3 +534,39 @@ func TestRebuildShellCache_DirectoryPermissions(t *testing.T) {
 		t.Errorf("expected shell.d directory permissions 0700, got %04o", perm)
 	}
 }
+
+// The shell cache is concatenated in alphabetical order, and that order is a
+// contract, not just reproducibility: a tool's init script often reads what its
+// recipe exported. The set_env action names its files "00-env-<tool>.<shell>"
+// to sit ahead of the tool's own entry, so this test fails if the sort is
+// dropped or reversed.
+func TestRebuildShellCache_EnvExportsPrecedeToolInit(t *testing.T) {
+	tsukuHome := t.TempDir()
+	shellDDir := filepath.Join(tsukuHome, "share", "shell.d")
+	if err := os.MkdirAll(shellDDir, 0700); err != nil {
+		t.Fatalf("failed to create shell.d: %v", err)
+	}
+
+	// Written in the order that would be wrong, so the sort has to do the work.
+	writeTestFile(t, filepath.Join(shellDDir, "nvm.bash"), "# nvm init\n")
+	writeTestFile(t, filepath.Join(shellDDir, "00-env-nvm.bash"), "export NVM_DIR='/tools/nvm-1'\n")
+
+	if err := RebuildShellCache(tsukuHome, "bash"); err != nil {
+		t.Fatalf("RebuildShellCache() error = %v", err)
+	}
+
+	content, err := os.ReadFile(filepath.Join(shellDDir, ".init-cache.bash"))
+	if err != nil {
+		t.Fatalf("reading cache: %v", err)
+	}
+
+	exportAt := strings.Index(string(content), "export NVM_DIR=")
+	initAt := strings.Index(string(content), "# nvm init")
+	if exportAt < 0 || initAt < 0 {
+		t.Fatalf("cache is missing one of the entries:\n%s", content)
+	}
+	if exportAt > initAt {
+		t.Errorf("the 00-env- exports were concatenated after the tool init script; "+
+			"a tool that reads its recipe's variables at source time would miss them:\n%s", content)
+	}
+}

--- a/plugins/tsuku-recipes/skills/recipe-author/SKILL.md
+++ b/plugins/tsuku-recipes/skills/recipe-author/SKILL.md
@@ -78,7 +78,7 @@ and action-specific parameters.
 | `install_binaries` | Copy binaries to install dir; register for PATH symlinking |
 | `chmod` | Set file permissions |
 | `set_rpath` | Modify ELF RPATH for library resolution (Linux) |
-| `set_env` | Export environment variables via env.sh |
+| `set_env` | Export environment variables into the user's shell via shell.d |
 | `text_replace` | Find/replace in files |
 | `install_shell_init` | Write shell initialization scripts |
 | `install_completions` | Write shell completion scripts |

--- a/plugins/tsuku-recipes/skills/recipe-author/references/action-reference.md
+++ b/plugins/tsuku-recipes/skills/recipe-author/references/action-reference.md
@@ -415,7 +415,8 @@ Notes:
 
 - Runs in the `post-install` phase automatically, so `{install_dir}` expands to
   the tool's permanent directory (`$TSUKU_HOME/tools/{name}-{version}`) rather
-  than the staging directory.
+  than the staging directory. Do not set `phase` on the step; any other value is
+  rejected by `tsuku validate`, since the final directory is not known earlier.
 - Covers bash and zsh — the shells `$TSUKU_HOME/env` sources. fish is not
   supported because it needs `set -gx` rather than `export`.
 - The `00-env-` prefix keeps exports sorted ahead of `install_shell_init` files,

--- a/plugins/tsuku-recipes/skills/recipe-author/references/action-reference.md
+++ b/plugins/tsuku-recipes/skills/recipe-author/references/action-reference.md
@@ -396,11 +396,34 @@ Platform: Linux only.
 
 ### set_env
 
-Creates an env.sh file that tsuku sources when activating the tool.
+Exports environment variables into the user's shell. Writes
+`$TSUKU_HOME/share/shell.d/00-env-{tool}.{shell}`, which tsuku concatenates into
+the init cache that `$TSUKU_HOME/env` sources on shell startup. Removing the tool
+deletes the files again.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `vars` | map | Yes | Environment variable name-value pairs |
+| `vars` | []table | Yes | Entries of `{name = "VAR", value = "..."}` |
+
+```toml
+[[steps]]
+action = "set_env"
+vars = [{name = "JAVA_HOME", value = "{install_dir}"}]
+```
+
+Notes:
+
+- Runs in the `post-install` phase automatically, so `{install_dir}` expands to
+  the tool's permanent directory (`$TSUKU_HOME/tools/{name}-{version}`) rather
+  than the staging directory.
+- Covers bash and zsh — the shells `$TSUKU_HOME/env` sources. fish is not
+  supported because it needs `set -gx` rather than `export`.
+- The `00-env-` prefix keeps exports sorted ahead of `install_shell_init` files,
+  so a tool's init script sees the variables its recipe set. `recipes/n/nvm.toml`
+  relies on this: `nvm.sh` only honors `NVM_DIR` when it is already set.
+- Names must match `[A-Za-z_][A-Za-z0-9_]*`, and values may not contain newlines.
+  Values are single-quoted, so no shell metacharacter in a value is interpreted.
+- Skipped entirely under `--no-shell-init`.
 
 ### text_replace
 

--- a/plugins/tsuku-recipes/skills/recipe-author/references/action-reference.md
+++ b/plugins/tsuku-recipes/skills/recipe-author/references/action-reference.md
@@ -423,7 +423,21 @@ Notes:
   relies on this: `nvm.sh` only honors `NVM_DIR` when it is already set.
 - Names must match `[A-Za-z_][A-Za-z0-9_]*`, and values may not contain newlines.
   Values are single-quoted, so no shell metacharacter in a value is interpreted.
+- Several `set_env` steps in one recipe append to the same file rather than
+  overwrite, so platform-gated variants and plain multiple steps both work.
 - Skipped entirely under `--no-shell-init`.
+
+Where it does not apply:
+
+- **Library recipes** (`type = "library"`) — rejected by recipe validation.
+  Libraries are installed without a post-install phase and have no shell
+  integration.
+- **Recipes installed as a dependency of another tool** — the dependency
+  installer runs every step inline with no post-install phase, so `set_env`
+  fails the install with an explicit error rather than exporting nothing.
+- **Already-installed tools** — an install that short-circuits on "already
+  installed" runs no steps, so the exports appear on the next fresh install or
+  version upgrade. `tsuku remove <tool> && tsuku install <tool>` applies them now.
 
 ### text_replace
 

--- a/recipes/n/nvm.toml
+++ b/recipes/n/nvm.toml
@@ -6,7 +6,10 @@ version_format = "semver"
 curated = true
 # nvm is a shell function, not a compiled binary. The recipe downloads the source
 # archive, installs it to the tool directory, and wires it into shell init via
-# install_shell_init. Node.js versions managed by nvm are stored under NVM_DIR.
+# install_shell_init. Node.js versions managed by nvm are stored under NVM_DIR,
+# which set_env points at the tool directory. That export has to reach the shell
+# before nvm.sh runs: nvm.sh only honors NVM_DIR when it is already set and
+# otherwise self-locates to the directory it was sourced from.
 
 [version]
 github_repo = "nvm-sh/nvm"

--- a/testdata/golden/plans/embedded/gcc-libs/v15.2.0-linux-arch-amd64.json
+++ b/testdata/golden/plans/embedded/gcc-libs/v15.2.0-linux-arch-amd64.json
@@ -65,15 +65,15 @@
     {
       "action": "download_file",
       "params": {
-        "checksum": "606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
+        "checksum": "eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
         "dest": "gcc.tar.gz",
-        "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c"
+        "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58"
       },
       "evaluable": true,
       "deterministic": true,
-      "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
-      "checksum": "606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
-      "size": 161998997
+      "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
+      "checksum": "eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
+      "size": 161971540
     },
     {
       "action": "extract",

--- a/testdata/golden/plans/embedded/gcc-libs/v15.2.0-linux-debian-amd64.json
+++ b/testdata/golden/plans/embedded/gcc-libs/v15.2.0-linux-debian-amd64.json
@@ -65,15 +65,15 @@
     {
       "action": "download_file",
       "params": {
-        "checksum": "606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
+        "checksum": "eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
         "dest": "gcc.tar.gz",
-        "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c"
+        "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58"
       },
       "evaluable": true,
       "deterministic": true,
-      "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
-      "checksum": "606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
-      "size": 161998997
+      "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
+      "checksum": "eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
+      "size": 161971540
     },
     {
       "action": "extract",

--- a/testdata/golden/plans/embedded/gcc-libs/v15.2.0-linux-rhel-amd64.json
+++ b/testdata/golden/plans/embedded/gcc-libs/v15.2.0-linux-rhel-amd64.json
@@ -65,15 +65,15 @@
     {
       "action": "download_file",
       "params": {
-        "checksum": "606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
+        "checksum": "eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
         "dest": "gcc.tar.gz",
-        "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c"
+        "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58"
       },
       "evaluable": true,
       "deterministic": true,
-      "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
-      "checksum": "606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
-      "size": 161998997
+      "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
+      "checksum": "eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
+      "size": 161971540
     },
     {
       "action": "extract",

--- a/testdata/golden/plans/embedded/gcc-libs/v15.2.0-linux-suse-amd64.json
+++ b/testdata/golden/plans/embedded/gcc-libs/v15.2.0-linux-suse-amd64.json
@@ -65,15 +65,15 @@
     {
       "action": "download_file",
       "params": {
-        "checksum": "606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
+        "checksum": "eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
         "dest": "gcc.tar.gz",
-        "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c"
+        "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58"
       },
       "evaluable": true,
       "deterministic": true,
-      "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
-      "checksum": "606c8f502852d586f85fba5754e255fa8bf8b81d371c1f75cf7edae19d852f0c",
-      "size": 161998997
+      "url": "https://ghcr.io/v2/homebrew/core/gcc/blobs/sha256:eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
+      "checksum": "eebab9738ff2c231ec19c5da5725a830d89322914f8aa84d58728c6b45f84a58",
+      "size": 161971540
     },
     {
       "action": "extract",


### PR DESCRIPTION
Rewrite `SetEnvAction.Execute` to write `$TSUKU_HOME/share/shell.d/00-env-{tool}.{shell}` instead of an `env.sh` inside the tool directory, and expand `{install_dir}` from `ToolInstallDir` rather than the staging `InstallDir`. `RebuildShellCache` already concatenates `share/shell.d` into the init cache that `$TSUKU_HOME/env` sources, so exports now reach the user's shell. Each file is recorded as a `CleanupAction` with a content hash, so removing a tool removes its exports.

Add an optional `PhaseDeclarer` interface to `internal/actions`, implemented by `SetEnvAction` to return `post-install`. `executor.StepPhase` consults it through the action registry when a recipe names no phase. `ToolInstallDir` is only populated between `ExecutePlan` and `ExecutePhase("post-install")`, so resolving through the registry at execution time rather than at plan generation keeps stored plans routing correctly.

Validate and quote what reaches the file: names must match `[A-Za-z_][A-Za-z0-9_]*`, values may not contain newlines, and values are single-quoted with POSIX escaping. Values are checked after placeholder substitution. Reject `set_env` in library recipes and reject a `phase` override the action cannot honor, both in `internal/recipe/validator.go`, via a new `DefaultPhase` method on the `ActionValidator` interface. Reject an `install_shell_init` target claiming the `00-env-` prefix, which would sort ahead of a recipe's exports and invert the load order the prefix exists to guarantee.

Document the alphabetical concatenation in `shellenv/cache.go` as a load-bearing contract rather than a reproducibility detail, and cover it with a test in that package. Update `recipes/n/nvm.toml`'s comment and the `tsuku-recipe-author` skill, whose action reference described the `env.sh` behavior that never worked.

---

## What This Fixes

`set_env` had no effect on any process. Two defects were visible: `internal/actions/set_env.go` wrote `env.sh` into the tool's install directory and nothing in the codebase ever read it, and `{install_dir}` expanded from `ctx.InstallDir`, the temporary staging directory that is deleted once the install finishes.

A third defect made fixing those two insufficient. `ToolInstallDir` is only set between `ExecutePlan` and `ExecutePhase("post-install")`, so reading the correct field during the install phase would have produced `export NVM_DIR=` — a different silent failure. Hence the phase change.

`recipes/n/nvm.toml` was the only affected recipe, and visibly so: `nvm.sh` self-locates when `NVM_DIR` is unset, so nvm was writing Node installs into `$TSUKU_HOME/share/shell.d` alongside the shell init scripts. It now resolves to `$TSUKU_HOME/tools/nvm-<version>` as the recipe always intended.

## Why keep the action rather than remove it

Removal was the stated alternative. Keeping it won because `set_env` is a documented public authoring surface, and because no other action can export an arbitrary variable — `install_shell_init`'s `source_file` needs a file the tool already ships, and its `source_command` is restricted to binaries inside the tool's install directory. Removal would push nvm onto `run_command`, which is classified non-evaluable and would cost that recipe its deterministic plan.

## Why the filename has a numeric prefix

The shell cache concatenates `share/shell.d` alphabetically, and a tool's init script often reads what its recipe exported. `nvm.sh` only honors `NVM_DIR` when it is already set. The `00-env-` prefix keeps exports ahead of every plausible init filename, following the `profile.d` convention.

## Changes

- `internal/actions/set_env.go`: write to shell.d, expand from `ToolInstallDir`, validate and quote, declare `post-install`, append across multiple steps
- `internal/actions/action.go`: add the `PhaseDeclarer` interface and `DefaultPhase` lookup
- `internal/actions/shell_init.go`: extract the cleanup-path formula into named helpers; reject a target claiming the reserved prefix
- `internal/executor/executor.go`: `StepPhase` resolves an unnamed phase through the action registry
- `internal/recipe/validator.go`: reject `set_env` in library recipes and reject an unhonorable `phase` override
- `internal/shellenv/cache.go`: document the sort as a contract
- `recipes/n/nvm.toml`, `plugins/tsuku-recipes/skills/recipe-author/`: correct the description of the action
- `testdata/golden/plans/embedded/gcc-libs/`: unrelated refresh, see below

## Example

Before, on a clean install of nvm 0.40.6:

```
$ cat $TSUKU_HOME/tools/nvm-0.40.6/env.sh
export NVM_DIR=/tmp/action-validator-4016723165/.install

$ bash -c '. "$TSUKU_HOME/env"; echo $NVM_DIR'
/home/user/.tsuku/share/shell.d
```

After:

```
$ bash -c '. "$TSUKU_HOME/env"; echo $NVM_DIR'
/home/user/.tsuku/tools/nvm-0.40.6

$ bash -c '. "$TSUKU_HOME/env"; nvm_version_dir new'
/home/user/.tsuku/tools/nvm-0.40.6/versions/node
```

No `env.sh` is written, and no staging path survives anywhere under `tools/`.

## Where set_env does not apply

Each of these fails loudly or is rejected at authoring time. None silently does nothing.

- **Library recipes** — rejected by recipe validation. The library install path calls `ExecutePlan` and never runs a post-install phase.
- **A recipe installed as another tool's dependency** — the dependency installer runs every step inline with no phases, so the action errors with an explicit message.
- **A `phase` override other than `post-install`** — rejected by `tsuku validate`.
- **`--no-shell-init`** — skipped entirely, writing nothing and recording no cleanup.
- **An install that short-circuits on "already installed"** — runs no steps, so an existing install picks up its exports on the next fresh install or upgrade. Pre-existing installer behavior that affects `install_shell_init` identically.

## Test Plan

The previous test passed precisely because it checked that `env.sh` had been written and never checked whether anything read it. That shape is what let this survive, so it is gone.

- [x] `TestSetEnvAction_ReachesUserShell` sources `$TSUKU_HOME/env` in a real bash subshell and reads the variable back. The tool init script it installs records what it saw *at source time*, since checking only the final value passes either way — a later export simply overwrites the self-located one.
- [x] `TestExecutePlan_SetEnvRunsInPostInstall` drives an unphased plan step through `ExecutePlan` → `SetToolInstallDir` → `ExecutePhase`. Calling the action directly would pass even if nothing routed a real install through it.
- [x] `TestRebuildShellCache_EnvExportsPrecedeToolInit` guards the ordering in the package that does the sorting.
- [x] Mutation-tested: reversing the sort in `RebuildShellCache`, changing `DefaultPhase`, and expanding from the staging directory each fail the test meant to catch them.
- [x] Manual verification on a real network install of nvm 0.40.6, with `main` built alongside as a baseline reproducing the original bug: install, remove, `--no-shell-init`, zsh, `tsuku doctor`, and shell metacharacters round-tripping without executing.
- [x] `go test ./...` (54 packages, including the golangci-lint run), `go vet`, `gofmt`, `tsuku validate recipes/n/nvm.toml`

## Note on the gcc-libs golden files

Four files under `testdata/golden/plans/embedded/gcc-libs/` are in this diff and are unrelated to `set_env` — that recipe has no such step. Homebrew republished the gcc bottle, changing the blob digest and size upstream.

The golden validation only runs on `pull_request`, so the drift accumulated invisibly on `main` and failed the next PR touching `internal/`. Building this branch and the merge base side by side produces byte-identical plans, confirming the change is upstream rather than mine. Regenerating it here unblocks CI; it is isolated in its own commit.

Worth considering separately: running that validation on pushes to `main` or on a schedule would surface bottle drift where it happens instead of billing it to an unrelated PR.

## Known issues left alone

- Removing the newest of several installed versions leaves the export pointing at the directory just deleted, and `doctor --fix` cannot repair it. A pre-existing refcount bug in `remove`; `main` shows the same hash mismatch for `nvm.bash`/`nvm.zsh`. The consequence is newly more visible because the stale content is now a filesystem path rather than self-contained script text.
- `tsuku install --plan` writes shell.d files but never calls `RecordCleanup`, so files installed that way are orphaned on remove. Pre-existing and identical for `install_shell_init`.

Fixes #2439
