### PR TITLE
fix(recipes): move zig off the unreachable hryx mirror

### DIFF
--- a/internal/recipe/recipes/zig.toml
+++ b/internal/recipe/recipes/zig.toml
@@ -8,23 +8,39 @@ supported_libc = ["glibc", "musl"]
 [version]
 github_repo = "ziglang/zig"
 
-# Use zigmirror.hryx.net (community mirror on the upstream-published list at
-# ziglang.org/download/community-mirrors.json) instead of ziglang.org/download
-# because the canonical CDN has been intermittently unreachable in CI (#2384).
+# Download source: ziglang.freetls.fastly.net, a community mirror on the
+# upstream-published list at ziglang.org/download/community-mirrors.txt.
+#
+# Source history — two outages, both from the same cause:
+#   ziglang.org        -> #2384: intermittently unreachable from CI
+#   zigmirror.hryx.net -> #2441: unreachable entirely
+# Both resolve to a single address (ziglang.org to one Hetzner address, hryx to
+# one address), so one box or one route going bad took plan generation down
+# repo-wide. Fastly answers from four anycast addresses, which is why it was
+# picked over the remaining community mirrors — pkg.hexops.org, zig.linus.dev,
+# zig.mirror.mschae23.de and zig.squirl.dev are all single-address and share the
+# topology that already failed twice. It carries the same archives as
+# ziglang.org but not its network path, so it does not re-create #2384.
 #
 # GitHub Releases is not a viable alternative: the ziglang/zig project only
 # publishes zig-bootstrap-<version>.tar.xz source archives on GitHub, not the
 # per-platform binaries this recipe needs (verified for 0.14.1 and 0.15.1 via
 # `gh release view <ver> -R ziglang/zig`).
 #
-# Mirror-selection heuristic for future maintainers if hryx becomes unreliable:
-# pick the next entry from community-mirrors.json that (a) is HTTPS, (b) is
-# reachable from GitHub-hosted CI runners, and (c) serves byte-identical
-# archives — the upstream MIRRORS.md spec requires this, and tsuku's pinned
-# checksums will catch any divergence at install time.
+# Mirror-selection heuristic for future maintainers if Fastly becomes
+# unreliable: pick an entry from community-mirrors.txt that (a) is HTTPS,
+# (b) resolves to several addresses rather than one — the property both failed
+# sources lacked, (c) is reachable from GitHub-hosted CI runners, not merely
+# from a developer machine, and (d) serves byte-identical archives. The upstream
+# MIRRORS.md spec requires (d), and tsuku's pinned checksums catch any
+# divergence at install time. Verify (c) by pushing a branch and letting
+# Validate Embedded Dependencies run; a local probe does not establish it.
+#
+# This is still one URL. #2443 tracks giving download_archive a real fallback
+# list so the next outage is not another recipe edit.
 [[steps]]
 action = "download_archive"
-url = "https://zigmirror.hryx.net/zig/zig-{arch}-{os}-{version}.tar.xz"
+url = "https://ziglang.freetls.fastly.net/zig-{arch}-{os}-{version}.tar.xz"
 strip_dirs = 1
 binaries = ["zig"]
 install_mode = "directory"

--- a/internal/recipe/recipes/zig.toml
+++ b/internal/recipe/recipes/zig.toml
@@ -28,23 +28,29 @@ github_repo = "ziglang/zig"
 # sits in front of the bytes; check the CNAME chain, not the address count.
 #
 # What this source does and does not fix — read this before picking the next
-# one. ziglang.freetls.fastly.net is Fastly fronting the SAME origin as
-# ziglang.org: identical ETag and Last-Modified, same nginx, one-hour TTL with
-# pull-through revalidation. It is not an independent copy. What it changes is
+# one. ziglang.freetls.fastly.net serves ziglang.org's own bytes rather than an
+# independent copy: both return the same ETag and Last-Modified from the same
+# nginx, with a one-hour TTL and pull-through revalidation. So what changes is
 # the path CI takes to the bytes — an edge cache at a nearby POP instead of one
-# long trip to one Hetzner box. If #2384 was a route problem between GitHub
-# runners and Hetzner, that is fixed. If the origin itself was down, this buys
-# an hour of cache per POP and then fails too. Both readings fit #2384's
-# symptoms, so treat the origin exposure as still open.
+# long trip to one Hetzner box — not the origin behind them. If #2384 was a
+# route problem between GitHub runners and Hetzner, that is fixed. If the
+# origin itself was down, this buys at least an hour of cache per POP and then
+# fails too. Both readings fit #2384's symptoms, so treat the origin exposure
+# as still open.
 #
 # Triage for whoever is here next, because the two cases need opposite moves:
 #   - Fastly timing out / unreachable at the edge -> a path problem. Another
 #     CDN-fronted source may help.
 #   - Fastly returning 5xx or revalidation errors -> suspect the shared origin.
 #     Switch to a mirror that stores its OWN copies rather than another
