### PR TITLE
fix(ci): unblock the no-GCC container job and report unrunnable patchelf clearly

### DIFF
--- a/.github/workflows/build-essentials.yml
+++ b/.github/workflows/build-essentials.yml
@@ -135,12 +135,17 @@ jobs:
   # This validates that configure_make falls back to zig when no gcc exists
   # Libtool compatibility via -print-prog-name workaround (ziglang/zig#17273)
   #
-  # The base image needs glibc >= 2.38. gdbm-source pulls in make, which tsuku
-  # installs from a Homebrew bottle and relocates with patchelf - and patchelf
-  # is itself a bottle that Homebrew builds against a recent glibc. On an older
-  # image it installs fine and then cannot execute, taking every relocation
-  # with it. ubuntu:24.04 ships 2.39; ubuntu:22.04 shipped 2.35 and broke this
-  # job for a month. Removing that floor entirely is tracked in #2451.
+  # The base image must be new enough for the patchelf Homebrew bottle to run.
+  # gdbm-source pulls in make, which tsuku installs from a bottle and relocates
+  # with patchelf - and patchelf is itself a bottle, built against whatever
+  # glibc Homebrew currently targets. On an older image it installs fine and
+  # then cannot execute, taking every relocation with it (#2447).
+  #
+  # That floor moves whenever Homebrew bumps its Linux build toolchain. As of
+  # #2447 it was glibc 2.38, so ubuntu:22.04 (2.35) failed and ubuntu:24.04
+  # (2.39) works. If this job starts failing the same way again, check the
+  # bottle's requirement before assuming the image is fine. Removing the
+  # dependency on the image's glibc entirely is tracked in #2451.
   test-no-gcc:
     name: "No-GCC Container: gdbm-source"
     runs-on: ubuntu-latest

--- a/.github/workflows/build-essentials.yml
+++ b/.github/workflows/build-essentials.yml
@@ -134,11 +134,18 @@ jobs:
   # Test source build with zig cc in container without system gcc
   # This validates that configure_make falls back to zig when no gcc exists
   # Libtool compatibility via -print-prog-name workaround (ziglang/zig#17273)
+  #
+  # The base image needs glibc >= 2.38. gdbm-source pulls in make, which tsuku
+  # installs from a Homebrew bottle and relocates with patchelf - and patchelf
+  # is itself a bottle that Homebrew builds against a recent glibc. On an older
+  # image it installs fine and then cannot execute, taking every relocation
+  # with it. ubuntu:24.04 ships 2.39; ubuntu:22.04 shipped 2.35 and broke this
+  # job for a month. Removing that floor entirely is tracked in #2451.
   test-no-gcc:
     name: "No-GCC Container: gdbm-source"
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:22.04
+      image: ubuntu:24.04
       options: --user root
 
     steps:

--- a/internal/actions/homebrew_relocate.go
+++ b/internal/actions/homebrew_relocate.go
@@ -6,9 +6,11 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/tsukumogami/tsuku/internal/progress"
 	"github.com/tsukumogami/tsuku/internal/version"
