### PR TITLE
fix: build git-source without cargo and surface sandbox build output

### DIFF
--- a/.github/workflows/batch-generate.yml
+++ b/.github/workflows/batch-generate.yml
@@ -271,7 +271,10 @@ jobs:
                   --json > "$RESULT_FILE" 2>/dev/null || true
 
                 if [ -f "$RESULT_FILE" ] && jq -e . "$RESULT_FILE" > /dev/null 2>&1; then
-                  cat "$RESULT_FILE"  # Show output for logging
+                  # Show the result for logging, minus the build-log fields
+                  # this loop does not read -- they would add up to 16 KiB of
+                  # escaped output per failing recipe per family.
+                  jq 'del(.install_output, .verify_output)' "$RESULT_FILE"
 
                   # Sandbox JSON has install_exit_code; error JSON has exit_code
                   if jq -e '.install_exit_code' "$RESULT_FILE" > /dev/null 2>&1; then
@@ -423,7 +426,10 @@ jobs:
                   --json > "$RESULT_FILE" 2>/dev/null || true
 
                 if [ -f "$RESULT_FILE" ] && jq -e . "$RESULT_FILE" > /dev/null 2>&1; then
-                  cat "$RESULT_FILE"  # Show output for logging
+                  # Show the result for logging, minus the build-log fields
+                  # this loop does not read -- they would add up to 16 KiB of
+                  # escaped output per failing recipe per family.
+                  jq 'del(.install_output, .verify_output)' "$RESULT_FILE"
 
                   # Sandbox JSON has install_exit_code; error JSON has exit_code
                   if jq -e '.install_exit_code' "$RESULT_FILE" > /dev/null 2>&1; then

--- a/.github/workflows/build-essentials.yml
+++ b/.github/workflows/build-essentials.yml
@@ -18,6 +18,7 @@ on:
       - 'cmd/tsuku/eval.go'
       - 'cmd/tsuku/install_deps.go'
       - 'cmd/tsuku/install_lib.go'
+      - 'cmd/tsuku/install_sandbox.go'
       - 'testdata/recipes/*.toml'
       - 'test/scripts/verify-*.sh'
       - 'test/scripts/test-*-provisioning.sh'
@@ -38,6 +39,7 @@ on:
       - 'cmd/tsuku/eval.go'
       - 'cmd/tsuku/install_deps.go'
       - 'cmd/tsuku/install_lib.go'
+      - 'cmd/tsuku/install_sandbox.go'
       - 'testdata/recipes/*.toml'
       - 'scripts/*.sh'
       - 'test/scripts/verify-*.sh'
@@ -124,8 +126,26 @@ jobs:
               echo "FAIL: ${{ matrix.tool.name }} (exit $EXIT_CODE)"
               if [ -f "$RESULT_FILE" ]; then
                 echo "Error: $(jq -r '.error // .message // "unknown"' "$RESULT_FILE")"
+                # install_output holds the tail of the container's build log and
+                # names the command that failed. Print it unescaped and
+                # uncollapsed -- this is the whole reason the job is red, and
+                # reading it out of the raw JSON below is impractical.
+                #
+                # Printing build output verbatim lets a "::" line in it act as
+                # a workflow command. That is acceptable here because the
+                # recipes this job builds live in the repo. Do not copy this
+                # into a workflow that builds recipes from a pull request
+                # without filtering those sequences first.
+                if [ -n "$(jq -r '.install_output // ""' "$RESULT_FILE")" ]; then
+                  echo "Container output:"
+                  jq -r '.install_output' "$RESULT_FILE"
+                fi
+                if [ -n "$(jq -r '.verify_output // ""' "$RESULT_FILE")" ]; then
+                  echo "Verify output:"
+                  jq -r '.verify_output' "$RESULT_FILE"
+                fi
                 echo "Full result:"
-                jq . "$RESULT_FILE"
+                jq 'del(.install_output, .verify_output)' "$RESULT_FILE"
               fi
               exit 1
             fi

--- a/README.md
+++ b/README.md
@@ -796,13 +796,20 @@ tsuku install ruff --sandbox --json
 | `verified` | Whether the verify command passed (true when no verify command exists) |
 | `install_exit_code` | Container exit code from the install step |
 | `verify_exit_code` | Exit code from the recipe's verify command (-1 if none) |
+| `install_output` | Container output, present only when the install fails |
+| `verify_output` | Verify command output, present only when verification fails |
 | `duration_ms` | Total execution time in milliseconds |
 | `error` | Error message string, or null on success |
+
+`install_output` and `verify_output` carry the last 16 KiB of output, so the failing command is visible without rerunning the build. Values passed with `--env` are masked out of both, since CI commonly forwards a token that way and publishes the result.
 
 When `--json` is set, human-readable progress output is suppressed. CI workflows can parse results with `jq`:
 
 ```bash
 tsuku install ruff --sandbox --json | jq '.passed'
+
+# On failure, read what the container actually printed
+tsuku install ruff --sandbox --json | jq -r '.install_output'
 ```
 
 For technical details, see [DESIGN-install-sandbox.md](docs/DESIGN-install-sandbox.md).

--- a/README.md
+++ b/README.md
@@ -801,7 +801,9 @@ tsuku install ruff --sandbox --json
 | `duration_ms` | Total execution time in milliseconds |
 | `error` | Error message string, or null on success |
 
-`install_output` and `verify_output` carry the last 16 KiB of output, so the failing command is visible without rerunning the build. Values passed with `--env` are masked out of both, since CI commonly forwards a token that way and publishes the result.
+`install_output` and `verify_output` carry the last 16 KiB of output, so the failing command is visible without rerunning the build.
+
+Values passed with `--env` are replaced by `[REDACTED]` wherever they appear, since CI commonly forwards a token that way and publishes the result. The test is length, not key name: values shorter than 8 characters are left alone, because masking a value like `1` would shred the log, and long values are masked whether or not they are secret. If you pass configuration you need to read back, expect to see it redacted.
 
 When `--json` is set, human-readable progress output is suppressed. CI workflows can parse results with `jq`:
 

--- a/cmd/tsuku/install_sandbox.go
+++ b/cmd/tsuku/install_sandbox.go
@@ -39,7 +39,8 @@ const sandboxTruncationNotice = "[earlier output truncated]"
 
 // minMaskedSecretLen is the shortest --env value masked out of container
 // output. Credentials are long; short values are things like DEBUG=1, and
-// masking every "1" in a build log would destroy it.
+// masking every "1" in a build log would destroy it. A credential shorter than
+// this is therefore not masked and reaches the output verbatim.
 const minMaskedSecretLen = 8
 
 // runSandboxInstall runs the installation in an isolated sandbox container.
@@ -147,13 +148,18 @@ func runSandboxInstall(toolName, planPath, recipePath, targetFamily string) erro
 		return fmt.Errorf("sandbox execution failed: %w", err)
 	}
 