-#     ziglang.org alias. zig.squirl.dev is the strongest such candidate: it is
-#     both independently operated and CDN-backed. It has not been verified from
-#     CI runners, so verify before trusting it.
+#     ziglang.org alias. Test for that the same way this note was written:
+#     compare Last-Modified against ziglang.org's. An independent mirror
+#     carries its own mtime; an alias reproduces ziglang.org's exactly.
+#     zig.squirl.dev is the strongest such candidate — independently operated
+#     and CDN-backed (BunnyCDN). It was not taken in #2441 only because
+#     reachability from GitHub runners was unproven for it and proven for
+#     Fastly, and that is the property that failed both previous times. Verify
+#     it from CI before trusting it.
 #
 # GitHub Releases is not a viable alternative: the ziglang/zig project only
 # publishes zig-bootstrap-<version>.tar.xz source archives on GitHub, not the

--- a/internal/recipe/recipes/zig.toml
+++ b/internal/recipe/recipes/zig.toml
@@ -38,9 +38,14 @@ github_repo = "ziglang/zig"
 # fails too. Both readings fit #2384's symptoms, so treat the origin exposure
 # as still open.
 #
-# Triage for whoever is here next, because the two cases need opposite moves:
+# Triage for whoever is here next, because the cases need different moves:
 #   - Fastly timing out / unreachable at the edge -> a path problem. Another
 #     CDN-fronted source may help.
+#   - A 404 on an older version while current ones still serve -> retention,
+#     not an outage. Mirrors are not obliged to keep old releases, and this
+#     recipe needs whatever the goldens pin (0.14.1 at time of writing) as
+#     well as current. Check the old version explicitly before switching to
+#     any candidate; ziglang.org itself keeps the full archive.
 #   - Fastly returning 5xx or revalidation errors -> suspect the shared origin.
 #     Switch to a mirror that stores its OWN copies rather than another
 #     ziglang.org alias. Test for that the same way this note was written:

--- a/internal/recipe/recipes/zig.toml
+++ b/internal/recipe/recipes/zig.toml
@@ -8,71 +8,59 @@ supported_libc = ["glibc", "musl"]
 [version]
 github_repo = "ziglang/zig"
 
-# Download source: ziglang.freetls.fastly.net, a community mirror on the
-# upstream-published list at ziglang.org/download/community-mirrors.txt.
+# Download source: ziglang.freetls.fastly.net. The upstream list of community
+# mirrors lives at ziglang.org/download/community-mirrors.txt — re-read it
+# rather than trusting any list written here.
 #
-# Source history — two outages:
-#   ziglang.org        -> #2384: intermittently unreachable from CI
-#   zigmirror.hryx.net -> #2441: unreachable entirely
-# Both were a single origin host with nothing cached in front of it, so one
-# machine or one route going bad took plan generation down repo-wide —
+# Source history. ziglang.org, intermittently unreachable from CI (#2384) ->
+# zigmirror.hryx.net, unreachable entirely (#2441) -> here. Both predecessors
+# were a single origin host with nothing cached in front of them. Note that
 # download_archive pre-downloads to compute a checksum, so an unreachable
-# source breaks `tsuku eval`, not just install.
+# source breaks `tsuku eval`, not just install, which is why one dead host
+# turns CI red across every recipe that reaches zig.
 #
-# Do NOT rank candidates by how many addresses they resolve to. That test looks
-# right and is not: ziglang.org is dual-stack (65.109.105.178 and
-# 2a01:4f9:3051:4bd2::2) and still one box, while zig.squirl.dev answers with a
-# single address per family and is a BunnyCDN pull zone (CNAME
-# squirl-zig.b-cdn.net) serving from many POPs. Geo-DNS hands back the local
-# POP, so a real CDN can look single-homed. What matters is whether a CDN edge
-# sits in front of the bytes; check the CNAME chain, not the address count.
-#
-# What this source does and does not fix — read this before picking the next
-# one. ziglang.freetls.fastly.net serves ziglang.org's own bytes rather than an
-# independent copy: both return the same ETag and Last-Modified from the same
-# nginx, with a one-hour TTL and pull-through revalidation. So what changes is
-# the path CI takes to the bytes — an edge cache at a nearby POP instead of one
-# long trip to one Hetzner box — not the origin behind them. If #2384 was a
-# route problem between GitHub runners and Hetzner, that is fixed. If the
-# origin itself was down, this buys at least an hour of cache per POP and then
-# fails too. Both readings fit #2384's symptoms, so treat the origin exposure
-# as still open.
-#
-# Triage for whoever is here next, because the cases need different moves:
-#   - Fastly timing out / unreachable at the edge -> a path problem. Another
+# TRIAGE — match the symptom before switching anything:
+#   - Timeouts / unreachable at the edge -> a path problem. Another
 #     CDN-fronted source may help.