@@ -72,8 +74,13 @@ func (a *HomebrewRelocateAction) Execute(ctx *ExecutionContext, params map[strin
 		cellarPath = filepath.Dir(installPath)
 	}
 
+	// One patchelf lookup for the whole action. Both the per-binary pass below
+	// and the ELF chain walk further down share it, so patchelf is located and
+	// probed once per install rather than once per binary.
+	findPatchelf := newPatchelfFinder(a, ctx)
+
 	// Relocate placeholders in files
-	if err := a.relocatePlaceholders(ctx, installPath, cellarPath, formula, reporter); err != nil {
+	if err := a.relocatePlaceholders(ctx, installPath, cellarPath, formula, findPatchelf, reporter); err != nil {
 		return fmt.Errorf("failed to relocate placeholders: %w", err)
 	}
 
@@ -118,7 +125,7 @@ func (a *HomebrewRelocateAction) Execute(ctx *ExecutionContext, params map[strin
 	// relocatePlaceholders so the chain entries can be appended to the
 	// rpath that pass installed.
 	if runtime.GOOS == "linux" && (len(ctx.Dependencies.RuntimeDependencies) > 0 || len(scanResult.AutoInclude) > 0) {
-		if err := a.fixElfRpathChain(ctx, installPath, scanResult.AutoInclude, reporter); err != nil {
+		if err := a.fixElfRpathChain(ctx, installPath, scanResult.AutoInclude, findPatchelf, reporter); err != nil {
 			return fmt.Errorf("failed to fix ELF RPATH chain: %w", err)
 		}
 	}
@@ -220,7 +227,7 @@ func resolveInstallPath(ctx *ExecutionContext) string {
 // For binary files: use patchelf/install_name_tool to reset RPATH
 // prefixPath is used for @@HOMEBREW_PREFIX@@, cellarPath for @@HOMEBREW_CELLAR@@
 // formula is the Homebrew formula name (may differ from recipe name, e.g., curl vs libcurl)
-func (a *HomebrewRelocateAction) relocatePlaceholders(ctx *ExecutionContext, prefixPath, cellarPath, formula string, reporter progress.Reporter) error {
+func (a *HomebrewRelocateAction) relocatePlaceholders(ctx *ExecutionContext, prefixPath, cellarPath, formula string, findPatchelf patchelfFinder, reporter progress.Reporter) error {
 	dir := ctx.WorkDir
 	prefixReplacement := []byte(prefixPath)
 	cellarReplacement := []byte(cellarPath)
@@ -337,7 +344,7 @@ func (a *HomebrewRelocateAction) relocatePlaceholders(ctx *ExecutionContext, pre
 
 	// Fix RPATH on binary files using patchelf/install_name_tool
 	for _, binaryPath := range binariesToFix {
-		if err := a.fixBinaryRpath(ctx, binaryPath, prefixPath, reporter); err != nil {
+		if err := a.fixBinaryRpath(binaryPath, prefixPath, findPatchelf, reporter); err != nil {
 			return fmt.Errorf("failed to fix RPATH for %s: %w", binaryPath, err)
 		}
 	}
@@ -347,7 +354,7 @@ func (a *HomebrewRelocateAction) relocatePlaceholders(ctx *ExecutionContext, pre
 
 // fixBinaryRpath uses patchelf or install_name_tool to set a proper RPATH
 // This replaces the Homebrew placeholder RPATH with a working path
-func (a *HomebrewRelocateAction) fixBinaryRpath(ctx *ExecutionContext, binaryPath, installPath string, reporter progress.Reporter) error {
+func (a *HomebrewRelocateAction) fixBinaryRpath(binaryPath, installPath string, findPatchelf patchelfFinder, reporter progress.Reporter) error {
 	// Detect binary format
 	f, err := os.Open(binaryPath)
 	if err != nil {
@@ -363,7 +370,7 @@ func (a *HomebrewRelocateAction) fixBinaryRpath(ctx *ExecutionContext, binaryPat
 
 	// Check if it's an ELF binary
 	if bytes.Equal(magic, []byte{0x7f, 'E', 'L', 'F'}) {
-		return a.fixElfRpath(ctx, binaryPath, installPath, reporter)
+		return a.fixElfRpath(binaryPath, installPath, findPatchelf, reporter)
 	}
 
 	// Check if it's a Mach-O binary
@@ -380,30 +387,129 @@ func (a *HomebrewRelocateAction) fixBinaryRpath(ctx *ExecutionContext, binaryPat
 	return nil
 }
 
-// findPatchelf locates the patchelf binary by checking (in order):
+// patchelfFinder resolves a patchelf binary that can actually execute on this
+// host. Implementations resolve once and return the same path (or the same
+// error) on every later call, so a relocation pass that patches many binaries
+// probes for patchelf at most once.
+type patchelfFinder func() (string, error)
+
+// newPatchelfFinder returns a patchelfFinder backed by a.findPatchelf(ctx).
+//
+// Resolution is deliberately lazy rather than done up front in Execute. The
+// binary list a relocation pass works from is produced by a content heuristic
+// (isBinaryFile), so it can hold files that are not ELF at all — compressed
+// man pages, static archives. Resolving eagerly whenever that list is
+// non-empty would fail bottles that install fine today because nothing in them
+// ever reaches patchelf. Deferring until the first genuine ELF dispatch keeps
+// that behavior intact.
+//
+// The memo lives in the closure rather than in a field on
+// HomebrewRelocateAction because the action is registered as a package-level
+// singleton, so a field would leak a resolved path across installs that have
+// different ExecPaths.
+func newPatchelfFinder(a *HomebrewRelocateAction, ctx *ExecutionContext) patchelfFinder {
+	var (
+		once sync.Once
+		path string
+		err  error
+	)
+	return func() (string, error) {
+		once.Do(func() { path, err = a.findPatchelf(ctx) })
+		return path, err
+	}
+}
+
+// glibcVersionPattern matches the dynamic loader's complaint about a missing
+// symbol version, e.g.
+//
+//	/lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
+//
+// capturing the version the binary was built against.
+var glibcVersionPattern = regexp.MustCompile("version `GLIBC_([0-9][0-9.]*)' not found")
+
+// verifyPatchelfRunnable reports whether the patchelf at path can execute, by
+// running `patchelf --version` and inspecting the result.
+//
+// On glibc Linux tsuku installs patchelf from a Homebrew bottle, and Homebrew
+// builds its Linux bottles against a recent glibc. On a host whose C library is
+// older the bottle downloads, extracts, and installs without complaint, and
+// only fails when the dynamic loader is asked to run it. Probing here means the
+// install fails with that cause named, instead of surfacing the loader's raw
+// symbol-version message from whichever patchelf invocation happened to run
+// first.
+func verifyPatchelfRunnable(path string) error {
+	output, err := exec.Command(path, "--version").CombinedOutput()
+	if err == nil {
+		return nil
+	}
+
+	text := strings.TrimSpace(string(output))
+
+	if m := glibcVersionPattern.FindStringSubmatch(text); m != nil {
+		required := m[1]
+		return fmt.Errorf("patchelf at %s cannot run on this system: it needs glibc %s, "+
+			"which is newer than this system's C library. tsuku installs patchelf from a "+
+			"Homebrew bottle, and Homebrew builds its Linux bottles against a recent glibc. "+
+			"Install patchelf with your system package manager so tsuku can use that one "+
+			"instead, or run tsuku on a system with glibc %s or newer. Loader reported: %s",
+			path, required, required, text)
+	}
+
+	if text == "" {
+		return fmt.Errorf("patchelf at %s cannot run on this system: %w", path, err)
+	}
+	return fmt.Errorf("patchelf at %s cannot run on this system: %s: %w", path, text, err)
+}
+
+// findPatchelf locates a runnable patchelf binary, checking (in order):
 //  1. ctx.ExecPaths (dependency bin dirs added during plan execution)
 //  2. System PATH
 //  3. $TSUKU_HOME/tools/patchelf-*/bin/patchelf (glob for any installed version)
 //  4. $TSUKU_HOME/tools/current/patchelf (current symlink)
 //
-// Returns the path to patchelf, or an error if not found anywhere.
+// Each candidate is probed with verifyPatchelfRunnable and skipped if it cannot
+// execute, so a host where tsuku's own bottled patchelf is unusable still
+// installs successfully when a working patchelf exists elsewhere — typically
+// one from the system package manager.
+//
+// Returns the path to the first runnable candidate. When candidates were found
+// but none of them run, the returned error describes why the first one did not,
+// which is far more useful than reporting that patchelf is missing when it
+// plainly is not.
 func (a *HomebrewRelocateAction) findPatchelf(ctx *ExecutionContext) (string, error) {
+	var candidates []string
+
 	// 1. Check ExecPaths (dependency bin dirs from earlier plan steps)
 	for _, p := range ctx.ExecPaths {
 		candidate := filepath.Join(p, "patchelf")
 		if _, err := os.Stat(candidate); err == nil {
-			return candidate, nil
+			candidates = append(candidates, candidate)
 		}
 	}
 
 	// 2. Check system PATH
 	if p, err := exec.LookPath("patchelf"); err == nil {
-		return p, nil
+		candidates = append(candidates, p)
 	}
 
 	// 3-4. Check $TSUKU_HOME tools directory (glob and current symlink)
 	if p, err := a.findPatchelfInToolsDir(ctx.ToolsDir, ctx.CurrentDir); err == nil {
-		return p, nil
+		candidates = append(candidates, p)
+	}
+
+	var firstUnrunnable error
+	for _, candidate := range candidates {
+		if err := verifyPatchelfRunnable(candidate); err != nil {
+			if firstUnrunnable == nil {
+				firstUnrunnable = err
+			}
+			continue
+		}
+		return candidate, nil
+	}
+
+	if firstUnrunnable != nil {
+		return "", firstUnrunnable
 	}
 
 	return "", fmt.Errorf("patchelf not found: checked ExecPaths, system PATH, %s/patchelf-*/bin/, and %s/", ctx.ToolsDir, ctx.CurrentDir)
@@ -433,9 +539,9 @@ func (a *HomebrewRelocateAction) findPatchelfInToolsDir(toolsDir, currentDir str
 }
 
 // fixElfRpath uses patchelf to set RPATH on Linux ELF binaries
-func (a *HomebrewRelocateAction) fixElfRpath(ctx *ExecutionContext, binaryPath, installPath string, reporter progress.Reporter) error {
+func (a *HomebrewRelocateAction) fixElfRpath(binaryPath, installPath string, findPatchelf patchelfFinder, reporter progress.Reporter) error {
 	// Find patchelf using multi-location discovery
-	patchelfPath, err := a.findPatchelf(ctx)
+	patchelfPath, err := findPatchelf()
 	if err != nil {
 		return fmt.Errorf("cannot fix RPATH for %s: %w", filepath.Base(binaryPath), err)
 	}
@@ -949,7 +1055,7 @@ func (a *HomebrewRelocateAction) addChainEntriesToMachO(
 // per-binary fixElfRpath pass that wipes stale HOMEBREW rpaths and sets
 // the $ORIGIN anchor), so the chain entries are appended to a clean
 // baseline rather than racing the wipe.
-func (a *HomebrewRelocateAction) fixElfRpathChain(ctx *ExecutionContext, installPath string, extra []chainEntry, reporter progress.Reporter) error {
+func (a *HomebrewRelocateAction) fixElfRpathChain(ctx *ExecutionContext, installPath string, extra []chainEntry, findPatchelf patchelfFinder, reporter progress.Reporter) error {
 	// Only run on Linux
 	if runtime.GOOS != "linux" {
 		return nil
@@ -996,7 +1102,7 @@ func (a *HomebrewRelocateAction) fixElfRpathChain(ctx *ExecutionContext, install
 	reporter.Log("   Chaining RPATHs for %d ELF file(s) with %d runtime dependency(ies)",
 		len(binaries), len(entries))
 
-	patchelfPath, err := a.findPatchelf(ctx)
+	patchelfPath, err := findPatchelf()
 	if err != nil {
 		// Without patchelf the chain cannot be applied; surface a clear error
 		// so the install fails loudly rather than producing under-linked

--- a/internal/actions/homebrew_relocate.go
+++ b/internal/actions/homebrew_relocate.go
@@ -388,9 +388,9 @@ func (a *HomebrewRelocateAction) fixBinaryRpath(binaryPath, installPath string, 
 }
 
 // patchelfFinder resolves a patchelf binary that can actually execute on this
-// host. Implementations resolve once and return the same path (or the same
-// error) on every later call, so a relocation pass that patches many binaries
-// probes for patchelf at most once.
+// host. It resolves on the first call and returns the same path (or the same
+// error) on every call after that, so a relocation pass that patches many
+// binaries searches for patchelf once rather than once per binary.
 type patchelfFinder func() (string, error)
 
 // newPatchelfFinder returns a patchelfFinder backed by a.findPatchelf(ctx).
@@ -447,9 +447,9 @@ func verifyPatchelfRunnable(path string) error {
 
 	if m := glibcVersionPattern.FindStringSubmatch(text); m != nil {
 		return fmt.Errorf("patchelf at %s needs glibc %s, which is newer than this "+
-			"system's C library, so it cannot run. Install patchelf with "+
-			"'apt install patchelf' or 'yum install patchelf' and tsuku will use that "+
-			"one instead. Loader reported: %s", path, m[1], text)
+			"system's C library, so it cannot run. Install patchelf with your system "+
+			"package manager (for example 'apt install patchelf') and tsuku will use "+
+			"that one instead. Loader reported: %s", path, m[1], text)
 	}
 
 	if text == "" {
@@ -464,10 +464,14 @@ func verifyPatchelfRunnable(path string) error {
 //  3. $TSUKU_HOME/tools/patchelf-*/bin/patchelf (glob for any installed version)
 //  4. $TSUKU_HOME/tools/current/patchelf (current symlink)
 //
-// Each candidate is probed with verifyPatchelfRunnable and skipped if it cannot
-// execute, so a host where tsuku's own bottled patchelf is unusable still
-// installs successfully when a working patchelf exists elsewhere — typically
-// one from the system package manager.
+// Each candidate is executed (`patchelf --version`) and skipped if it cannot
+// run, so a host where tsuku's own bottled patchelf is unusable still installs
+// successfully when a working patchelf exists elsewhere — typically one from
+// the system package manager. Note that this makes the function spawn
+// processes, which a name beginning "find" does not suggest.
+//
+// Relocation passes must not call this directly: go through the patchelfFinder
+// that Execute builds, or every binary in the bottle re-runs the whole search.
 //
 // Returns the path to the first runnable candidate. When candidates were found
 // but none run, it reports why one of them failed rather than claiming patchelf
@@ -501,8 +505,18 @@ func (a *HomebrewRelocateAction) findPatchelf(ctx *ExecutionContext) (string, er
 		candidates = append(candidates, candidate{p, true})
 	}
 
+	// The same binary can surface more than once — an ExecPaths entry that is
+	// also on PATH, or a versioned dir that tools/current points at — and
+	// probing it twice would spawn a process to learn what we already know.
+	probed := make(map[string]bool, len(candidates))
+
 	var firstFailure, firstTsukuFailure error
 	for _, c := range candidates {
+		if probed[c.path] {
+			continue
+		}
+		probed[c.path] = true
+
 		err := verifyPatchelfRunnable(c.path)
 		if err == nil {
 			return c.path, nil

--- a/internal/actions/homebrew_relocate.go
+++ b/internal/actions/homebrew_relocate.go
@@ -446,13 +446,10 @@ func verifyPatchelfRunnable(path string) error {
 	text := strings.TrimSpace(string(output))
 
 	if m := glibcVersionPattern.FindStringSubmatch(text); m != nil {
-		required := m[1]
-		return fmt.Errorf("patchelf at %s cannot run on this system: it needs glibc %s, "+
-			"which is newer than this system's C library. tsuku installs patchelf from a "+
-			"Homebrew bottle, and Homebrew builds its Linux bottles against a recent glibc. "+
-			"Install patchelf with your system package manager so tsuku can use that one "+
-			"instead, or run tsuku on a system with glibc %s or newer. Loader reported: %s",
-			path, required, required, text)
+		return fmt.Errorf("patchelf at %s needs glibc %s, which is newer than this "+
+			"system's C library, so it cannot run. Install patchelf with "+
+			"'apt install patchelf' or 'yum install patchelf' and tsuku will use that "+
+			"one instead. Loader reported: %s", path, m[1], text)
 	}
 
 	if text == "" {
@@ -493,9 +490,7 @@ func (a *HomebrewRelocateAction) findPatchelf(ctx *ExecutionContext) (string, er
 	}
 
 	// 3-4. Check $TSUKU_HOME tools directory (glob and current symlink)
-	if p, err := a.findPatchelfInToolsDir(ctx.ToolsDir, ctx.CurrentDir); err == nil {
-		candidates = append(candidates, p)
-	}
+	candidates = append(candidates, a.patchelfCandidatesInToolsDir(ctx.ToolsDir, ctx.CurrentDir)...)
 
 	var firstUnrunnable error
 	for _, candidate := range candidates {
@@ -515,15 +510,29 @@ func (a *HomebrewRelocateAction) findPatchelf(ctx *ExecutionContext) (string, er
 	return "", fmt.Errorf("patchelf not found: checked ExecPaths, system PATH, %s/patchelf-*/bin/, and %s/", ctx.ToolsDir, ctx.CurrentDir)
 }
 
-// findPatchelfInToolsDir searches for patchelf in the tsuku tools directory.
-// It first globs for versioned install dirs, then checks the current symlink dir.
-func (a *HomebrewRelocateAction) findPatchelfInToolsDir(toolsDir, currentDir string) (string, error) {
+// patchelfCandidatesInToolsDir returns every patchelf in the tsuku tools
+// directory, most-preferred first: the versioned install dirs in reverse glob
+// order, then the current symlink dir.
+//
+// It returns all of them rather than just the best one so findPatchelf can
+// probe each in turn. Keeping only the top match would let a single unrunnable
+// install mask a working one sitting beside it — which is exactly the
+// situation a glibc-mismatched patchelf creates.
+//
+// Reverse glob order approximates newest-first. It is only an approximation:
+// the sort is lexicographic, so "patchelf-0.9.0" sorts above
+// "patchelf-0.19.1". That inversion no longer decides anything on its own,
+// since every candidate is probed and the first runnable one wins.
+func (a *HomebrewRelocateAction) patchelfCandidatesInToolsDir(toolsDir, currentDir string) []string {
+	var candidates []string
+
 	// Glob $TSUKU_HOME/tools/patchelf-*/bin/patchelf
 	if toolsDir != "" {
 		matches, err := filepath.Glob(filepath.Join(toolsDir, "patchelf-*", "bin", "patchelf"))
-		if err == nil && len(matches) > 0 {
-			// Use the last match (highest version due to lexicographic sort)
-			return matches[len(matches)-1], nil
+		if err == nil {
+			for i := len(matches) - 1; i >= 0; i-- {
+				candidates = append(candidates, matches[i])
+			}
 		}
 	}
 
@@ -531,10 +540,19 @@ func (a *HomebrewRelocateAction) findPatchelfInToolsDir(toolsDir, currentDir str
 	if currentDir != "" {
 		candidate := filepath.Join(currentDir, "patchelf")
 		if _, err := os.Stat(candidate); err == nil {
-			return candidate, nil
+			candidates = append(candidates, candidate)
 		}
 	}
 
+	return candidates
+}
+
+// findPatchelfInToolsDir returns the most-preferred patchelf in the tsuku
+// tools directory, without checking whether it runs.
+func (a *HomebrewRelocateAction) findPatchelfInToolsDir(toolsDir, currentDir string) (string, error) {
+	if candidates := a.patchelfCandidatesInToolsDir(toolsDir, currentDir); len(candidates) > 0 {
+		return candidates[0], nil
+	}
 	return "", fmt.Errorf("patchelf not found in tools directory")
 }
 

--- a/internal/actions/homebrew_relocate.go
+++ b/internal/actions/homebrew_relocate.go
@@ -470,41 +470,56 @@ func verifyPatchelfRunnable(path string) error {
 // one from the system package manager.
 //
 // Returns the path to the first runnable candidate. When candidates were found
-// but none of them run, the returned error describes why the first one did not,
-// which is far more useful than reporting that patchelf is missing when it
-// plainly is not.
+// but none run, it reports why one of them failed rather than claiming patchelf
+// is missing. A tsuku-installed candidate's failure is preferred over a system
+// one's, since that is the copy the user can act on — telling someone whose
+// system patchelf just failed to install patchelf would be circular.
 func (a *HomebrewRelocateAction) findPatchelf(ctx *ExecutionContext) (string, error) {
-	var candidates []string
+	// tsukuProvided distinguishes copies tsuku installed from whatever is on
+	// PATH; it only affects which failure gets reported.
+	type candidate struct {
+		path          string
+		tsukuProvided bool
+	}
+	var candidates []candidate
 
 	// 1. Check ExecPaths (dependency bin dirs from earlier plan steps)
 	for _, p := range ctx.ExecPaths {
-		candidate := filepath.Join(p, "patchelf")
-		if _, err := os.Stat(candidate); err == nil {
-			candidates = append(candidates, candidate)
+		path := filepath.Join(p, "patchelf")
+		if _, err := os.Stat(path); err == nil {
+			candidates = append(candidates, candidate{path, true})
 		}
 	}
 
 	// 2. Check system PATH
 	if p, err := exec.LookPath("patchelf"); err == nil {
-		candidates = append(candidates, p)
+		candidates = append(candidates, candidate{p, false})
 	}
 
 	// 3-4. Check $TSUKU_HOME tools directory (glob and current symlink)
-	candidates = append(candidates, a.patchelfCandidatesInToolsDir(ctx.ToolsDir, ctx.CurrentDir)...)
-
-	var firstUnrunnable error
-	for _, candidate := range candidates {
-		if err := verifyPatchelfRunnable(candidate); err != nil {
-			if firstUnrunnable == nil {
-				firstUnrunnable = err
-			}
-			continue
-		}
-		return candidate, nil
+	for _, p := range a.patchelfCandidatesInToolsDir(ctx.ToolsDir, ctx.CurrentDir) {
+		candidates = append(candidates, candidate{p, true})
 	}
 
-	if firstUnrunnable != nil {
-		return "", firstUnrunnable
+	var firstFailure, firstTsukuFailure error
+	for _, c := range candidates {
+		err := verifyPatchelfRunnable(c.path)
+		if err == nil {
+			return c.path, nil
+		}
+		if firstFailure == nil {
+			firstFailure = err
+		}
+		if c.tsukuProvided && firstTsukuFailure == nil {
+			firstTsukuFailure = err
+		}
+	}
+
+	if firstTsukuFailure != nil {
+		return "", firstTsukuFailure
+	}
+	if firstFailure != nil {
+		return "", firstFailure
 	}
 
 	return "", fmt.Errorf("patchelf not found: checked ExecPaths, system PATH, %s/patchelf-*/bin/, and %s/", ctx.ToolsDir, ctx.CurrentDir)
@@ -519,10 +534,9 @@ func (a *HomebrewRelocateAction) findPatchelf(ctx *ExecutionContext) (string, er
 // install mask a working one sitting beside it — which is exactly the
 // situation a glibc-mismatched patchelf creates.
 //
-// Reverse glob order approximates newest-first. It is only an approximation:
-// the sort is lexicographic, so "patchelf-0.9.0" sorts above
-// "patchelf-0.19.1". That inversion no longer decides anything on its own,
-// since every candidate is probed and the first runnable one wins.
+// Reverse glob order approximates newest-first. The sort is lexicographic, so
+// it is only an approximation, but nothing rests on it: every candidate is
+// probed and the first runnable one wins.
 func (a *HomebrewRelocateAction) patchelfCandidatesInToolsDir(toolsDir, currentDir string) []string {
 	var candidates []string
 
@@ -545,15 +559,6 @@ func (a *HomebrewRelocateAction) patchelfCandidatesInToolsDir(toolsDir, currentD
 	}
 
 	return candidates
-}
-
-// findPatchelfInToolsDir returns the most-preferred patchelf in the tsuku
-// tools directory, without checking whether it runs.
-func (a *HomebrewRelocateAction) findPatchelfInToolsDir(toolsDir, currentDir string) (string, error) {
-	if candidates := a.patchelfCandidatesInToolsDir(toolsDir, currentDir); len(candidates) > 0 {
-		return candidates[0], nil
-	}
-	return "", fmt.Errorf("patchelf not found in tools directory")
 }
 
 // fixElfRpath uses patchelf to set RPATH on Linux ELF binaries

--- a/internal/actions/homebrew_relocate_test.go
+++ b/internal/actions/homebrew_relocate_test.go
@@ -170,7 +170,7 @@ func TestVerifyPatchelfRunnable_GlibcMismatch(t *testing.T) {
 	// The point of the check is that the caller learns the cause without
 	// having to interpret a loader message, so assert on the explanation
 	// rather than on the passed-through loader text.
-	for _, want := range []string{"cannot run on this system", "glibc", "2.38", path} {
+	for _, want := range []string{"cannot run", "glibc", "2.38", "apt install patchelf", path} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("error message = %q, want it to contain %q", msg, want)
 		}
@@ -220,6 +220,36 @@ func TestFindPatchelf_SkipsUnrunnableCandidate(t *testing.T) {
 	}
 	if got != working {
 		t.Errorf("findPatchelf() = %q, want the runnable candidate %q", got, working)
+	}
+}
+
+// TestFindPatchelf_SkipsUnrunnableToolsDirInstall covers the same fallback one
+// level down: when tsuku has installed several patchelf versions and the
+// preferred one cannot run, the others must still be considered. Returning
+// only the top match would let one broken install mask a working one sitting
+// beside it.
+func TestFindPatchelf_SkipsUnrunnableToolsDirInstall(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv()
+	action := &HomebrewRelocateAction{}
+
+	t.Setenv("PATH", t.TempDir())
+
+	toolsDir := filepath.Join(t.TempDir(), "tools")
+	// Reverse glob order makes 0.19.1 the preferred candidate.
+	writeFakePatchelf(t, filepath.Join(toolsDir, "patchelf-0.19.1", "bin"), glibcLoaderFailureBody)
+	working := writeFakePatchelf(t, filepath.Join(toolsDir, "patchelf-0.18.0", "bin"), "")
+
+	ctx := &ExecutionContext{
+		ToolsDir:   toolsDir,
+		CurrentDir: filepath.Join(toolsDir, "current"),
+	}
+
+	got, err := action.findPatchelf(ctx)
+	if err != nil {
+		t.Fatalf("findPatchelf() returned error: %v", err)
+	}
+	if got != working {
+		t.Errorf("findPatchelf() = %q, want the runnable older install %q", got, working)
 	}
 }
 

--- a/internal/actions/homebrew_relocate_test.go
+++ b/internal/actions/homebrew_relocate_test.go
@@ -121,6 +121,215 @@ func TestFindPatchelf_NotFound_ReturnsError(t *testing.T) {
 	}
 }
 
+// -- patchelf runnability tests --
+
+// writeFakePatchelf writes an executable shell script named "patchelf" into
+// dir, with body as its contents after the shebang, and returns its path.
+func writeFakePatchelf(t *testing.T, dir, body string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "patchelf")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// glibcLoaderFailureBody makes a fake patchelf reproduce what the dynamic
+// loader prints when a binary needs a newer glibc than the host provides —
+// the exact failure mode of issue #2447, where the Homebrew patchelf bottle
+// wants GLIBC_2.38 on an image that ships something older.
+//
+// The backtick is escaped because the message is inside shell double quotes,
+// where an unescaped one would start a command substitution. Go itself needs
+// no escaping for it.
+const glibcLoaderFailureBody = "echo \"$0: /lib/x86_64-linux-gnu/libc.so.6: version \\`GLIBC_2.38' not found (required by $0)\" >&2\nexit 1\n"
+
+func TestVerifyPatchelfRunnable_Runnable(t *testing.T) {
+	t.Parallel()
+	// An empty script exits 0 for any arguments, standing in for a patchelf
+	// that answers --version normally.
+	path := writeFakePatchelf(t, t.TempDir(), "")
+	if err := verifyPatchelfRunnable(path); err != nil {
+		t.Errorf("verifyPatchelfRunnable() on a runnable binary = %v, want nil", err)
+	}
+}
+
+func TestVerifyPatchelfRunnable_GlibcMismatch(t *testing.T) {
+	t.Parallel()
+	path := writeFakePatchelf(t, t.TempDir(), glibcLoaderFailureBody)
+
+	err := verifyPatchelfRunnable(path)
+	if err == nil {
+		t.Fatal("verifyPatchelfRunnable() on an unrunnable binary = nil, want error")
+	}
+
+	msg := err.Error()
+	// The point of the check is that the caller learns the cause without
+	// having to interpret a loader message, so assert on the explanation
+	// rather than on the passed-through loader text.
+	for _, want := range []string{"cannot run on this system", "glibc", "2.38", path} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("error message = %q, want it to contain %q", msg, want)
+		}
+	}
+}
+
+func TestVerifyPatchelfRunnable_GenericFailure(t *testing.T) {
+	t.Parallel()
+	path := writeFakePatchelf(t, t.TempDir(), "echo 'illegal instruction' >&2\nexit 132\n")
+
+	err := verifyPatchelfRunnable(path)
+	if err == nil {
+		t.Fatal("verifyPatchelfRunnable() on a failing binary = nil, want error")
+	}
+
+	msg := err.Error()
+	if !strings.Contains(msg, "illegal instruction") {
+		t.Errorf("error message = %q, want it to carry the command output", msg)
+	}
+	// A failure that isn't a symbol-version problem must not be reported as one.
+	if strings.Contains(msg, "glibc") {
+		t.Errorf("error message = %q, want no glibc claim for an unrelated failure", msg)
+	}
+}
+
+// TestFindPatchelf_SkipsUnrunnableCandidate covers the fallback that keeps an
+// install alive when tsuku's own patchelf cannot execute but another one on
+// the host can — the realistic recovery for a user whose distribution ships an
+// older glibc and who has installed patchelf from their package manager.
+func TestFindPatchelf_SkipsUnrunnableCandidate(t *testing.T) {
+	t.Parallel()
+	action := &HomebrewRelocateAction{}
+
+	tmpDir := t.TempDir()
+	brokenDir := filepath.Join(tmpDir, "broken")
+	workingDir := filepath.Join(tmpDir, "working")
+	writeFakePatchelf(t, brokenDir, glibcLoaderFailureBody)
+	working := writeFakePatchelf(t, workingDir, "")
+
+	ctx := &ExecutionContext{
+		ExecPaths: []string{brokenDir, workingDir},
+	}
+
+	got, err := action.findPatchelf(ctx)
+	if err != nil {
+		t.Fatalf("findPatchelf() returned error: %v", err)
+	}
+	if got != working {
+		t.Errorf("findPatchelf() = %q, want the runnable candidate %q", got, working)
+	}
+}
+
+// TestFindPatchelf_AllCandidatesUnrunnable_ReportsCause guards against the
+// regression that motivated this check: reporting "patchelf not found" when
+// patchelf is present and merely unusable sends the reader looking for a
+// missing dependency instead of a glibc mismatch.
+func TestFindPatchelf_AllCandidatesUnrunnable_ReportsCause(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv()
+	action := &HomebrewRelocateAction{}
+
+	// Override PATH so a real system patchelf can't satisfy the lookup.
+	t.Setenv("PATH", t.TempDir())
+
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	writeFakePatchelf(t, binDir, glibcLoaderFailureBody)
+
+	ctx := &ExecutionContext{
+		ExecPaths:  []string{binDir},
+		ToolsDir:   filepath.Join(tmpDir, "tools"),
+		CurrentDir: filepath.Join(tmpDir, "tools", "current"),
+	}
+
+	_, err := action.findPatchelf(ctx)
+	if err == nil {
+		t.Fatal("findPatchelf() with only unrunnable candidates = nil, want error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "glibc") || !strings.Contains(msg, "2.38") {
+		t.Errorf("error message = %q, want it to name the glibc mismatch", msg)
+	}
+	if strings.Contains(msg, "patchelf not found") {
+		t.Errorf("error message = %q, want it not to claim patchelf is missing", msg)
+	}
+}
+
+// TestPatchelfFinder_ResolvesOnce is the regression guard for the "probe once
+// per install, not once per binary" property. Without memoization a bottle
+// with many binaries would spawn a patchelf process per binary just to check
+// that patchelf works.
+func TestPatchelfFinder_ResolvesOnce(t *testing.T) {
+	t.Parallel()
+	action := &HomebrewRelocateAction{}
+
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	counter := filepath.Join(tmpDir, "invocations")
+	expected := writeFakePatchelf(t, binDir, "echo x >> "+counter+"\n")
+
+	ctx := &ExecutionContext{ExecPaths: []string{binDir}}
+	finder := newPatchelfFinder(action, ctx)
+
+	for i := 0; i < 3; i++ {
+		got, err := finder()
+		if err != nil {
+			t.Fatalf("finder() call %d returned error: %v", i, err)
+		}
+		if got != expected {
+			t.Errorf("finder() call %d = %q, want %q", i, got, expected)
+		}
+	}
+
+	data, err := os.ReadFile(counter)
+	if err != nil {
+		t.Fatalf("reading invocation counter: %v", err)
+	}
+	if n := len(strings.Fields(string(data))); n != 1 {
+		t.Errorf("patchelf was invoked %d times across 3 finder calls, want 1", n)
+	}
+}
+
+// TestFixBinaryRpath_UnrunnablePatchelfNamesCause is the end-to-end assertion
+// for the reporting behavior: an ELF binary dispatched for RPATH fixup with
+// an unrunnable patchelf must fail with the cause named, not with the loader's
+// raw output. Execute wires the same finder into this pass and the ELF chain
+// walk, so both report identically.
+func TestFixBinaryRpath_UnrunnablePatchelfNamesCause(t *testing.T) {
+	// Cannot use t.Parallel() with t.Setenv()
+	action := &HomebrewRelocateAction{}
+
+	t.Setenv("PATH", t.TempDir())
+
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	writeFakePatchelf(t, binDir, glibcLoaderFailureBody)
+
+	// Magic bytes are what routes fixBinaryRpath to the ELF path, so a stub
+	// header is enough to reach the patchelf lookup on any host.
+	fixture := filepath.Join(tmpDir, "make")
+	if err := os.WriteFile(fixture, []byte{0x7f, 'E', 'L', 'F', 0x02, 0x01, 0x01}, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := &ExecutionContext{
+		ExecPaths:  []string{binDir},
+		ToolsDir:   filepath.Join(tmpDir, "tools"),
+		CurrentDir: filepath.Join(tmpDir, "tools", "current"),
+	}
+
+	err := action.fixBinaryRpath(fixture, "/opt/make", newPatchelfFinder(action, ctx), progress.NoopReporter{})
+	if err == nil {
+		t.Fatal("fixBinaryRpath() with an unrunnable patchelf = nil, want error")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "glibc") || !strings.Contains(msg, "2.38") {
+		t.Errorf("error message = %q, want it to name the glibc mismatch", msg)
+	}
+}
+
 // -- findPatchelfInToolsDir tests (test glob/current fallback directly) --
 
 func TestFindPatchelfInToolsDir_Glob(t *testing.T) {
@@ -737,7 +946,7 @@ func TestFixElfRpathChain_NonLinuxIsNoOp(t *testing.T) {
 		},
 	}
 
-	err := action.fixElfRpathChain(ctx, "/unused", nil, progress.NoopReporter{})
+	err := action.fixElfRpathChain(ctx, "/unused", nil, newPatchelfFinder(action, ctx), progress.NoopReporter{})
 	if err != nil {
 		t.Fatalf("fixElfRpathChain on non-linux = %v, want nil", err)
 	}
@@ -762,7 +971,7 @@ func TestFixElfRpathChain_EmptyRuntimeDepsIsNoOp(t *testing.T) {
 		Dependencies: ResolvedDeps{}, // RuntimeDependencies is nil
 	}
 
-	err := action.fixElfRpathChain(ctx, "/unused", nil, progress.NoopReporter{})
+	err := action.fixElfRpathChain(ctx, "/unused", nil, newPatchelfFinder(action, ctx), progress.NoopReporter{})
 	if err != nil {
 		t.Fatalf("fixElfRpathChain with empty RuntimeDeps = %v, want nil", err)
 	}
@@ -875,7 +1084,7 @@ func TestFixElfRpathChain_WritesDTRpath(t *testing.T) {
 		},
 	}
 
-	if err := action.fixElfRpathChain(ctx, installPath, nil, progress.NoopReporter{}); err != nil {
+	if err := action.fixElfRpathChain(ctx, installPath, nil, newPatchelfFinder(action, ctx), progress.NoopReporter{}); err != nil {
 		t.Fatalf("fixElfRpathChain returned error: %v", err)
 	}
 

--- a/internal/actions/homebrew_relocate_test.go
+++ b/internal/actions/homebrew_relocate_test.go
@@ -150,8 +150,14 @@ func writeFakePatchelf(t *testing.T, dir, body string) string {
 // the exact failure mode of issue #2447, where the Homebrew patchelf bottle
 // wants GLIBC_2.38 on an image that ships something older.
 //
-// The backtick is escaped because the message sits inside shell double quotes,
-// where an unescaped one would start a command substitution.
+// Two things to know before editing this. The backtick is escaped because the
+// message sits inside shell double quotes, where an unescaped one would start a
+// command substitution; Go needs no escape for it. And this has to stay a
+// double-quoted Go literal — a raw (backquoted) string cannot contain a
+// backtick at all, so converting it for readability is not possible.
+//
+// The two $0s are live shell expansions, not literal text: anything else with a
+// $ added here will expand too.
 const glibcLoaderFailureBody = "echo \"$0: /lib/x86_64-linux-gnu/libc.so.6: version \\`GLIBC_2.38' not found (required by $0)\" >&2\nexit 1\n"
 
 func TestVerifyPatchelfRunnable_Runnable(t *testing.T) {
@@ -210,6 +216,10 @@ func TestVerifyPatchelfRunnable_GenericFailure(t *testing.T) {
 func TestFindPatchelf_SkipsUnrunnableCandidate(t *testing.T) {
 	// No t.Parallel(): writes then execs a fake patchelf (see writeFakePatchelf).
 	action := &HomebrewRelocateAction{}
+
+	// Neutralize PATH so the assertion rests on the ExecPaths ordering under
+	// test rather than on ExecPaths happening to be searched before PATH.
+	t.Setenv("PATH", t.TempDir())
 
 	tmpDir := t.TempDir()
 	brokenDir := filepath.Join(tmpDir, "broken")
@@ -326,6 +336,45 @@ func TestPatchelfFinder_ResolvesOnce(t *testing.T) {
 	}
 	if n := len(strings.Fields(string(data))); n != 1 {
 		t.Errorf("patchelf was invoked %d times across 3 finder calls, want 1", n)
+	}
+}
+
+// TestPatchelfFinder_MemoizesFailure covers the other half of the finder's
+// contract. A failed search is as expensive as a successful one, and a bottle
+// full of ELF binaries would re-run it per binary if only success were cached.
+func TestPatchelfFinder_MemoizesFailure(t *testing.T) {
+	// No t.Parallel(): writes then execs a fake patchelf (see writeFakePatchelf).
+	action := &HomebrewRelocateAction{}
+
+	t.Setenv("PATH", t.TempDir())
+
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "bin")
+	counter := filepath.Join(tmpDir, "invocations")
+	writeFakePatchelf(t, binDir, "echo x >> "+counter+"\n"+glibcLoaderFailureBody)
+
+	ctx := &ExecutionContext{ExecPaths: []string{binDir}}
+	finder := newPatchelfFinder(action, ctx)
+
+	var first error
+	for i := 0; i < 3; i++ {
+		_, err := finder()
+		if err == nil {
+			t.Fatalf("finder() call %d = nil error, want the glibc failure", i)
+		}
+		if i == 0 {
+			first = err
+		} else if err.Error() != first.Error() {
+			t.Errorf("finder() call %d returned a different error:\n got %v\nwant %v", i, err, first)
+		}
+	}
+
+	data, err := os.ReadFile(counter)
+	if err != nil {
+		t.Fatalf("reading invocation counter: %v", err)
+	}
+	if n := len(strings.Fields(string(data))); n != 1 {
+		t.Errorf("patchelf was invoked %d times across 3 failing finder calls, want 1", n)
 	}
 }
 

--- a/internal/actions/homebrew_relocate_test.go
+++ b/internal/actions/homebrew_relocate_test.go
@@ -72,7 +72,7 @@ func TestHomebrewRelocateAction_ExtractBottlePrefixes_NoInstallSegment(t *testin
 // -- findPatchelf discovery tests --
 
 func TestFindPatchelf_ExecPaths(t *testing.T) {
-	t.Parallel()
+	// No t.Parallel(): writes then execs a fake patchelf (see writeFakePatchelf).
 	action := &HomebrewRelocateAction{}
 
 	// Create a temporary bin dir with a fake patchelf
@@ -125,6 +125,14 @@ func TestFindPatchelf_NotFound_ReturnsError(t *testing.T) {
 
 // writeFakePatchelf writes an executable shell script named "patchelf" into
 // dir, with body as its contents after the shebang, and returns its path.
+//
+// Tests that write a fake and then run it must NOT call t.Parallel(). Go's
+// fork inherits open file descriptors, so a fork in one goroutine racing a
+// WriteFile in another can leave the child holding the new script open for
+// writing, and the subsequent exec fails with ETXTBSY (golang/go#22315). The
+// symptom is an assertion failing against "text file busy" instead of the
+// message under test, intermittently. Keeping these tests sequential keeps
+// their writes away from other tests' forks.
 func writeFakePatchelf(t *testing.T, dir, body string) string {
 	t.Helper()
 	if err := os.MkdirAll(dir, 0o755); err != nil {
@@ -142,13 +150,12 @@ func writeFakePatchelf(t *testing.T, dir, body string) string {
 // the exact failure mode of issue #2447, where the Homebrew patchelf bottle
 // wants GLIBC_2.38 on an image that ships something older.
 //
-// The backtick is escaped because the message is inside shell double quotes,
-// where an unescaped one would start a command substitution. Go itself needs
-// no escaping for it.
+// The backtick is escaped because the message sits inside shell double quotes,
+// where an unescaped one would start a command substitution.
 const glibcLoaderFailureBody = "echo \"$0: /lib/x86_64-linux-gnu/libc.so.6: version \\`GLIBC_2.38' not found (required by $0)\" >&2\nexit 1\n"
 
 func TestVerifyPatchelfRunnable_Runnable(t *testing.T) {
-	t.Parallel()
+	// No t.Parallel(): writes then execs a fake patchelf (see writeFakePatchelf).
 	// An empty script exits 0 for any arguments, standing in for a patchelf
 	// that answers --version normally.
 	path := writeFakePatchelf(t, t.TempDir(), "")
@@ -158,7 +165,7 @@ func TestVerifyPatchelfRunnable_Runnable(t *testing.T) {
 }
 
 func TestVerifyPatchelfRunnable_GlibcMismatch(t *testing.T) {
-	t.Parallel()
+	// No t.Parallel(): writes then execs a fake patchelf (see writeFakePatchelf).
 	path := writeFakePatchelf(t, t.TempDir(), glibcLoaderFailureBody)
 
 	err := verifyPatchelfRunnable(path)
@@ -178,7 +185,7 @@ func TestVerifyPatchelfRunnable_GlibcMismatch(t *testing.T) {
 }
 
 func TestVerifyPatchelfRunnable_GenericFailure(t *testing.T) {
-	t.Parallel()
+	// No t.Parallel(): writes then execs a fake patchelf (see writeFakePatchelf).
 	path := writeFakePatchelf(t, t.TempDir(), "echo 'illegal instruction' >&2\nexit 132\n")
 
 	err := verifyPatchelfRunnable(path)
@@ -201,7 +208,7 @@ func TestVerifyPatchelfRunnable_GenericFailure(t *testing.T) {
 // the host can — the realistic recovery for a user whose distribution ships an
 // older glibc and who has installed patchelf from their package manager.
 func TestFindPatchelf_SkipsUnrunnableCandidate(t *testing.T) {
-	t.Parallel()
+	// No t.Parallel(): writes then execs a fake patchelf (see writeFakePatchelf).
 	action := &HomebrewRelocateAction{}
 
 	tmpDir := t.TempDir()
@@ -292,7 +299,7 @@ func TestFindPatchelf_AllCandidatesUnrunnable_ReportsCause(t *testing.T) {
 // with many binaries would spawn a patchelf process per binary just to check
 // that patchelf works.
 func TestPatchelfFinder_ResolvesOnce(t *testing.T) {
-	t.Parallel()
+	// No t.Parallel(): writes then execs a fake patchelf (see writeFakePatchelf).
 	action := &HomebrewRelocateAction{}
 
 	tmpDir := t.TempDir()
@@ -360,7 +367,18 @@ func TestFixBinaryRpath_UnrunnablePatchelfNamesCause(t *testing.T) {
 	}
 }
 
-// -- findPatchelfInToolsDir tests (test glob/current fallback directly) --
+// -- patchelfCandidatesInToolsDir tests (glob/current discovery, no probing) --
+
+// firstCandidate returns the most-preferred candidate, failing the test if the
+// list is empty. Discovery order is what these tests pin down; which candidate
+// survives probing is covered by the findPatchelf tests above.
+func firstCandidate(t *testing.T, candidates []string) string {
+	t.Helper()
+	if len(candidates) == 0 {
+		t.Fatal("patchelfCandidatesInToolsDir() returned no candidates")
+	}
+	return candidates[0]
+}
 
 func TestFindPatchelfInToolsDir_Glob(t *testing.T) {
 	t.Parallel()
@@ -378,12 +396,9 @@ func TestFindPatchelfInToolsDir_Glob(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := action.findPatchelfInToolsDir(toolsDir, filepath.Join(toolsDir, "current"))
-	if err != nil {
-		t.Fatalf("findPatchelfInToolsDir() returned error: %v", err)
-	}
+	got := firstCandidate(t, action.patchelfCandidatesInToolsDir(toolsDir, filepath.Join(toolsDir, "current")))
 	if got != fakePatchelf {
-		t.Errorf("findPatchelfInToolsDir() = %q, want %q", got, fakePatchelf)
+		t.Errorf("patchelfCandidatesInToolsDir() first = %q, want %q", got, fakePatchelf)
 	}
 }
 
@@ -402,12 +417,9 @@ func TestFindPatchelfInToolsDir_CurrentDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got, err := action.findPatchelfInToolsDir(filepath.Join(tmpDir, "tools"), currentDir)
-	if err != nil {
-		t.Fatalf("findPatchelfInToolsDir() returned error: %v", err)
-	}
+	got := firstCandidate(t, action.patchelfCandidatesInToolsDir(filepath.Join(tmpDir, "tools"), currentDir))
 	if got != fakePatchelf {
-		t.Errorf("findPatchelfInToolsDir() = %q, want %q", got, fakePatchelf)
+		t.Errorf("patchelfCandidatesInToolsDir() first = %q, want %q", got, fakePatchelf)
 	}
 }
 
@@ -428,14 +440,11 @@ func TestFindPatchelfInToolsDir_PicksLatestVersion(t *testing.T) {
 		}
 	}
 
-	got, err := action.findPatchelfInToolsDir(toolsDir, filepath.Join(toolsDir, "current"))
-	if err != nil {
-		t.Fatalf("findPatchelfInToolsDir() returned error: %v", err)
-	}
+	got := firstCandidate(t, action.patchelfCandidatesInToolsDir(toolsDir, filepath.Join(toolsDir, "current")))
 	// Should pick 0.18.0 (last in lexicographic order)
 	want := filepath.Join(toolsDir, "patchelf-0.18.0", "bin", "patchelf")
 	if got != want {
-		t.Errorf("findPatchelfInToolsDir() = %q, want %q (latest version)", got, want)
+		t.Errorf("patchelfCandidatesInToolsDir() first = %q, want %q (latest version)", got, want)
 	}
 }
 
@@ -444,9 +453,9 @@ func TestFindPatchelfInToolsDir_NotFound(t *testing.T) {
 	action := &HomebrewRelocateAction{}
 
 	tmpDir := t.TempDir()
-	_, err := action.findPatchelfInToolsDir(filepath.Join(tmpDir, "tools"), filepath.Join(tmpDir, "tools", "current"))
-	if err == nil {
-		t.Fatal("findPatchelfInToolsDir() should return error when patchelf not found")
+	got := action.patchelfCandidatesInToolsDir(filepath.Join(tmpDir, "tools"), filepath.Join(tmpDir, "tools", "current"))
+	if len(got) != 0 {
+		t.Fatalf("patchelfCandidatesInToolsDir() = %v, want no candidates", got)
 	}
 }
 

--- a/internal/actions/homebrew_test.go
+++ b/internal/actions/homebrew_test.go
@@ -159,7 +159,7 @@ func TestHomebrewRelocateAction_RelocatePlaceholders_TextFile(t *testing.T) {
 		WorkDir:   tmpDir,
 		ExecPaths: []string{},
 	}
-	if err := action.relocatePlaceholders(ctx, installPath, installPath, "test", progress.NoopReporter{}); err != nil {
+	if err := action.relocatePlaceholders(ctx, installPath, installPath, "test", newPatchelfFinder(action, ctx), progress.NoopReporter{}); err != nil {
 		t.Fatalf("relocatePlaceholders failed: %v", err)
 	}
 
@@ -194,7 +194,7 @@ func TestHomebrewRelocateAction_RelocatePlaceholders_BinaryFile(t *testing.T) {
 		WorkDir:   tmpDir,
 		ExecPaths: []string{},
 	}
-	if err := action.relocatePlaceholders(ctx, installPath, installPath, "test", progress.NoopReporter{}); err != nil {
+	if err := action.relocatePlaceholders(ctx, installPath, installPath, "test", newPatchelfFinder(action, ctx), progress.NoopReporter{}); err != nil {
 		t.Fatalf("relocatePlaceholders failed: %v", err)
 	}
 
@@ -235,7 +235,7 @@ func TestHomebrewRelocateAction_RelocatePlaceholders_SkipsSymlinks(t *testing.T)
 		WorkDir:   tmpDir,
 		ExecPaths: []string{},
 	}
-	if err := action.relocatePlaceholders(ctx, "/opt", "/opt", "test", progress.NoopReporter{}); err != nil {
+	if err := action.relocatePlaceholders(ctx, "/opt", "/opt", "test", newPatchelfFinder(action, ctx), progress.NoopReporter{}); err != nil {
 		t.Fatalf("relocatePlaceholders failed: %v", err)
 	}
 }
@@ -257,7 +257,7 @@ func TestHomebrewRelocateAction_RelocatePlaceholders_NoPlaceholder(t *testing.T)
 		WorkDir:   tmpDir,
 		ExecPaths: []string{},
 	}
-	if err := action.relocatePlaceholders(ctx, "/opt", "/opt", "test", progress.NoopReporter{}); err != nil {
+	if err := action.relocatePlaceholders(ctx, "/opt", "/opt", "test", newPatchelfFinder(action, ctx), progress.NoopReporter{}); err != nil {
 		t.Fatalf("relocatePlaceholders failed: %v", err)
 	}
 
@@ -379,7 +379,7 @@ func TestHomebrewRelocateAction_FixBinaryRpath_UnrecognizedFormat(t *testing.T) 
 
 	// Should return nil (skip silently) for unrecognized format
 	ctx := &ExecutionContext{ExecPaths: []string{}}
-	err := action.fixBinaryRpath(ctx, testFile, "/opt/test", progress.NoopReporter{})
+	err := action.fixBinaryRpath(testFile, "/opt/test", newPatchelfFinder(action, ctx), progress.NoopReporter{})
 	if err != nil {
 		t.Errorf("fixBinaryRpath should skip unrecognized format, got error: %v", err)
 	}
@@ -392,7 +392,7 @@ func TestHomebrewRelocateAction_FixBinaryRpath_NonexistentFile(t *testing.T) {
 
 	// Try to fix RPATH on non-existent file
 	ctx := &ExecutionContext{ExecPaths: []string{}}
-	err := action.fixBinaryRpath(ctx, filepath.Join(tmpDir, "nonexistent"), "/opt/test", progress.NoopReporter{})
+	err := action.fixBinaryRpath(filepath.Join(tmpDir, "nonexistent"), "/opt/test", newPatchelfFinder(action, ctx), progress.NoopReporter{})
 	if err == nil {
 		t.Error("fixBinaryRpath should fail for nonexistent file")
 	}
@@ -411,7 +411,7 @@ func TestHomebrewRelocateAction_FixBinaryRpath_EmptyFile(t *testing.T) {
 
 	// Should return error for empty file (EOF when reading magic)
 	ctx := &ExecutionContext{ExecPaths: []string{}}
-	err := action.fixBinaryRpath(ctx, testFile, "/opt/test", progress.NoopReporter{})
+	err := action.fixBinaryRpath(testFile, "/opt/test", newPatchelfFinder(action, ctx), progress.NoopReporter{})
 	if err == nil {
 		t.Error("fixBinaryRpath should fail for empty file")
 	}
@@ -435,7 +435,7 @@ func TestHomebrewRelocateAction_RelocatePlaceholders_ReadOnlyTextFile(t *testing
 		WorkDir:   tmpDir,
 		ExecPaths: []string{},
 	}
-	if err := action.relocatePlaceholders(ctx, installPath, installPath, "test", progress.NoopReporter{}); err != nil {
+	if err := action.relocatePlaceholders(ctx, installPath, installPath, "test", newPatchelfFinder(action, ctx), progress.NoopReporter{}); err != nil {
 		t.Fatalf("relocatePlaceholders failed: %v", err)
 	}
 
@@ -475,7 +475,7 @@ func TestHomebrewRelocateAction_RelocatePlaceholders_MultipleFiles(t *testing.T)
 		WorkDir:   tmpDir,
 		ExecPaths: []string{},
 	}
-	if err := action.relocatePlaceholders(ctx, installPath, installPath, "test", progress.NoopReporter{}); err != nil {
+	if err := action.relocatePlaceholders(ctx, installPath, installPath, "test", newPatchelfFinder(action, ctx), progress.NoopReporter{}); err != nil {
 		t.Fatalf("relocatePlaceholders failed: %v", err)
 	}
 
@@ -521,7 +521,7 @@ func TestHomebrewRelocateAction_RelocatePlaceholders_NestedDirectories(t *testin
 		WorkDir:   tmpDir,
 		ExecPaths: []string{},
 	}
-	if err := action.relocatePlaceholders(ctx, installPath, installPath, "test", progress.NoopReporter{}); err != nil {
+	if err := action.relocatePlaceholders(ctx, installPath, installPath, "test", newPatchelfFinder(action, ctx), progress.NoopReporter{}); err != nil {
 		t.Fatalf("relocatePlaceholders failed: %v", err)
 	}
 
@@ -614,7 +614,7 @@ func TestHomebrewRelocateAction_FixBinaryRpath_ELFMagic(t *testing.T) {
 	// - Use patchelf if available (CI has it), or
 	// - Print warning and return nil if patchelf not found
 	ctx := &ExecutionContext{ExecPaths: []string{}}
-	err := action.fixBinaryRpath(ctx, testFile, "/opt/test", progress.NoopReporter{})
+	err := action.fixBinaryRpath(testFile, "/opt/test", newPatchelfFinder(action, ctx), progress.NoopReporter{})
 	if err != nil {
 		// patchelf may fail on invalid ELF, but that's still a valid test
 		t.Logf("fixBinaryRpath returned error (may be expected): %v", err)
@@ -650,7 +650,7 @@ func TestHomebrewRelocateAction_FixBinaryRpath_MachOMagic(t *testing.T) {
 			// - Use install_name_tool if available (macOS), or
 			// - Print warning and return nil if not found (Linux)
 			ctx := &ExecutionContext{ExecPaths: []string{}}
-			err := action.fixBinaryRpath(ctx, testFile, "/opt/test", progress.NoopReporter{})
+			err := action.fixBinaryRpath(testFile, "/opt/test", newPatchelfFinder(action, ctx), progress.NoopReporter{})
 			if err != nil {
 				// May fail on invalid binary, but still valid test
 				t.Logf("fixBinaryRpath returned error (may be expected): %v", err)
@@ -673,7 +673,7 @@ func TestHomebrewRelocateAction_FixBinaryRpath_ReadOnlyELF(t *testing.T) {
 
 	// This exercises the chmod code path in fixElfRpath
 	ctx := &ExecutionContext{ExecPaths: []string{}}
-	err := action.fixBinaryRpath(ctx, testFile, "/opt/test", progress.NoopReporter{})
+	err := action.fixBinaryRpath(testFile, "/opt/test", newPatchelfFinder(action, ctx), progress.NoopReporter{})
 	if err != nil {
 		t.Logf("fixBinaryRpath returned error (may be expected): %v", err)
 	}
@@ -700,7 +700,7 @@ func TestHomebrewRelocateAction_RelocatePlaceholders_BinaryWithELFMagic(t *testi
 		WorkDir:   tmpDir,
 		ExecPaths: []string{},
 	}
-	err := action.relocatePlaceholders(ctx, "/opt/test", "/opt/test", "test", progress.NoopReporter{})
+	err := action.relocatePlaceholders(ctx, "/opt/test", "/opt/test", "test", newPatchelfFinder(action, ctx), progress.NoopReporter{})
 	if err != nil {
 		t.Logf("relocatePlaceholders returned error (may be expected if patchelf not found): %v", err)
 	}
@@ -722,7 +722,7 @@ func TestHomebrewRelocateAction_RelocatePlaceholders_BothPlaceholders(t *testing
 		WorkDir:   tmpDir,
 		ExecPaths: []string{},
 	}
-	if err := action.relocatePlaceholders(ctx, "/opt/test", "/opt/test", "test", progress.NoopReporter{}); err != nil {
+	if err := action.relocatePlaceholders(ctx, "/opt/test", "/opt/test", "test", newPatchelfFinder(action, ctx), progress.NoopReporter{}); err != nil {
 		t.Fatalf("relocatePlaceholders failed: %v", err)
 	}
 

--- a/internal/actions/soname_scan_test.go
+++ b/internal/actions/soname_scan_test.go
@@ -573,7 +573,7 @@ func TestRunSonameScan_ChainEmitsAutoIncludeRPATH(t *testing.T) {
 	}
 
 	action := &HomebrewRelocateAction{}
-	if err := action.fixElfRpathChain(ctx, "/unused", result.AutoInclude, progress.NoopReporter{}); err != nil {
+	if err := action.fixElfRpathChain(ctx, "/unused", result.AutoInclude, newPatchelfFinder(action, ctx), progress.NoopReporter{}); err != nil {
 		t.Fatalf("fixElfRpathChain: %v", err)
 	}
 

--- a/plugins/tsuku-recipes/skills/recipe-test/SKILL.md
+++ b/plugins/tsuku-recipes/skills/recipe-test/SKILL.md
@@ -135,6 +135,8 @@ export TSUKU_HOME=$(mktemp -d)
 
 **"patchelf not found" warning.** A dependency is missing and RPATH won't be fixed. The recipe needs patchelf as a dependency, or the tool needs static linking.
 
+**"patchelf cannot run on this system" during relocation.** Different problem: patchelf installed but the host's glibc is older than the one its Homebrew bottle was built against, so nothing that needs relocation can install. Install patchelf with the system package manager -- tsuku prefers a working one over its own -- or test on a newer base image.
+
 **Golden file mismatch in CI.** Regenerate locally and diff. Use `--pin-from` to test determinism. If the change is intentional, regenerate via the Actions workflow with `commit_back` enabled.
 
 **Family-specific failures (passes on Debian, fails on Alpine).** Usually a glibc/musl difference or missing package. Test all five families before submitting. Check that family-specific install actions (`apt_install`, `apk_install`, etc.) cover every target.


### PR DESCRIPTION
Add `verifyPatchelfRunnable` to `internal/actions/homebrew_relocate.go`, which runs
`patchelf --version` and, when the dynamic loader rejects the binary over a symbol
version, returns an error naming the glibc requirement instead of passing the loader's
message through. `findPatchelf` now probes each of its four candidate locations and
returns the first one that actually executes, so a host where tsuku's own patchelf is
unusable still installs successfully when a working patchelf exists elsewhere. When
candidates were found but none run, the error says so rather than reporting patchelf as
missing.

The probe is memoized in a closure built once per `Execute` and threaded to both the
per-binary relocation pass and the ELF chain walk, so patchelf is located once per install
rather than once per binary. Resolution stays lazy, since the binary list comes from a
content heuristic and can hold files that are not ELF; resolving eagerly would fail bottles
that install fine today. The memo cannot live on `HomebrewRelocateAction`, which is
registered as a package-level singleton and would leak a resolved path across installs with
different `ExecPaths`.

Split `patchelfCandidatesInToolsDir` out of `findPatchelfInToolsDir`, which previously
returned only the highest-sorting match. One unrunnable install used to mask a working one
beside it, and a glob hit made `$TSUKU_HOME/tools/current/patchelf` unreachable, so the
documented four-candidate search was really two. All candidates are now probed in preference
order.

Move the `test-no-gcc` job in `.github/workflows/build-essentials.yml` from `ubuntu:22.04`
to `ubuntu:24.04` and record the glibc constraint in the job comment. This raises the floor
the job runs above rather than removing tsuku's dependency on the host's glibc. Add a
troubleshooting entry for the new failure mode to the recipe-test skill.

---

## This is a stopgap

Read this PR as a patch, not a resolution. It unblocks the failing job and makes the failure
legible when it recurs; it does not stop tsuku's patchelf from requiring a glibc newer than
many supported distributions provide.

The long-term solution is **#2459**: select the patchelf version by the host's glibc — pinned
on older hosts, unbounded on newer ones. That is filed with `needs-design` because tsuku
cannot express it today (neither a glibc-version predicate nor per-platform version selection
exists), and because there is a prior question worth answering deliberately: whether that is a
capability tsuku wants at all, or whether patchelf should simply stop coming from a Homebrew
bottle. #2451 is the breakage itself, and now defers to #2459 on approach.

What is durable in this PR is the reporting: an unrunnable patchelf is detected up front and
named as a glibc mismatch, and a working patchelf elsewhere on the host is used instead of
failing. Those help every affected user today and stay useful whichever way #2459 is decided.

## Root cause

The failing step is named "Build gdbm from source (uses zig cc)", which has already misled
one reviewer. zig is not involved. It installs successfully earlier in the same job; the
failure comes afterwards, while installing the `make` dependency.

tsuku installs `patchelf` from a Homebrew bottle on glibc Linux, and `homebrew_relocate`
runs it to fix RPATHs on every other bottle. Homebrew builds its Linux bottles against a
recent glibc, and the current patchelf bottle imports `GLIBC_2.38`. `ubuntu:22.04` ships
2.35, so the bottle downloaded, extracted, and installed without complaint, and only failed
when the loader was asked to run it. Because patchelf is what performs relocation, that took
every dependency needing relocation down with it.

Worth noting what the old output looked like: `patchelf --remove-rpath` failed first and was
swallowed into a `Note: Could not remove existing RPATH from make` line, then `--set-rpath`
failed hard and surfaced the loader's symbol-version complaint. Understanding that required
reading a linker error.

## Why the real fix is not here

Every approach that removes the glibc dependency — pinning patchelf, selecting by host glibc,
switching to upstream release binaries, statically linking — requires editing
`internal/recipe/recipes/patchelf.toml`. That path triggers `Validate Golden Files
(Recipes)`, and 43 of the 110 golden plan files under `testdata/golden/plans/embedded/` embed
patchelf's fully resolved step list — download URL, checksum, resolved version — because
patchelf is an install-time dependency of every Homebrew recipe. So the recipe change and a
golden regeneration travel together, into a directory this work was scoped out of while other
work was open against it.

Being precise about the strength of that claim: a pin specifically to 0.18.0 might turn out
golden-neutral, since the stored goldens already record 0.18.0. Confirming it either way means
exercising the golden pipeline over that directory, which is the thing that was out of bounds.
So this is a scoping constraint, not a demonstrated impossibility.

Beyond scope, the approach itself is not settled, which is the better reason not to rush it.
A global pin would fix the breakage but freeze every user on a 2023 patchelf to accommodate
the oldest supported host, and would need revisiting by hand each time Homebrew moves its
floor. Conditional selection avoids that but does not exist in the schema yet. #2459 is where
that gets decided.

## The trade-off this PR makes

Bumping the image removes CI's only automated detection of a bug that is live for users.
Ubuntu 22.04 (glibc 2.35, supported until 2027), Debian 12 (2.36), and RHEL 9 (2.34) still
cannot relocate any Homebrew bottle unless a working patchelf is already on the host.

Two things offset it, neither a substitute for #2459. The `findPatchelf` fallback means a user
who runs `apt-get install patchelf` now recovers automatically, which was not true before. And
the failure, when it happens, now says what it is instead of printing a dynamic-loader message
about symbol versions. Restoring the lost CI signal is covered as a verification requirement
on #2459, since coverage of a fallback path is only worth building once it is known the path
will still exist.

## Verification

The mechanism was confirmed rather than assumed. The patchelf 0.19.1 bottle for
`x86_64_linux` was pulled and its dynamic symbol table inspected: it imports `GLIBC_2.38`.
Running that binary under `ubuntu:22.04` reproduces the CI error byte for byte; under
`ubuntu:24.04` it prints `patchelf 0.19.1` and exits 0. The job's `Install minimal
dependencies` step was replayed end to end in a 24.04 container — the apt set, the gcc
removal, the `update-alternatives` calls, and the "no system compiler binary present"
assertion all pass, with `make` at `/usr/bin/make` and `git` at 2.43.0.

Locally: `gofmt` clean, `go vet ./...` clean, `golangci-lint run --timeout=5m ./...` reports
0 issues, and `go test ./...` is fully green.

## Follow-up work, filed separately

None of this is fixed here; all of it is recorded so it is not lost.

**#2459 — select the patchelf version by host glibc.** The long-term solution, described
above. `needs-design`.

**#2454 — install-time dependencies are never verified.** This is why the failing log printed
`✅ patchelf@0.19.1` for a binary that could not execute. `installSingleDependency` copies the
dependency's `[verify]` block into a synthetic recipe and hands it to the execution context,
then never runs it. `patchelf.toml` already declares `patchelf --version` as its verify
probe — the exact check that would have caught this at the dependency, instead of two steps
later as a loader error attributed to `make`. The probe added here is the patchelf-specific
case; #2454 is the general form.

**#2451 — the underlying breakage.** Updated with three notes from this work: `set_rpath.go`
and `meson_build.go` reach patchelf through their own discovery logic and still emit raw
loader output for the same cause, so `verifyPatchelfRunnable` (package-level and reusable)
should be wired into both; the patchelf functions in `homebrew_relocate.go` do not use their
receiver and would be better placed in their own file as free functions, which makes that
wiring a one-liner; and the issue's original "pin to 0.18.0" lead is superseded by #2459.

## Note for reviewers on CI

`Build Essentials` will still show red on this PR. The workflow has a second, unrelated
pre-existing failure, `Linux x86_64: git-source`, tracked as #2449 and fixed elsewhere.
Check this PR job by job rather than at the workflow level. Main's scheduled run
[30183663952](https://github.com/tsukumogami/tsuku/actions/runs/30183663952) fails exactly
these two jobs, so it is the baseline for comparison — `No-GCC Container: gdbm-source`
should now be green, and nothing else should have changed colour.

## One judgement call left open

`testdata/recipes/gdbm-source.toml` declares `dependencies = ["make"]`, which is what drags
the Homebrew make — and therefore patchelf and `homebrew_relocate` — into this job. The
job's own comments say it deliberately apt-installs make so configure detects the system
one, and it pointedly keeps tsuku's tools off `PATH`. So the Homebrew make is installed and
then never used, and dropping that line would also make the job pass with a smaller diff.
It is not the recommendation here: the same test recipe feeds the macOS jobs, where the
dependency behaves differently, and removing it would silently stop this job exercising the
bottle-relocation path on Linux, which is coverage worth keeping. Worth a maintainer's eye.

Fixes #2447