+	// Both output paths mask the values forwarded into the container. Deriving
+	// them from reqs.ExtraEnv rather than re-reading the flag keeps one source
+	// for "what env the container received".
+	secrets := sandboxSecretValues(reqs.ExtraEnv)
+
 	// JSON output mode: emit a single JSON object and return
 	if installJSON {
-		return emitSandboxJSON(toolName, result)
+		return emitSandboxJSON(toolName, result, secrets)
 	}
 
 	// Human-readable output mode (unchanged from before --json was added)
-	return emitSandboxHumanReadable(result)
+	return emitSandboxHumanReadable(result, secrets)
 }
 
 // emitSandboxJSON writes a single JSON object to stdout for the sandbox result.
@@ -162,8 +168,8 @@ func runSandboxInstall(toolName, planPath, recipePath, targetFamily string) erro
 // to the caller, which prevents handleInstallError from emitting a second JSON
 // object. For non-passing states, it calls exitWithCode directly to set the
 // appropriate process exit code.
-func emitSandboxJSON(toolName string, result *sandbox.SandboxResult) error {
-	out := buildSandboxJSONOutput(toolName, result, sandboxSecretValues(installEnv))
+func emitSandboxJSON(toolName string, result *sandbox.SandboxResult, secrets []string) error {
+	out := buildSandboxJSONOutput(toolName, result, secrets)
 	printJSON(out)
 
 	// For failed or errored states, exit directly so the caller doesn't
@@ -234,6 +240,9 @@ func buildSandboxJSONOutput(toolName string, result *sandbox.SandboxResult, secr
 // a JSON result. Without it a failing CI job reports only an exit code, and
 // identifying the failing command means reproducing the build by hand.
 //
+// stdout and stderr are concatenated in that order, not interleaved, so the
+// seam between them is not a moment in time.
+//
 // The tail is what matters: a build log's last lines name the command that
 // died, so anything over the cap loses its head rather than its end.
 //
@@ -263,19 +272,31 @@ func maskAndTail(output string, secrets []string) string {
 	if output == "" {
 		return ""
 	}
+	return tailBytes(maskSecrets(output, secrets), maxSandboxOutputBytes)
+}
+
+// maskSecrets replaces each secret with [REDACTED] wherever it appears. Exact
+// values match anywhere, including inside a URL, which is how a forwarded token
+// most often escapes into a log.
+func maskSecrets(output string, secrets []string) string {
 	for _, secret := range secrets {
 		output = strings.ReplaceAll(output, secret, "[REDACTED]")
 	}
-	return tailLines(output, maxSandboxOutputBytes)
+	return output
 }
 
-// sandboxSecretValues returns the --env values long enough to be credentials.
-// CI forwards GITHUB_TOKEN into the sandbox this way and publishes the JSON
-// result to a public job log, so those exact strings are masked out of any
-// container output the result carries.
-func sandboxSecretValues(entries []string) []string {
+// sandboxSecretValues returns the values to mask out of container output, given
+// the already-resolved KEY=VALUE entries forwarded into the sandbox. CI forwards
+// GITHUB_TOKEN this way and publishes the output to a public job log.
+//
+// The only test applied is length, because --env carries both credentials and
+// plain configuration and nothing distinguishes them at this layer. That cuts
+// both ways: a credential shorter than minMaskedSecretLen is left in the output
+// verbatim, and a long non-secret value (a registry URL, say) is replaced with
+// [REDACTED] even though a reader would rather see it.
+func sandboxSecretValues(resolvedEnv []string) []string {
 	var secrets []string
-	for _, entry := range resolveEnvFlags(entries) {
+	for _, entry := range resolvedEnv {
 		idx := strings.IndexByte(entry, '=')
 		if idx < 0 {
 			continue
@@ -287,9 +308,9 @@ func sandboxSecretValues(entries []string) []string {
 	return secrets
 }
 
-// tailLines returns at most maxBytes of trailing text, starting at a line
+// tailBytes returns at most maxBytes of trailing text, starting at a line
 // boundary and prefixed with a notice when anything was dropped.
-func tailLines(s string, maxBytes int) string {
+func tailBytes(s string, maxBytes int) string {
 	if len(s) <= maxBytes {
 		return s
 	}
@@ -308,10 +329,12 @@ func tailLines(s string, maxBytes int) string {
 // emitSandboxHumanReadable prints the sandbox result in human-readable format.
 // This is the original output path used when --json is not set.
 //
-// Unlike the JSON path, this prints container output verbatim: it goes to the
-// operator's own terminal, who supplied any --env values in the first place,
-// and truncating a local build log would only get in the way of debugging.
-func emitSandboxHumanReadable(result *sandbox.SandboxResult) error {
+// Output is masked but not truncated. Masking applies because this path is not
+// only interactive -- validate-golden-execution.yml runs the sandbox without
+// --json while forwarding a token, and its output lands in a public job log.
+// Truncation does not, because the operator running this locally wants the
+// whole build log, which is the thing they came for.
+func emitSandboxHumanReadable(result *sandbox.SandboxResult, secrets []string) error {
 	// Handle skipped sandbox (no container runtime)
 	if result.Skipped {
 		printInfo("Sandbox testing skipped (no container runtime available)")
@@ -319,13 +342,16 @@ func emitSandboxHumanReadable(result *sandbox.SandboxResult) error {
 		return nil
 	}
 
+	stdout := maskSecrets(result.Stdout, secrets)
+	stderr := maskSecrets(result.Stderr, secrets)
+
 	// Report results
 	if result.Passed {
 		printInfo("Sandbox test PASSED")
-		if result.Stdout != "" {
+		if stdout != "" {
 			printInfo()
 			printInfo("Container output:")
-			printInfo(result.Stdout)
+			printInfo(stdout)
 		}
 	} else {
 		printInfo("Sandbox test FAILED")
@@ -334,15 +360,15 @@ func emitSandboxHumanReadable(result *sandbox.SandboxResult) error {
 		} else {
 			printInfof("Verification failed with exit code: %d\n", result.VerifyExitCode)
 		}
-		if result.Stderr != "" {
+		if stderr != "" {
 			printInfo()
 			printInfo("Error output:")
-			fmt.Fprintln(os.Stderr, result.Stderr)
+			fmt.Fprintln(os.Stderr, stderr)
 		}
-		if result.Stdout != "" {
+		if stdout != "" {
 			printInfo()
 			printInfo("Container output:")
-			printInfo(result.Stdout)
+			printInfo(stdout)
 		}
 		if result.ExitCode != 0 {
 			return fmt.Errorf("sandbox test failed with exit code %d", result.ExitCode)

--- a/cmd/tsuku/install_sandbox.go
+++ b/cmd/tsuku/install_sandbox.go
@@ -20,10 +20,27 @@ type sandboxJSONOutput struct {
 	Verified        bool    `json:"verified"`
 	InstallExitCode int     `json:"install_exit_code"`
 	VerifyExitCode  int     `json:"verify_exit_code"`
-	VerifyOutput    string  `json:"verify_output,omitempty"` // included when verify fails
+	InstallOutput   string  `json:"install_output,omitempty"` // included when install fails
+	VerifyOutput    string  `json:"verify_output,omitempty"`  // included when verify fails
 	DurationMs      int64   `json:"duration_ms"`
 	Error           *string `json:"error"` // null on success, string on failure
 }
+
+// maxSandboxOutputBytes caps the container output embedded in a JSON result.
+// A source build can emit megabytes, so some bound is needed; 16 KiB is a round
+// number picked for log readability. For scale, the whole tail tsuku emits for a
+// failed git build -- plan step, make invocation, and the error -- came to about
+// 6.7 KiB.
+const maxSandboxOutputBytes = 16384
+
+// sandboxTruncationNotice marks output that had its head dropped, so a reader
+// does not mistake a partial log for the whole build.
+const sandboxTruncationNotice = "[earlier output truncated]"
+
+// minMaskedSecretLen is the shortest --env value masked out of container
+// output. Credentials are long; short values are things like DEBUG=1, and
+// masking every "1" in a build log would destroy it.
+const minMaskedSecretLen = 8
 
 // runSandboxInstall runs the installation in an isolated sandbox container.
 // It supports three modes:
@@ -146,7 +163,7 @@ func runSandboxInstall(toolName, planPath, recipePath, targetFamily string) erro
 // object. For non-passing states, it calls exitWithCode directly to set the
 // appropriate process exit code.
 func emitSandboxJSON(toolName string, result *sandbox.SandboxResult) error {
-	out := buildSandboxJSONOutput(toolName, result)
+	out := buildSandboxJSONOutput(toolName, result, sandboxSecretValues(installEnv))
 	printJSON(out)
 
 	// For failed or errored states, exit directly so the caller doesn't
@@ -159,8 +176,9 @@ func emitSandboxJSON(toolName string, result *sandbox.SandboxResult) error {
 
 // buildSandboxJSONOutput constructs the JSON output struct from a sandbox result.
 // This is a pure function with no side effects, making it testable independently
-// of stdout.
-func buildSandboxJSONOutput(toolName string, result *sandbox.SandboxResult) sandboxJSONOutput {
+// of stdout. secrets are the values masked out of any container output the
+// result carries; the caller resolves them from --env.
+func buildSandboxJSONOutput(toolName string, result *sandbox.SandboxResult, secrets []string) sandboxJSONOutput {
 	out := sandboxJSONOutput{
 		Tool:            toolName,
 		Passed:          result.Passed,
@@ -185,6 +203,7 @@ func buildSandboxJSONOutput(toolName string, result *sandbox.SandboxResult) sand
 	if result.Error != nil {
 		errMsg := result.Error.Error()
 		out.Error = &errMsg
+		out.InstallOutput = sandboxFailureOutput(result, secrets)
 		return out
 	}
 
@@ -193,9 +212,14 @@ func buildSandboxJSONOutput(toolName string, result *sandbox.SandboxResult) sand
 		var errMsg string
 		if result.ExitCode != 0 {
 			errMsg = fmt.Sprintf("installation failed with exit code %d", result.ExitCode)
+			// The exit code alone says nothing about which build step died,
+			// so carry the container output that names the failing command.
+			out.InstallOutput = sandboxFailureOutput(result, secrets)
 		} else {
 			errMsg = fmt.Sprintf("verification failed with exit code %d", result.VerifyExitCode)
-			out.VerifyOutput = strings.TrimSpace(result.VerifyOutput)
+			// The verify command runs in the same container with the same
+			// forwarded env, so its output gets the same treatment.
+			out.VerifyOutput = maskAndTail(result.VerifyOutput, secrets)
 		}
 		out.Error = &errMsg
 		return out
@@ -206,8 +230,87 @@ func buildSandboxJSONOutput(toolName string, result *sandbox.SandboxResult) sand
 	return out
 }
 
+// sandboxFailureOutput renders the container's combined output for inclusion in
+// a JSON result. Without it a failing CI job reports only an exit code, and
+// identifying the failing command means reproducing the build by hand.
+//
+// The tail is what matters: a build log's last lines name the command that
+// died, so anything over the cap loses its head rather than its end.
+//
+// secrets holds values that must not reach the output. Masking them by exact
+// value rather than by pattern is deliberate: validate.Sanitizer's regexes are
+// tuned for error messages bound for an LLM repair API and mangle build logs,
+// rewriting "foo.c:12:3:" to "foo.c[IP]3:" and "unexpected token: ')'" to
+// "unexpected [REDACTED]". The only credentials tsuku puts in a sandbox are the
+// ones the caller passed with --env, so their values are known exactly and
+// match wherever they appear, including inside a URL.
+func sandboxFailureOutput(result *sandbox.SandboxResult, secrets []string) string {
+	parts := make([]string, 0, 2)
+	if s := strings.TrimSpace(result.Stdout); s != "" {
+		parts = append(parts, s)
+	}
+	if s := strings.TrimSpace(result.Stderr); s != "" {
+		parts = append(parts, s)
+	}
+	return maskAndTail(strings.Join(parts, "\n"), secrets)
+}
+
+// maskAndTail removes secrets from container output and bounds what is left.
+// Masking runs before truncation so a secret straddling the cut cannot leave a
+// fragment behind.
+func maskAndTail(output string, secrets []string) string {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return ""
+	}
+	for _, secret := range secrets {
+		output = strings.ReplaceAll(output, secret, "[REDACTED]")
+	}
+	return tailLines(output, maxSandboxOutputBytes)
+}
+
+// sandboxSecretValues returns the --env values long enough to be credentials.
+// CI forwards GITHUB_TOKEN into the sandbox this way and publishes the JSON
+// result to a public job log, so those exact strings are masked out of any
+// container output the result carries.
+func sandboxSecretValues(entries []string) []string {
+	var secrets []string
+	for _, entry := range resolveEnvFlags(entries) {
+		idx := strings.IndexByte(entry, '=')
+		if idx < 0 {
+			continue
+		}
+		if value := entry[idx+1:]; len(value) >= minMaskedSecretLen {
+			secrets = append(secrets, value)
+		}
+	}
+	return secrets
+}
+
+// tailLines returns at most maxBytes of trailing text, starting at a line
+// boundary and prefixed with a notice when anything was dropped.
+func tailLines(s string, maxBytes int) string {
+	if len(s) <= maxBytes {
+		return s
+	}
+	tail := s[len(s)-maxBytes:]
+	// Byte-slicing can land mid-line and mid-rune. Advancing past the first
+	// newline fixes both, but a log with no newline in its last maxBytes has
+	// no boundary to advance to, so drop any partial rune left at the front.
+	if idx := strings.IndexByte(tail, '\n'); idx >= 0 {
+		tail = tail[idx+1:]
+	} else {
+		tail = strings.ToValidUTF8(tail, "")
+	}
+	return sandboxTruncationNotice + "\n" + tail
+}
+
 // emitSandboxHumanReadable prints the sandbox result in human-readable format.
 // This is the original output path used when --json is not set.
+//
+// Unlike the JSON path, this prints container output verbatim: it goes to the
+// operator's own terminal, who supplied any --env values in the first place,
+// and truncating a local build log would only get in the way of debugging.
 func emitSandboxHumanReadable(result *sandbox.SandboxResult) error {
 	// Handle skipped sandbox (no container runtime)
 	if result.Skipped {

--- a/cmd/tsuku/install_sandbox_test.go
+++ b/cmd/tsuku/install_sandbox_test.go
@@ -178,7 +178,7 @@ func TestSandboxJSONOutput_ErrorFieldStringEncoding(t *testing.T) {
 	}
 }
 
-func TestEmitSandboxJSON_PassedResult(t *testing.T) {
+func TestBuildSandboxJSONOutput_PassedResult(t *testing.T) {
 	t.Parallel()
 
 	result := &sandbox.SandboxResult{
@@ -214,7 +214,7 @@ func TestEmitSandboxJSON_PassedResult(t *testing.T) {
 	}
 }
 
-func TestEmitSandboxJSON_FailedResult(t *testing.T) {
+func TestBuildSandboxJSONOutput_FailedResult(t *testing.T) {
 	t.Parallel()
 
 	result := &sandbox.SandboxResult{
@@ -238,7 +238,7 @@ func TestEmitSandboxJSON_FailedResult(t *testing.T) {
 	}
 }
 
-func TestEmitSandboxJSON_SkippedResult(t *testing.T) {
+func TestBuildSandboxJSONOutput_SkippedResult(t *testing.T) {
 	t.Parallel()
 
 	result := &sandbox.SandboxResult{
@@ -268,7 +268,7 @@ func TestEmitSandboxJSON_SkippedResult(t *testing.T) {
 	}
 }
 
-func TestEmitSandboxJSON_ErrorResult(t *testing.T) {
+func TestBuildSandboxJSONOutput_ErrorResult(t *testing.T) {
 	t.Parallel()
 
 	result := &sandbox.SandboxResult{
@@ -296,7 +296,7 @@ func TestEmitSandboxJSON_ErrorResult(t *testing.T) {
 	}
 }
 
-func TestEmitSandboxJSON_PassedNoVerifyCommand(t *testing.T) {
+func TestBuildSandboxJSONOutput_PassedNoVerifyCommand(t *testing.T) {
 	t.Parallel()
 
 	// When no verify command exists, Verified is true (vacuously) and
@@ -322,7 +322,7 @@ func TestEmitSandboxJSON_PassedNoVerifyCommand(t *testing.T) {
 	}
 }
 
-func TestEmitSandboxJSON_AllFieldsRoundTrip(t *testing.T) {
+func TestBuildSandboxJSONOutput_AllFieldsRoundTrip(t *testing.T) {
 	t.Parallel()
 
 	// Test that JSON output round-trips correctly through marshal/unmarshal
@@ -555,40 +555,50 @@ func TestSandboxFailureOutput_MasksSecrets(t *testing.T) {
 	t.Parallel()
 
 	// The Build Essentials workflow forwards GITHUB_TOKEN into the sandbox and
-	// publishes this JSON to a public job log.
-	result := &sandbox.SandboxResult{
-		Stdout: "fetching with token=ghp_abcdef1234567890\n",
-		Stderr: "Authorization: Bearer ghp_abcdef1234567890\n",
+	// publishes this JSON to a public job log. A token escapes as often inside a
+	// URL as in a tidy KEY=VALUE pair, so exact values are matched anywhere.
+	const secret = "ghp_abcdef1234567890"
+
+	tests := []struct {
+		name   string
+		result *sandbox.SandboxResult
+		want   string
+	}{
+		{
+			name: "key=value and bearer header",
+			result: &sandbox.SandboxResult{
+				Stdout: "fetching with token=" + secret + "\n",
+				Stderr: "Authorization: Bearer " + secret + "\n",
+			},
+			want: "fetching with token=[REDACTED]\nAuthorization: Bearer [REDACTED]",
+		},
+		{
+			name: "embedded in a clone URL",
+			result: &sandbox.SandboxResult{
+				Stdout: "cloning https://x-access-token:" + secret + "@github.com/o/r\n",
+			},
+			want: "cloning https://x-access-token:[REDACTED]@github.com/o/r",
+		},
+		{
+			name:   "bare on its own line",
+			result: &sandbox.SandboxResult{Stderr: secret + "\n"},
+			want:   "[REDACTED]",
+		},
 	}
 
-	got := sandboxFailureOutput(result, []string{"ghp_abcdef1234567890"})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	if strings.Contains(got, "ghp_abcdef1234567890") {
-		t.Errorf("secret survived masking: %q", got)
-	}
-	if strings.Count(got, "[REDACTED]") != 2 {
-		t.Errorf("both occurrences should be masked, got %q", got)
-	}
-}
+			got := sandboxFailureOutput(tt.result, []string{secret})
 
-func TestSandboxFailureOutput_MasksSecretsAnywhereInTheLine(t *testing.T) {
-	t.Parallel()
-
-	// A token most often escapes inside a clone URL or a bare echo, not as a
-	// tidy KEY=VALUE pair. Exact-value masking catches it either way.
-	secret := "ghp_abcdef1234567890"
-	result := &sandbox.SandboxResult{
-		Stdout: "cloning https://x-access-token:" + secret + "@github.com/o/r\n",
-		Stderr: secret + "\n",
-	}
-
-	got := sandboxFailureOutput(result, []string{secret})
-
-	if strings.Contains(got, secret) {
-		t.Errorf("secret survived masking: %q", got)
-	}
-	if !strings.Contains(got, "https://x-access-token:[REDACTED]@github.com/o/r") {
-		t.Errorf("masking should leave the rest of the URL readable, got %q", got)
+			if strings.Contains(got, secret) {
+				t.Errorf("secret survived masking: %q", got)
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
 	}
 }
 
@@ -655,29 +665,6 @@ func TestSandboxFailureOutput_LeavesBuildDiagnosticsIntact(t *testing.T) {
 	}
 }
 
-func TestSandboxSecretValues(t *testing.T) {
-	// No t.Parallel: t.Setenv is incompatible with parallel tests.
-	t.Setenv("TSUKU_TEST_HOST_SECRET", "host-side-credential")
-
-	got := sandboxSecretValues([]string{
-		"GITHUB_TOKEN=ghp_abcdef1234567890",
-		"DEBUG=1",     // too short to mask without wrecking the log
-		"EMPTY=",      // no value to mask
-		"NOEQUALSIGN", // KEY-only, resolves from the host (unset -> empty)
-		"TSUKU_TEST_HOST_SECRET",
-	})
-
-	want := []string{"ghp_abcdef1234567890", "host-side-credential"}
-	if len(got) != len(want) {
-		t.Fatalf("got %q, want %q", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
-		}
-	}
-}
-
 func TestSandboxFailureOutput_NoNewlineTailStaysValidUTF8(t *testing.T) {
 	t.Parallel()
 
@@ -707,13 +694,49 @@ func TestSandboxFailureOutput_EmptyWhenNoOutput(t *testing.T) {
 func TestSandboxFailureOutput_CombinesStdoutAndStderr(t *testing.T) {
 	t.Parallel()
 
+	// The two streams are concatenated in that order, not interleaved.
 	got := sandboxFailureOutput(&sandbox.SandboxResult{
 		Stdout: "step 3/5: configure_make\n",
 		Stderr: "make failed\n",
 	}, nil)
 
-	if !strings.Contains(got, "step 3/5: configure_make") || !strings.Contains(got, "make failed") {
-		t.Errorf("got %q, want both streams", got)
+	if got != "step 3/5: configure_make\nmake failed" {
+		t.Errorf("got %q, want stdout then stderr", got)
+	}
+}
+
+func TestSandboxSecretValues(t *testing.T) {
+	t.Parallel()
+
+	got := sandboxSecretValues([]string{
+		"GITHUB_TOKEN=ghp_abcdef1234567890",
+		"DEBUG=1",     // too short to mask without wrecking the log
+		"EMPTY=",      // no value to mask
+		"NOEQUALSIGN", // not a KEY=VALUE entry
+	})
+
+	want := []string{"ghp_abcdef1234567890"}
+	if len(got) != len(want) {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSandboxSecretValues_WiredFromResolvedEnv(t *testing.T) {
+	// No t.Parallel: t.Setenv is incompatible with parallel tests.
+	// runSandboxInstall feeds reqs.ExtraEnv, which resolveEnvFlags has already
+	// expanded from --env. This pins that a KEY-only flag, whose value comes
+	// from the host, still reaches the mask list.
+	t.Setenv("TSUKU_TEST_HOST_SECRET", "host-side-credential")
+
+	got := sandboxSecretValues(resolveEnvFlags([]string{"TSUKU_TEST_HOST_SECRET"}))
+
+	if len(got) != 1 || got[0] != "host-side-credential" {
+		t.Errorf("got %q, want [host-side-credential]", got)
 	}
 }
 

--- a/cmd/tsuku/install_sandbox_test.go
+++ b/cmd/tsuku/install_sandbox_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/tsukumogami/tsuku/internal/sandbox"
 )
@@ -188,7 +189,7 @@ func TestEmitSandboxJSON_PassedResult(t *testing.T) {
 		DurationMs:     5000,
 	}
 
-	out := buildSandboxJSONOutput("ruff", result)
+	out := buildSandboxJSONOutput("ruff", result, nil)
 
 	if out.Tool != "ruff" {
 		t.Errorf("Tool = %q, want %q", out.Tool, "ruff")
@@ -224,7 +225,7 @@ func TestEmitSandboxJSON_FailedResult(t *testing.T) {
 		DurationMs:     3000,
 	}
 
-	out := buildSandboxJSONOutput("ruff", result)
+	out := buildSandboxJSONOutput("ruff", result, nil)
 
 	if out.Passed {
 		t.Error("Passed should be false")
@@ -245,7 +246,7 @@ func TestEmitSandboxJSON_SkippedResult(t *testing.T) {
 		DurationMs: 10,
 	}
 
-	out := buildSandboxJSONOutput("ruff", result)
+	out := buildSandboxJSONOutput("ruff", result, nil)
 
 	if out.Passed {
 		t.Error("Passed should be false for skipped result")
@@ -279,7 +280,7 @@ func TestEmitSandboxJSON_ErrorResult(t *testing.T) {
 		DurationMs:     500,
 	}
 
-	out := buildSandboxJSONOutput("ruff", result)
+	out := buildSandboxJSONOutput("ruff", result, nil)
 
 	if out.Passed {
 		t.Error("Passed should be false for error result")
@@ -308,7 +309,7 @@ func TestEmitSandboxJSON_PassedNoVerifyCommand(t *testing.T) {
 		DurationMs:     2000,
 	}
 
-	out := buildSandboxJSONOutput("serve", result)
+	out := buildSandboxJSONOutput("serve", result, nil)
 
 	if !out.Verified {
 		t.Error("Verified should be true when no verify command exists")
@@ -332,6 +333,8 @@ func TestEmitSandboxJSON_AllFieldsRoundTrip(t *testing.T) {
 		Verified:        false,
 		InstallExitCode: 127,
 		VerifyExitCode:  -1,
+		InstallOutput:   "cargo: not found",
+		VerifyOutput:    "my-tool: command not found",
 		DurationMs:      99999,
 		Error:           &errMsg,
 	}
@@ -361,11 +364,356 @@ func TestEmitSandboxJSON_AllFieldsRoundTrip(t *testing.T) {
 	if roundTripped.VerifyExitCode != original.VerifyExitCode {
 		t.Errorf("VerifyExitCode = %d, want %d", roundTripped.VerifyExitCode, original.VerifyExitCode)
 	}
+	if roundTripped.InstallOutput != original.InstallOutput {
+		t.Errorf("InstallOutput = %q, want %q", roundTripped.InstallOutput, original.InstallOutput)
+	}
+	if roundTripped.VerifyOutput != original.VerifyOutput {
+		t.Errorf("VerifyOutput = %q, want %q", roundTripped.VerifyOutput, original.VerifyOutput)
+	}
 	if roundTripped.DurationMs != original.DurationMs {
 		t.Errorf("DurationMs = %d, want %d", roundTripped.DurationMs, original.DurationMs)
 	}
 	if roundTripped.Error == nil || *roundTripped.Error != *original.Error {
 		t.Errorf("Error = %v, want %v", roundTripped.Error, original.Error)
+	}
+}
+
+func TestBuildSandboxJSONOutput_InstallFailureIncludesOutput(t *testing.T) {
+	t.Parallel()
+
+	result := &sandbox.SandboxResult{
+		Passed:         false,
+		ExitCode:       6,
+		Stdout:         "    AR libgit.a\n    CARGO target/release/libgitcore.a\n",
+		Stderr:         "/bin/sh: 1: cargo: not found\nmake: *** [Makefile:3021: target/release/libgitcore.a] Error 127\n",
+		Verified:       false,
+		VerifyExitCode: -1,
+		DurationMs:     420000,
+	}
+
+	out := buildSandboxJSONOutput("git-source", result, nil)
+
+	if out.InstallOutput == "" {
+		t.Fatal("InstallOutput should be populated when the install fails")
+	}
+	for _, want := range []string{"CARGO target/release/libgitcore.a", "cargo: not found", "Error 127"} {
+		if !strings.Contains(out.InstallOutput, want) {
+			t.Errorf("InstallOutput missing %q, got:\n%s", want, out.InstallOutput)
+		}
+	}
+}
+
+func TestBuildSandboxJSONOutput_InstallOutputSerializesUnderExpectedKey(t *testing.T) {
+	t.Parallel()
+
+	// build-essentials.yml reads `.install_output` with jq. Renaming the tag
+	// would compile and pass every struct-level test while silently returning
+	// the job log to exit-code-only.
+	out := buildSandboxJSONOutput("git-source", &sandbox.SandboxResult{
+		ExitCode: 6,
+		Stderr:   "cargo: not found\n",
+	}, nil)
+
+	data, err := json.Marshal(out)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	got, ok := parsed["install_output"].(string)
+	if !ok {
+		t.Fatalf("install_output missing or not a string in %s", data)
+	}
+	if !strings.Contains(got, "cargo: not found") {
+		t.Errorf("install_output = %q, want the container output", got)
+	}
+}
+
+func TestBuildSandboxJSONOutput_RunErrorIncludesOutput(t *testing.T) {
+	t.Parallel()
+
+	result := &sandbox.SandboxResult{
+		Passed:         false,
+		ExitCode:       -1,
+		Stderr:         "Error: image pull failed\n",
+		Error:          fmt.Errorf("container execution failed"),
+		Verified:       false,
+		VerifyExitCode: -1,
+		DurationMs:     500,
+	}
+
+	out := buildSandboxJSONOutput("ruff", result, nil)
+
+	if !strings.Contains(out.InstallOutput, "image pull failed") {
+		t.Errorf("InstallOutput should carry container output on run error, got %q", out.InstallOutput)
+	}
+}
+
+func TestBuildSandboxJSONOutput_PassedOmitsOutput(t *testing.T) {
+	t.Parallel()
+
+	result := &sandbox.SandboxResult{
+		Passed:         true,
+		ExitCode:       0,
+		Stdout:         "Installed ruff 0.1.0\n",
+		Verified:       true,
+		VerifyExitCode: 0,
+		DurationMs:     4000,
+	}
+
+	out := buildSandboxJSONOutput("ruff", result, nil)
+
+	if out.InstallOutput != "" {
+		t.Errorf("InstallOutput should be empty on success, got %q", out.InstallOutput)
+	}
+}
+
+func TestBuildSandboxJSONOutput_SkippedOmitsOutput(t *testing.T) {
+	t.Parallel()
+
+	result := &sandbox.SandboxResult{
+		Skipped:    true,
+		DurationMs: 10,
+	}
+
+	out := buildSandboxJSONOutput("ruff", result, nil)
+
+	if out.InstallOutput != "" {
+		t.Errorf("InstallOutput should be empty when the sandbox is skipped, got %q", out.InstallOutput)
+	}
+}
+
+func TestBuildSandboxJSONOutput_VerifyFailureOmitsInstallOutput(t *testing.T) {
+	t.Parallel()
+
+	// The install succeeded, so the build log is noise -- verify_output is the
+	// field that matters here.
+	result := &sandbox.SandboxResult{
+		Passed:         false,
+		ExitCode:       0,
+		Stdout:         "Installed ruff 0.1.0\n",
+		Verified:       false,
+		VerifyExitCode: 1,
+		VerifyOutput:   "ruff: command not found\n",
+		DurationMs:     4000,
+	}
+
+	out := buildSandboxJSONOutput("ruff", result, nil)
+
+	if out.InstallOutput != "" {
+		t.Errorf("InstallOutput should be empty when only verification failed, got %q", out.InstallOutput)
+	}
+	if !strings.Contains(out.VerifyOutput, "command not found") {
+		t.Errorf("VerifyOutput = %q, want it to carry the verify failure", out.VerifyOutput)
+	}
+}
+
+func TestSandboxFailureOutput_KeepsTailAndMarksTruncation(t *testing.T) {
+	t.Parallel()
+
+	// A build log far larger than the cap: the failing command is at the end,
+	// so the tail is what must survive.
+	var sb strings.Builder
+	for i := 0; i < 20000; i++ {
+		fmt.Fprintf(&sb, "    CC builtin/file-%d.o\n", i)
+	}
+	sb.WriteString("cargo: not found\n")
+
+	got := sandboxFailureOutput(&sandbox.SandboxResult{Stdout: sb.String()}, nil)
+
+	if want := maxSandboxOutputBytes + len(sandboxTruncationNotice) + 1; len(got) > want {
+		t.Errorf("output length %d exceeds the cap plus the notice (%d)", len(got), want)
+	}
+	if !strings.Contains(got, "cargo: not found") {
+		t.Error("truncation dropped the tail, which is where the failing command is")
+	}
+	if !strings.Contains(got, sandboxTruncationNotice) {
+		t.Errorf("truncated output should say so, got prefix %q", got[:80])
+	}
+	if strings.Contains(got, "file-0.o") {
+		t.Error("head of the log should have been dropped, not the tail")
+	}
+}
+
+func TestSandboxFailureOutput_ShortOutputNotTruncated(t *testing.T) {
+	t.Parallel()
+
+	got := sandboxFailureOutput(&sandbox.SandboxResult{Stderr: "make: *** Error 2\n"}, nil)
+
+	if strings.Contains(got, sandboxTruncationNotice) {
+		t.Errorf("short output should not be marked truncated, got %q", got)
+	}
+	if got != "make: *** Error 2" {
+		t.Errorf("got %q, want the trimmed stderr", got)
+	}
+}
+
+func TestSandboxFailureOutput_MasksSecrets(t *testing.T) {
+	t.Parallel()
+
+	// The Build Essentials workflow forwards GITHUB_TOKEN into the sandbox and
+	// publishes this JSON to a public job log.
+	result := &sandbox.SandboxResult{
+		Stdout: "fetching with token=ghp_abcdef1234567890\n",
+		Stderr: "Authorization: Bearer ghp_abcdef1234567890\n",
+	}
+
+	got := sandboxFailureOutput(result, []string{"ghp_abcdef1234567890"})
+
+	if strings.Contains(got, "ghp_abcdef1234567890") {
+		t.Errorf("secret survived masking: %q", got)
+	}
+	if strings.Count(got, "[REDACTED]") != 2 {
+		t.Errorf("both occurrences should be masked, got %q", got)
+	}
+}
+
+func TestSandboxFailureOutput_MasksSecretsAnywhereInTheLine(t *testing.T) {
+	t.Parallel()
+
+	// A token most often escapes inside a clone URL or a bare echo, not as a
+	// tidy KEY=VALUE pair. Exact-value masking catches it either way.
+	secret := "ghp_abcdef1234567890"
+	result := &sandbox.SandboxResult{
+		Stdout: "cloning https://x-access-token:" + secret + "@github.com/o/r\n",
+		Stderr: secret + "\n",
+	}
+
+	got := sandboxFailureOutput(result, []string{secret})
+
+	if strings.Contains(got, secret) {
+		t.Errorf("secret survived masking: %q", got)
+	}
+	if !strings.Contains(got, "https://x-access-token:[REDACTED]@github.com/o/r") {
+		t.Errorf("masking should leave the rest of the URL readable, got %q", got)
+	}
+}
+
+func TestBuildSandboxJSONOutput_VerifyOutputIsMasked(t *testing.T) {
+	t.Parallel()
+
+	// verify_output is printed in the same job log as install_output, so it
+	// gets the same treatment.
+	secret := "ghp_abcdef1234567890"
+	result := &sandbox.SandboxResult{
+		Passed:         false,
+		ExitCode:       0,
+		Verified:       false,
+		VerifyExitCode: 1,
+		VerifyOutput:   "auth failed for " + secret + "\n",
+	}
+
+	out := buildSandboxJSONOutput("ruff", result, []string{secret})
+
+	if strings.Contains(out.VerifyOutput, secret) {
+		t.Errorf("secret survived masking in VerifyOutput: %q", out.VerifyOutput)
+	}
+	if !strings.Contains(out.VerifyOutput, "auth failed for [REDACTED]") {
+		t.Errorf("VerifyOutput = %q, want the masked message", out.VerifyOutput)
+	}
+}
+
+func TestSandboxFailureOutput_MasksBeforeTruncating(t *testing.T) {
+	t.Parallel()
+
+	// A secret near the head would otherwise be cut mid-string by truncation,
+	// leaving a fragment that exact-match masking can no longer find.
+	secret := strings.Repeat("s3cr3t", 8)
+	var sb strings.Builder
+	sb.WriteString("leaked " + secret + "\n")
+	for i := 0; i < 6000; i++ {
+		fmt.Fprintf(&sb, "    CC builtin/file-%d.o\n", i)
+	}
+
+	got := sandboxFailureOutput(&sandbox.SandboxResult{Stdout: sb.String()}, []string{secret})
+
+	if strings.Contains(got, "s3cr3t") {
+		t.Errorf("a fragment of the secret survived: %q", got[:200])
+	}
+}
+
+func TestSandboxFailureOutput_LeavesBuildDiagnosticsIntact(t *testing.T) {
+	t.Parallel()
+
+	// Regression guard: pattern-based redaction used to rewrite "foo.c:12:3:"
+	// to "foo.c[IP]3:" and "unexpected token: X" to "unexpected [REDACTED]",
+	// destroying the diagnostics this field exists to carry.
+	log := strings.Join([]string{
+		"foo.c:12:3: error: unexpected token: ')'",
+		"checking for basic C types... yes",
+		"/bin/sh: 1: cargo: not found",
+		"make: *** [Makefile:3021: target/release/libgitcore.a] Error 127",
+	}, "\n")
+
+	got := sandboxFailureOutput(&sandbox.SandboxResult{Stdout: log}, nil)
+
+	if got != log {
+		t.Errorf("build output was altered:\ngot:  %q\nwant: %q", got, log)
+	}
+}
+
+func TestSandboxSecretValues(t *testing.T) {
+	// No t.Parallel: t.Setenv is incompatible with parallel tests.
+	t.Setenv("TSUKU_TEST_HOST_SECRET", "host-side-credential")
+
+	got := sandboxSecretValues([]string{
+		"GITHUB_TOKEN=ghp_abcdef1234567890",
+		"DEBUG=1",     // too short to mask without wrecking the log
+		"EMPTY=",      // no value to mask
+		"NOEQUALSIGN", // KEY-only, resolves from the host (unset -> empty)
+		"TSUKU_TEST_HOST_SECRET",
+	})
+
+	want := []string{"ghp_abcdef1234567890", "host-side-credential"}
+	if len(got) != len(want) {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestSandboxFailureOutput_NoNewlineTailStaysValidUTF8(t *testing.T) {
+	t.Parallel()
+
+	// One enormous line with no newline to cut on: the byte slice can land
+	// mid-rune, and invalid UTF-8 would come back from JSON as replacement
+	// characters.
+	oneLine := strings.Repeat("é", maxSandboxOutputBytes)
+
+	got := sandboxFailureOutput(&sandbox.SandboxResult{Stdout: oneLine}, nil)
+
+	if !utf8.ValidString(got) {
+		t.Error("truncated output is not valid UTF-8")
+	}
+	if !strings.Contains(got, sandboxTruncationNotice) {
+		t.Error("expected the truncation notice")
+	}
+}
+
+func TestSandboxFailureOutput_EmptyWhenNoOutput(t *testing.T) {
+	t.Parallel()
+
+	if got := sandboxFailureOutput(&sandbox.SandboxResult{}, nil); got != "" {
+		t.Errorf("got %q, want empty string when the container produced nothing", got)
+	}
+}
+
+func TestSandboxFailureOutput_CombinesStdoutAndStderr(t *testing.T) {
+	t.Parallel()
+
+	got := sandboxFailureOutput(&sandbox.SandboxResult{
+		Stdout: "step 3/5: configure_make\n",
+		Stderr: "make failed\n",
+	}, nil)
+
+	if !strings.Contains(got, "step 3/5: configure_make") || !strings.Contains(got, "make failed") {
+		t.Errorf("got %q, want both streams", got)
 	}
 }
 

--- a/testdata/recipes/README.md
+++ b/testdata/recipes/README.md
@@ -33,6 +33,21 @@ In production, these tools use pre-built bottles or binaries because:
 - More reliable (no build tool dependencies)
 - Consistent across environments
 
+#### They track upstream, so upstream can break them
+
+Most of these resolve their version from a homebrew formula, which means they
+build whatever the formula currently reports. A project can add a build-time
+toolchain requirement in any release, and the recipe will follow it there with
+no commit in this repo. That is what happened to `git-source` in #2449: git
+started compiling part of itself in Rust and the sandbox, which has no `cargo`,
+stopped being able to build it.
+
+Expect this class of failure and treat a red source-build job as a question
+about upstream rather than about a change here. `tsuku install --sandbox --json`
+carries the container's output in `install_output` on failure, and
+`Build Essentials` prints it, so the failing command should be visible in the
+job log without reproducing the build locally.
+
 ### System Recipes (`*-system.toml`)
 
 Recipes like `build-tools-system.toml` and `ssl-libs-system.toml` demonstrate integration with system package managers. These verify:

--- a/testdata/recipes/README.md
+++ b/testdata/recipes/README.md
@@ -43,10 +43,9 @@ started compiling part of itself in Rust and the sandbox, which has no `cargo`,
 stopped being able to build it.
 
 Expect this class of failure and treat a red source-build job as a question
-about upstream rather than about a change here. `tsuku install --sandbox --json`
-carries the container's output in `install_output` on failure, and
-`Build Essentials` prints it, so the failing command should be visible in the
-job log without reproducing the build locally.
+about upstream rather than about a change here. The failing command should be
+visible in the job log without reproducing the build locally — see the
+`install_output` field documented under sandbox testing in the root README.
 
 ### System Recipes (`*-system.toml`)
 

--- a/testdata/recipes/git-source.toml
+++ b/testdata/recipes/git-source.toml
@@ -8,8 +8,7 @@ description = "Distributed revision control system (source build for testing)"
 homepage = "https://git-scm.com/"
 # libcurl-source is built from source with --disable-ldap to avoid OPENLDAP
 # symbol version mismatch in Debian sandbox containers.
-# NO_TCLTK skips gitk/git-gui (need msgfmt in container).
-# NO_RUST skips git's optional Rust subsystems, which would require cargo.
+# See make_args below for the flags that keep this dependency set small.
 dependencies = ["libcurl-source", "openssl", "zlib", "expat"]
 
 [version]
@@ -37,6 +36,7 @@ make_args = [
     "RUNTIME_PREFIX=YesPlease",
     "gitexecdir=libexec/git-core",
     "NO_GETTEXT=YesPlease",
+    # NO_TCLTK skips gitk/git-gui, which need msgfmt in the container.
     "NO_TCLTK=YesPlease",
     # git 2.55 builds part of itself in Rust and invokes cargo from the
     # Makefile. This fixture exercises configure_make against C library

--- a/testdata/recipes/git-source.toml
+++ b/testdata/recipes/git-source.toml
@@ -9,6 +9,7 @@ homepage = "https://git-scm.com/"
 # libcurl-source is built from source with --disable-ldap to avoid OPENLDAP
 # symbol version mismatch in Debian sandbox containers.
 # NO_TCLTK skips gitk/git-gui (need msgfmt in container).
+# NO_RUST skips git's optional Rust subsystems, which would require cargo.
 dependencies = ["libcurl-source", "openssl", "zlib", "expat"]
 
 [version]
@@ -37,6 +38,13 @@ make_args = [
     "gitexecdir=libexec/git-core",
     "NO_GETTEXT=YesPlease",
     "NO_TCLTK=YesPlease",
+    # git 2.55 builds part of itself in Rust and invokes cargo from the
+    # Makefile. This fixture exercises configure_make against C library
+    # dependencies, so it opts out rather than pulling a Rust toolchain into
+    # the sandbox.
+    # TODO(#2456): git 3.0 removes NO_RUST. This recipe then needs a
+    # cargo-providing dependency or a pinned version.
+    "NO_RUST=YesPlease",
     "NO_CURL=",
     "CURLDIR={libs_dir}/libcurl-source-{deps.libcurl-source.version}",
     "CURL_LIBCURL=-L{libs_dir}/libcurl-source-{deps.libcurl-source.version}/lib -lcurl",


### PR DESCRIPTION
Add `NO_RUST=YesPlease` to `testdata/recipes/git-source.toml`'s `make_args`, so the fixture builds git without its Rust subsystems and no longer needs `cargo` in the sandbox.

Add an `install_output` field to the `tsuku install --sandbox --json` result, populated when the install fails or the container cannot run. `sandboxFailureOutput` in `cmd/tsuku/install_sandbox.go` joins the container's stdout and stderr, masks any values the caller passed with `--env`, and keeps the last 16 KiB, marking that it dropped the head. `verify_output` now goes through the same masking and cap. Build Essentials prints both fields unescaped on failure and drops them from the raw result dump, and `cmd/tsuku/install_sandbox.go` joins the workflow's path triggers.

Document the two fields in the README, and note in `testdata/recipes/README.md` that latest-tracking source fixtures can acquire an upstream build requirement with no commit here.

---

Fixes #2449

## Root cause

git 2.55 compiles part of itself in Rust and invokes `cargo` from its Makefile:

```
    CARGO target/release/libgitcore.a
/bin/sh: 1: cargo: not found
make: *** [Makefile:3021: target/release/libgitcore.a] Error 127
```

The recipe resolves its version from the homebrew formula, so it follows whatever git the formula reports and walked onto that release. `Linux x86_64: git-source` has failed since 2026-06-28 with no commit in this repo.

## Why NO_RUST rather than a toolchain or a pin

git's Makefile documents the knob and its expiry:

```
# == Optional Rust support ==
#
# Define NO_RUST if you want to disable features and subsystems written in Rust
# from being compiled into Git. For now, Rust is still an optional feature of
# the build process. With Git 3.0 though, Rust will always be enabled.
```

Adding a Rust toolchain to the recipe's dependencies would work — `internal/recipe/recipes/rust.toml` exists and the sandbox already mounts a shared cargo registry cache, so the cost is probably not prohibitive. The reason not to is what it does to the fixture rather than what it costs: this recipe exists to exercise `configure_make` against multiple C library dependencies, and a Rust toolchain in the dependency list makes it a different test. Pinning to a pre-Rust git also works, but it stops the recipe from ever again catching the thing that broke it. Excluding git-source on linux was not viable — it is already excluded on macOS per #881, so that would leave the recipe with no coverage at all.

`NO_RUST` has a known end date, so it is tracked rather than just commented: #2456 covers the git 3.0 migration, and the recipe carries a `TODO(#2456)` next to the flag.

## The diagnosability half

CI reported this as `FAIL: git-source (exit 6)` and nothing else. `--json` carried `install_exit_code` but not the container's output, so seven minutes of compilation produced a number and finding `cargo: not found` meant reproducing the build by hand.

`install_output` mirrors the existing `verify_output`. Three details are deliberate:

- **Tail, not head.** A build log names the failing command at the end. Truncating from the front would keep 16 KiB of `CC builtin/*.o` and drop the only line that matters.
- **Exact-value masking, not pattern redaction.** The workflow forwards `GITHUB_TOKEN` into the sandbox via `--env` and publishes this JSON to a public job log. tsuku knows those values exactly, so it masks them wherever they appear, including inside a clone URL. `validate.Sanitizer` was the first attempt and is the wrong tool: its regexes are tuned for error messages bound for the LLM repair path, and on a build log they rewrite `foo.c:12:3:` to `foo.c[IP]3:` and `unexpected token: ')'` to `unexpected [REDACTED]` — destroying the diagnostics the field exists to carry. There is a regression test for that.
- **Uncollapsed in the workflow.** The output is the reason the job is red; a collapsed group would just move the digging.

Other consumers of this JSON extract named fields with `jq` and are unaffected by a new optional one. `batch-generate.yml` does an unconditional `cat` of each result file, so a failing recipe there now dumps up to 16 KiB as an escaped line — noise, but on the failure path, and it is information that was previously discarded. `recipe-validation-core.yml` still reports only an exit code; wiring the new field into its failure branch would be a reasonable follow-up, but it has its own retry-loop structure and is outside this issue.

## The general case

Any recipe with `source = "homebrew"` (or another latest-tracking provider) that builds from source can acquire a new build-time toolchain dependency at any time, with no commit here, and the first signal is a red CI job. This PR does not remove that exposure — tracking latest is what these fixtures are for — but it changes what the next occurrence costs, and records the expectation in `testdata/recipes/README.md` so it does not have to be rediscovered.

Worth being honest about the limit: this failure sat red from 2026-06-28 until #2449 was filed, and nothing here shortens that. `Build Essentials` still runs weekly and still needs someone to look. What is different is that when someone does look, the job log names the failing command instead of a number.

## Verification

Local sandbox runs against Docker.

Fixed recipe:

```
$ tsuku install --sandbox --force --recipe testdata/recipes/git-source.toml
Sandbox test PASSED
Installing git-source@2.55.0 from plan...
Installation successful!
```

The original recipe, run through the new JSON path — the failure this issue is about, as it would now appear in the job log:

```
$ tsuku install --sandbox --force --json --recipe <pre-fix>.toml | jq -r .install_output
Installing git-source@2.55.0 from plan...
Error: plan execution failed: step 4 (configure_make) failed: make  failed: exit status 2
Output: GIT_VERSION=2.55.0
...
    AR libgit.a
    CARGO target/release/libgitcore.a
/bin/sh: 1: cargo: not found
make: *** [Makefile:3021: target/release/libgitcore.a] Error 127
```

`go build ./...`, `go vet ./...`, `go test ./...`, and `golangci-lint run --timeout=5m ./...` all pass, as do `.github/scripts/checks/ci-patterns-lint.sh` and `retired-runners.sh`.

## Note on this PR's CI

`Build Essentials` reports red at the workflow level. `No-GCC Container: gdbm-source` fails on main for an unrelated reason (#2447) and is not touched here. `Linux x86_64: git-source` passes. Main's scheduled run [30183663952](https://github.com/tsukumogami/tsuku/actions/runs/30183663952) is the baseline showing exactly these two jobs failing.