-#   - A 404 on an older version while current ones still serve -> retention,
-#     not an outage. Mirrors are not obliged to keep old releases, and this
-#     recipe needs whatever the goldens pin (0.14.1 at time of writing) as
-#     well as current. Check the old version explicitly before switching to
-#     any candidate; ziglang.org itself keeps the full archive.
-#   - Fastly returning 5xx or revalidation errors -> suspect the shared origin.
-#     Switch to a mirror that stores its OWN copies rather than another
-#     ziglang.org alias. Test for that the same way this note was written:
-#     compare Last-Modified against ziglang.org's. An independent mirror
-#     carries its own mtime; an alias reproduces ziglang.org's exactly.
-#     zig.squirl.dev is the strongest such candidate — independently operated
-#     and CDN-backed (BunnyCDN). It was not taken in #2441 only because
-#     reachability from GitHub runners was unproven for it and proven for
-#     Fastly, and that is the property that failed both previous times. Verify
-#     it from CI before trusting it.
+#   - 5xx or revalidation errors -> suspect the origin. This mirror is Fastly
+#     in front of ziglang.org's own bytes, not an independent copy: both
+#     return the same ETag and Last-Modified from the same nginx, with a
+#     one-hour TTL and pull-through revalidation. So an origin outage is
+#     survived for about a cache TTL per POP and no longer. Switch to a mirror
+#     that stores its OWN copies — test for that by comparing Last-Modified
+#     against ziglang.org's, since an independent mirror carries its own mtime
+#     and an alias reproduces ziglang.org's exactly. zig.squirl.dev is the
+#     strongest such candidate, independently operated and CDN-backed
+#     (BunnyCDN, at time of writing). It was not taken in #2441 only because
+#     reachability from GitHub runners was proven for Fastly and unproven for
+#     it.
+#   - 404 on an older version while current ones still serve -> retention, not
+#     an outage. Mirrors need not keep old releases.
 #
-# GitHub Releases is not a viable alternative: the ziglang/zig project only
-# publishes zig-bootstrap-<version>.tar.xz source archives on GitHub, not the
-# per-platform binaries this recipe needs (verified for 0.14.1 and 0.15.1 via
+# Picking a replacement. Require HTTPS, byte-identical archives (the upstream
+# MIRRORS.md spec mandates this and tsuku's pinned checksums catch divergence
+# at install time), and reachability from GitHub-hosted CI runners. Prove that
+# last one by pushing a branch and letting Validate Embedded Dependencies run
+# — a local probe does not establish it, and skipping that step is what
+# produced #2441. Prefer a CDN edge over a bare origin host as the tiebreak,
+# but do not use DNS address count to judge that: ziglang.org is dual-stack
+# and still one box, while a BunnyCDN pull zone answers with one address per
+# family via geo-DNS. Check the CNAME chain instead.
+#
+# A swap is not a one-file change. zig is an implicit install-time dependency
+# of cmake_build/configure_make/meson_build, so its URL is baked into nine
+# goldens under testdata/golden/plans/embedded/: the three zig ones and six
+# ninja ones. They pin more than one zig version — 0.14.1 and 0.15.1 at time
+# of writing — so verify every version a candidate must serve, not just
+# current. `grep -rl zig- testdata/golden/plans/embedded/` finds the current
+# set. Regenerate the zig goldens; the ninja ones need a URL-only edit,
+# because ninja sits on the #988 code-validation exclusion list and a full
+# regeneration would sweep in unrelated format drift.
+#
+# GitHub Releases is not an option: ziglang/zig publishes only
+# zig-bootstrap-<version>.tar.xz source archives there, never the per-platform
+# binaries this recipe needs (verified for 0.14.1 and 0.15.1 via
 # `gh release view <ver> -R ziglang/zig`).
-#
-# Selection heuristic: re-read community-mirrors.txt rather than trusting any
-# list written here — it had 16 entries when this was written and it changes.
-# Prefer a source that (a) is HTTPS, (b) serves byte-identical archives — the
-# upstream MIRRORS.md spec requires it, and tsuku's pinned checksums catch
-# divergence at install time, and (c) is reachable from GitHub-hosted CI
-# runners. Verify (c) by pushing a branch and letting Validate Embedded
-# Dependencies run; a local probe does not establish it, and getting that wrong
-# is what produced #2441. Among sources that qualify, prefer a CDN edge over a
-# bare origin host, and prefer an independent operator over another ziglang.org
-# alias when the origin is the suspect. If nothing better qualifies, take the
-# most reachable candidate as a stopgap — the real fix is #2443.
 #
 # This is still one URL. #2443 tracks giving download_archive a fallback list
 # so the next outage is not another recipe edit.

--- a/internal/recipe/recipes/zig.toml
+++ b/internal/recipe/recipes/zig.toml
@@ -11,33 +11,60 @@ github_repo = "ziglang/zig"
 # Download source: ziglang.freetls.fastly.net, a community mirror on the
 # upstream-published list at ziglang.org/download/community-mirrors.txt.
 #
-# Source history — two outages, both from the same cause:
+# Source history — two outages:
 #   ziglang.org        -> #2384: intermittently unreachable from CI
 #   zigmirror.hryx.net -> #2441: unreachable entirely
-# Both resolve to a single address (ziglang.org to one Hetzner address, hryx to
-# one address), so one box or one route going bad took plan generation down
-# repo-wide. Fastly answers from four anycast addresses, which is why it was
-# picked over the remaining community mirrors — pkg.hexops.org, zig.linus.dev,
-# zig.mirror.mschae23.de and zig.squirl.dev are all single-address and share the
-# topology that already failed twice. It carries the same archives as
-# ziglang.org but not its network path, so it does not re-create #2384.
+# Both were a single origin host with nothing cached in front of it, so one
+# machine or one route going bad took plan generation down repo-wide —
+# download_archive pre-downloads to compute a checksum, so an unreachable
+# source breaks `tsuku eval`, not just install.
+#
+# Do NOT rank candidates by how many addresses they resolve to. That test looks
+# right and is not: ziglang.org is dual-stack (65.109.105.178 and
+# 2a01:4f9:3051:4bd2::2) and still one box, while zig.squirl.dev answers with a
+# single address per family and is a BunnyCDN pull zone (CNAME
+# squirl-zig.b-cdn.net) serving from many POPs. Geo-DNS hands back the local
+# POP, so a real CDN can look single-homed. What matters is whether a CDN edge
+# sits in front of the bytes; check the CNAME chain, not the address count.
+#
+# What this source does and does not fix — read this before picking the next
+# one. ziglang.freetls.fastly.net is Fastly fronting the SAME origin as
+# ziglang.org: identical ETag and Last-Modified, same nginx, one-hour TTL with
+# pull-through revalidation. It is not an independent copy. What it changes is
+# the path CI takes to the bytes — an edge cache at a nearby POP instead of one
+# long trip to one Hetzner box. If #2384 was a route problem between GitHub
+# runners and Hetzner, that is fixed. If the origin itself was down, this buys
+# an hour of cache per POP and then fails too. Both readings fit #2384's
+# symptoms, so treat the origin exposure as still open.
+#
+# Triage for whoever is here next, because the two cases need opposite moves:
+#   - Fastly timing out / unreachable at the edge -> a path problem. Another
+#     CDN-fronted source may help.
+#   - Fastly returning 5xx or revalidation errors -> suspect the shared origin.
+#     Switch to a mirror that stores its OWN copies rather than another
+#     ziglang.org alias. zig.squirl.dev is the strongest such candidate: it is
+#     both independently operated and CDN-backed. It has not been verified from
+#     CI runners, so verify before trusting it.
 #
 # GitHub Releases is not a viable alternative: the ziglang/zig project only
 # publishes zig-bootstrap-<version>.tar.xz source archives on GitHub, not the
 # per-platform binaries this recipe needs (verified for 0.14.1 and 0.15.1 via
 # `gh release view <ver> -R ziglang/zig`).
 #
-# Mirror-selection heuristic for future maintainers if Fastly becomes
-# unreliable: pick an entry from community-mirrors.txt that (a) is HTTPS,
-# (b) resolves to several addresses rather than one — the property both failed
-# sources lacked, (c) is reachable from GitHub-hosted CI runners, not merely
-# from a developer machine, and (d) serves byte-identical archives. The upstream
-# MIRRORS.md spec requires (d), and tsuku's pinned checksums catch any
-# divergence at install time. Verify (c) by pushing a branch and letting
-# Validate Embedded Dependencies run; a local probe does not establish it.
+# Selection heuristic: re-read community-mirrors.txt rather than trusting any
+# list written here — it had 16 entries when this was written and it changes.
+# Prefer a source that (a) is HTTPS, (b) serves byte-identical archives — the
+# upstream MIRRORS.md spec requires it, and tsuku's pinned checksums catch
+# divergence at install time, and (c) is reachable from GitHub-hosted CI
+# runners. Verify (c) by pushing a branch and letting Validate Embedded
+# Dependencies run; a local probe does not establish it, and getting that wrong
+# is what produced #2441. Among sources that qualify, prefer a CDN edge over a
+# bare origin host, and prefer an independent operator over another ziglang.org
+# alias when the origin is the suspect. If nothing better qualifies, take the
+# most reachable candidate as a stopgap — the real fix is #2443.
 #
-# This is still one URL. #2443 tracks giving download_archive a real fallback
-# list so the next outage is not another recipe edit.
+# This is still one URL. #2443 tracks giving download_archive a fallback list
+# so the next outage is not another recipe edit.
 [[steps]]
 action = "download_archive"
 url = "https://ziglang.freetls.fastly.net/zig-{arch}-{os}-{version}.tar.xz"

--- a/testdata/golden/plans/embedded/ninja/v1.13.2-darwin-amd64.json
+++ b/testdata/golden/plans/embedded/ninja/v1.13.2-darwin-amd64.json
@@ -171,11 +171,11 @@
             "checksum": "9919392e0287cccc106dfbcbb46c7c1c3fa05d919567bb58d7eb16bca4116184",
             "checksum_algo": "sha256",
             "dest": "zig-x86_64-macos-0.15.1.tar.xz",
-            "url": "https://zigmirror.hryx.net/zig/zig-x86_64-macos-0.15.1.tar.xz"
+            "url": "https://ziglang.freetls.fastly.net/zig-x86_64-macos-0.15.1.tar.xz"
           },
           "evaluable": true,
           "deterministic": true,
-          "url": "https://zigmirror.hryx.net/zig/zig-x86_64-macos-0.15.1.tar.xz",
+          "url": "https://ziglang.freetls.fastly.net/zig-x86_64-macos-0.15.1.tar.xz",
           "checksum": "9919392e0287cccc106dfbcbb46c7c1c3fa05d919567bb58d7eb16bca4116184",
           "size": 55791880
         },

--- a/testdata/golden/plans/embedded/ninja/v1.13.2-darwin-arm64.json
+++ b/testdata/golden/plans/embedded/ninja/v1.13.2-darwin-arm64.json
@@ -171,11 +171,11 @@
             "checksum": "c4bd624d901c1268f2deb9d8eb2d86a2f8b97bafa3f118025344242da2c54d7b",
             "checksum_algo": "sha256",
             "dest": "zig-aarch64-macos-0.15.1.tar.xz",
-            "url": "https://zigmirror.hryx.net/zig/zig-aarch64-macos-0.15.1.tar.xz"
+            "url": "https://ziglang.freetls.fastly.net/zig-aarch64-macos-0.15.1.tar.xz"
           },
           "evaluable": true,
           "deterministic": true,
-          "url": "https://zigmirror.hryx.net/zig/zig-aarch64-macos-0.15.1.tar.xz",
+          "url": "https://ziglang.freetls.fastly.net/zig-aarch64-macos-0.15.1.tar.xz",
           "checksum": "c4bd624d901c1268f2deb9d8eb2d86a2f8b97bafa3f118025344242da2c54d7b",
           "size": 50644996
         },

--- a/testdata/golden/plans/embedded/ninja/v1.13.2-linux-arch-amd64.json
+++ b/testdata/golden/plans/embedded/ninja/v1.13.2-linux-arch-amd64.json
@@ -230,11 +230,11 @@
             "checksum": "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05",
             "checksum_algo": "sha256",
             "dest": "zig-x86_64-linux-0.15.1.tar.xz",
-            "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.15.1.tar.xz"
+            "url": "https://ziglang.freetls.fastly.net/zig-x86_64-linux-0.15.1.tar.xz"
           },
           "evaluable": true,
           "deterministic": true,
-          "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.15.1.tar.xz",
+          "url": "https://ziglang.freetls.fastly.net/zig-x86_64-linux-0.15.1.tar.xz",
           "checksum": "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05",
           "size": 53734456
         },

--- a/testdata/golden/plans/embedded/ninja/v1.13.2-linux-debian-amd64.json
+++ b/testdata/golden/plans/embedded/ninja/v1.13.2-linux-debian-amd64.json
@@ -230,11 +230,11 @@
             "checksum": "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05",
             "checksum_algo": "sha256",
             "dest": "zig-x86_64-linux-0.15.1.tar.xz",
-            "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.15.1.tar.xz"
+            "url": "https://ziglang.freetls.fastly.net/zig-x86_64-linux-0.15.1.tar.xz"
           },
           "evaluable": true,
           "deterministic": true,
-          "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.15.1.tar.xz",
+          "url": "https://ziglang.freetls.fastly.net/zig-x86_64-linux-0.15.1.tar.xz",
           "checksum": "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05",
           "size": 53734456
         },

--- a/testdata/golden/plans/embedded/ninja/v1.13.2-linux-rhel-amd64.json
+++ b/testdata/golden/plans/embedded/ninja/v1.13.2-linux-rhel-amd64.json
@@ -230,11 +230,11 @@
             "checksum": "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05",
             "checksum_algo": "sha256",
             "dest": "zig-x86_64-linux-0.15.1.tar.xz",
-            "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.15.1.tar.xz"
+            "url": "https://ziglang.freetls.fastly.net/zig-x86_64-linux-0.15.1.tar.xz"
           },
           "evaluable": true,
           "deterministic": true,
-          "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.15.1.tar.xz",
+          "url": "https://ziglang.freetls.fastly.net/zig-x86_64-linux-0.15.1.tar.xz",
           "checksum": "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05",
           "size": 53734456
         },

--- a/testdata/golden/plans/embedded/ninja/v1.13.2-linux-suse-amd64.json
+++ b/testdata/golden/plans/embedded/ninja/v1.13.2-linux-suse-amd64.json
@@ -230,11 +230,11 @@
             "checksum": "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05",
             "checksum_algo": "sha256",
             "dest": "zig-x86_64-linux-0.15.1.tar.xz",
-            "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.15.1.tar.xz"
+            "url": "https://ziglang.freetls.fastly.net/zig-x86_64-linux-0.15.1.tar.xz"
           },
           "evaluable": true,
           "deterministic": true,
-          "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.15.1.tar.xz",
+          "url": "https://ziglang.freetls.fastly.net/zig-x86_64-linux-0.15.1.tar.xz",
           "checksum": "c61c5da6edeea14ca51ecd5e4520c6f4189ef5250383db33d01848293bfafe05",
           "size": 53734456
         },

--- a/testdata/golden/plans/embedded/zig/v0.14.1-darwin-amd64.json
+++ b/testdata/golden/plans/embedded/zig/v0.14.1-darwin-amd64.json
@@ -14,11 +14,11 @@
         "checksum": "b0f8bdfb9035783db58dd6c19d7dea89892acc3814421853e5752fe4573e5f43",
         "checksum_algo": "sha256",
         "dest": "zig-x86_64-macos-0.14.1.tar.xz",
-        "url": "https://zigmirror.hryx.net/zig/zig-x86_64-macos-0.14.1.tar.xz"
+        "url": "https://ziglang.freetls.fastly.net/zig-x86_64-macos-0.14.1.tar.xz"
       },
       "evaluable": true,
       "deterministic": true,
-      "url": "https://zigmirror.hryx.net/zig/zig-x86_64-macos-0.14.1.tar.xz",
+      "url": "https://ziglang.freetls.fastly.net/zig-x86_64-macos-0.14.1.tar.xz",
       "checksum": "b0f8bdfb9035783db58dd6c19d7dea89892acc3814421853e5752fe4573e5f43",
       "size": 51044512
     },

--- a/testdata/golden/plans/embedded/zig/v0.14.1-darwin-arm64.json
+++ b/testdata/golden/plans/embedded/zig/v0.14.1-darwin-arm64.json
@@ -14,11 +14,11 @@
         "checksum": "39f3dc5e79c22088ce878edc821dedb4ca5a1cd9f5ef915e9b3cc3053e8faefa",
         "checksum_algo": "sha256",
         "dest": "zig-aarch64-macos-0.14.1.tar.xz",
-        "url": "https://zigmirror.hryx.net/zig/zig-aarch64-macos-0.14.1.tar.xz"
+        "url": "https://ziglang.freetls.fastly.net/zig-aarch64-macos-0.14.1.tar.xz"
       },
       "evaluable": true,
       "deterministic": true,
-      "url": "https://zigmirror.hryx.net/zig/zig-aarch64-macos-0.14.1.tar.xz",
+      "url": "https://ziglang.freetls.fastly.net/zig-aarch64-macos-0.14.1.tar.xz",
       "checksum": "39f3dc5e79c22088ce878edc821dedb4ca5a1cd9f5ef915e9b3cc3053e8faefa",
       "size": 45903552
     },

--- a/testdata/golden/plans/embedded/zig/v0.14.1-linux-amd64.json
+++ b/testdata/golden/plans/embedded/zig/v0.14.1-linux-amd64.json
@@ -14,11 +14,11 @@
         "checksum": "24aeeec8af16c381934a6cd7d95c807a8cb2cf7df9fa40d359aa884195c4716c",
         "checksum_algo": "sha256",
         "dest": "zig-x86_64-linux-0.14.1.tar.xz",
-        "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.14.1.tar.xz"
+        "url": "https://ziglang.freetls.fastly.net/zig-x86_64-linux-0.14.1.tar.xz"
       },
       "evaluable": true,
       "deterministic": true,
-      "url": "https://zigmirror.hryx.net/zig/zig-x86_64-linux-0.14.1.tar.xz",
+      "url": "https://ziglang.freetls.fastly.net/zig-x86_64-linux-0.14.1.tar.xz",
       "checksum": "24aeeec8af16c381934a6cd7d95c807a8cb2cf7df9fa40d359aa884195c4716c",
       "size": 49086504
     },


### PR DESCRIPTION
Point `internal/recipe/recipes/zig.toml` at `ziglang.freetls.fastly.net` instead of `zigmirror.hryx.net`, which is unreachable. Because `download_archive` pre-downloads the archive to compute a checksum, that host failing breaks **plan generation**, not install, so every recipe whose dependency graph reaches zig fails to plan and `Validate Embedded Dependencies` goes red on every PR touching `recipes/`.

Both previously chosen sources were a single origin host with nothing cached in front of it, and each failed the same way: one machine or one route going bad took plan generation down repo-wide. `ziglang.freetls.fastly.net` puts a Fastly edge cache in front of the same archives, so CI terminates at a nearby POP instead of making one long trip to one box. It is on the same upstream community-mirror list, so the MIRRORS.md byte-identical guarantee that tsuku's pinned checksums rely on still applies.

Also rewrites the recipe comment: corrects the `community-mirrors.json` reference, which 404s, to the `.txt` path that actually serves the list; records both outages and why this source was picked over the previous one; and rewrites the maintainer heuristic to gate on HTTPS, byte-identity and CI-runner reachability — with a CDN edge in front of the bytes as the tiebreak, replacing the DNS-address-count test that was there before.

Regenerates the three zig 0.14.1 goldens and updates the zig URL in the six ninja 1.13.2 goldens that embed zig as a build-time dependency.

---

Fixes #2441

## Why not revert to ziglang.org, and what this does and does not fix

A straight revert re-creates #2384 — the canonical source was intermittently unreachable from CI, which is why #2391 moved the recipe to hryx in the first place. This is not that revert, but it is closer to it than I first wrote, and the recipe comment now says so plainly rather than claiming the question is settled.

`ziglang.freetls.fastly.net` serves **`ziglang.org`'s own bytes**, not an independent copy: both return the same ETag and `Last-Modified` from the same nginx, with a one-hour TTL and pull-through revalidation. The three genuinely independent mirrors each carry their own distinct `Last-Modified`, which is what makes the shared-origin reading the right one — and is also the test the recipe comment now hands the next maintainer. What changes is the path CI takes to the bytes — an edge cache at a nearby POP instead of one trip to one Hetzner box. If #2384 was a route problem between GitHub runners and Hetzner, this fixes it. If the origin itself was down, this buys an hour of cache per POP and then fails too. Both readings fit #2384's symptoms, so the origin exposure stays open and the comment records the triage for telling the two cases apart next time.

An earlier revision of this PR ranked candidates by DNS address count and claimed the alternatives were all single-address. That was wrong and has been removed. `ziglang.org` is dual-stack (`65.109.105.178` and `2a01:4f9:3051:4bd2::2`) and still one box; `zig.squirl.dev` answers with one address per family and is a BunnyCDN pull zone (CNAME `squirl-zig.b-cdn.net`) serving from many POPs. Geo-DNS makes a real CDN look single-homed, so address count does not distinguish a CDN from a single origin. The comment now says to check the CNAME chain instead, and records `zig.squirl.dev` as the strongest independent-operator fallback if the shared origin turns out to be the problem.

To say it plainly, since `zig.squirl.dev` is better than Fastly on both properties this PR ranks on — independently operated *and* CDN-backed: it was not taken here because reachability from GitHub-hosted runners is unproven for it and proven for Fastly, and runner reachability is precisely the property that failed in both #2384 and #2441. Swapping a proven source for an unverified one while CI is red repo-wide would repeat this issue's mistake rather than avoid it. Squirl is the first thing to try if the shared origin turns out to be the failure, and it belongs in #2443's fallback list.

## Why not fix this properly with a fallback list

Because it is a CLI change, not a recipe change, and CI is red for every recipe contributor right now.

`download_archive` takes a single `url` string (`internal/actions/composites.go`), passes it through `decomposeDownload` to `DownloadAction.Decompose` (`internal/actions/download.go:118`), which emits exactly one `download_file` step with one URL baked into the generated plan. Fallback has to cross the recipe schema, the validator, the checksum-computation path, the emitted step params, the executor's install-time download, the plan format, and every embedded golden that records a URL. Landing that as the emergency unblock keeps everyone's CI red through a large review.

Filed as #2443. PR #2391 named this same follow-up in its own description in May and never filed the issue, which is a direct cause of this recurrence. Filing it is both part of this fix and a deferral — an issue that exists is better than a bullet in a merged PR body, but nothing about filing it makes it more likely to get scheduled. It needs an owner or a milestone; without one this recurs as "filed the follow-up, never scheduled it."

Honest framing: this puts an edge cache in front of a source that had none. It does not remove the single point of failure, and because the origin is shared with `ziglang.org` it does not fully remove #2384's exposure either.

## Byte-identity is verified, not assumed

Every golden diff in this PR changes the URL and nothing else — no checksum churn. The computed checksums from Fastly match the values previously pinned against hryx exactly:

| Archive | SHA256 |
|---|---|
| `zig-x86_64-linux-0.15.1` | `c61c5da6…fe05` |
| `zig-x86_64-linux-0.14.1` | `24aeeec8…716c` |
| `zig-x86_64-macos-0.14.1` | `b0f8bdfb…5f43` |
| `zig-aarch64-macos-0.14.1` | `39f3dc5e…aefa` |

0.14.1 mattered to check separately: community mirrors are not obliged to retain old releases, and the zig goldens pin 0.14.1 while the recipe resolves 0.15.1. Fastly serves both, plus `aarch64-linux` for each.

## Why the ninja goldens got a URL-only edit

Running `regenerate-golden.sh ninja` emits current-format output that differs from the stored goldens in ways unrelated to this issue: it drops `generated_at`/`recipe_source` and adds a `binaries` field. Ninja is excluded from code validation for exactly that stale-golden drift (#988). A full regeneration would have pulled a tracked, unrelated problem into an emergency CI fix and made the diff much harder to read, so the six affected files get the URL substitution only. #988 stays #988.

## Where the evidence stops

Two gaps a reviewer should know about rather than infer.

**linux/arm64 is covered by emulation, not by hardware.** The issue's last acceptance criterion asks that zig still installs and verifies on linux/amd64 and linux/arm64. amd64 is proven directly — local install-and-verify from a scratch `TSUKU_HOME`, `Linux x86_64: zig` green in Build Essentials, and the golden execution lane.

arm64 was exercised too, under qemu-user: a cross-built `GOARCH=arm64` tsuku running in an `arm64v8/debian` container downloads the `aarch64-linux` archive from Fastly, extracts it, symlinks it, passes the integrity check, and runs the aarch64 `zig` binary to print `0.15.1`. Byte-identity holds independently: evaluating for `linux/arm64` computes `f7a654ac…992b` for `zig-aarch64-linux-0.14.1`, matching the hash upstream publishes in its download index.

What that does not establish is behaviour on real arm64 silicon — qemu translates instructions and syscalls, so a hardware-specific defect would not surface. For a URL swap serving verified-identical archives the residual risk is small, but it is not zero and no CI lane closes it: no embedded recipe has a linux-arm64 golden, Build Essentials' only arm64 lane is macOS, and the platform-integration arm64 lane never touches zig. #2445 covers why the arm64 recipe lane that should have caught this never ran.

**Build Essentials is red, and was already red on main.** Two of its fifteen jobs fail: `No-GCC Container: gdbm-source` and `Linux x86_64: git-source`. Both fail identically on main — the most recent scheduled run there ([30183663952](https://github.com/tsukumogami/tsuku/actions/runs/30183663952)) fails the same two jobs with the same root causes, and has since 2026-06-28. Now tracked separately as #2447 (gdbm-source) and #2449 (git-source). In gdbm-source, zig installs first and succeeds; the job then dies installing its `make` dependency, because the vendored `patchelf` needs `GLIBC_2.38` and the container image is older. git-source fails because git 2.55.0 now builds part of itself in Rust and the sandbox has no `cargo` (`make: *** [Makefile:3021: target/release/libgitcore.a] Error 127`), which I reproduced locally. Neither involves zig. Every zig-dependent job in that workflow passes on this branch: `Linux x86_64: zig`, `libsixel-source`, `sqlite-source`, `ninja`, and `Sandbox multifamily: ninja` — which are the jobs #2384 listed as casualties of the zig outage.

**Published plans in R2 still record the dead URL, but nothing reads them.** The nine goldens in this diff are the in-repo ones. `scripts/r2-upload.sh` also publishes plans to R2, and those for zig-dependent recipes still name `zigmirror.hryx.net`. I initially assumed the nightly registry validation was installing from them and therefore hitting a dead host; it is not. The publish workflow writes to `plans/registry/…` while every consumer globs single-letter category directories, so the objects match nothing — the 2026-07-31 nightly downloaded 3,770 files, logged `No recipes with golden files found.`, and passed green having validated nothing. The stale URLs are therefore inert rather than breaking, and re-publishing them would land in a prefix nothing reads. Filed as #2448, which is a bigger problem than this PR's.

## Test Plan

Authoritative, because local probes do not establish runner reachability — the recipe's own heuristic requires it, and skipping it is what produced #2441:

- [x] `Validate Embedded Dependencies` green on this branch — [run 30715201408](https://github.com/tsukumogami/tsuku/actions/runs/30715201408): 7 passed, 0 failed, including `TEST: cargo-audit (cargo_install)... PASS`, the exemplar that was failing
- [x] `Validate Golden Files (Execution)` green — the job that actually executes the hand-edited ninja plans

Local:

- [x] `go build ./...`, `go vet ./...`, `go test ./...` — green, 54 packages ok
- [x] `tsuku validate internal/recipe/recipes/zig.toml --strict` — valid
- [x] `tsuku eval zig` and `tsuku eval cargo-audit --install-deps` — both generate plans; `cargo-audit` is the exemplar that was failing
- [x] `tsuku eval zig@0.14.1` for `linux/amd64`, `darwin/amd64` and `darwin/arm64` — all download, and all three checksums match the values previously pinned against hryx. `linux/arm64` matches the hash upstream publishes in `download/index.json` (`f7a654ac…992b`), as does `aarch64-linux-0.15.1` (`bb4a8d2a…19fe`).
- [x] `scripts/validate-golden.sh zig --category embedded` — up to date
- [x] `tsuku install zig --force` then `tsuku verify zig` from a scratch `TSUKU_HOME` — installs and verifies on linux/amd64
- [x] Same install-and-verify on linux/arm64 under qemu-user in `arm64v8/debian:bookworm-slim`, with a cross-built `GOARCH=arm64` tsuku — install exit 0, verify exit 0 through all five steps, aarch64 `zig` prints `0.15.1`

One note for anyone re-running the issue's Validation script verbatim: step 2 aborts under `set -euo pipefail` because `cargo_install` needs rust at eval time and prompts interactively. Add `--install-deps`. That is a defect in the script, not the change — it would have failed the same way before this PR.
