### PR TITLE
fix(ci): match embedded recipes in the Test Recipe detect step

### DIFF
--- a/.github/workflows/test-recipe.yml
+++ b/.github/workflows/test-recipe.yml
@@ -8,6 +8,10 @@
 # Triggers:
 #   - workflow_dispatch: manually test a recipe by name
 #   - pull_request: auto-detect changed recipes in the PR
+#
+# The build job also fails the run if it would have tested nothing: if the
+# diff holds recipe files that detection missed, or if detected recipes
+# produce zero batches. Both used to pass green. See #2445.
 
 name: Test Recipe
 
@@ -19,6 +23,15 @@ on:
         required: true
         type: string
   pull_request:
+    # Adding a recipe location here is not enough, and nothing enforces the
+    # rest. The same location has to be added to the detect step's git
+    # pathspec and to the cross-check step's grep in the `build` job (search
+    # this file for ":(glob)"), and to the four `hashFiles` cache keys.
+    #
+    # The failure modes are asymmetric. Miss the detect pathspec and the
+    # cross-check step catches it. Miss this filter, or miss the cross-check's
+    # grep, and nothing reports anything at all -- the job either never starts
+    # or goes quiet about the new location. See #2445 for what that looks like.
     paths:
       - "recipes/**/*.toml"
       - "internal/recipe/recipes/**/*.toml"
@@ -97,21 +110,26 @@ jobs:
           else
             # PR trigger: detect changed recipe files.
             #
-            # These patterns mirror the `on: paths:` filter at the top of this
-            # file, and the `:(glob)` prefixes are what keep them matching the
-            # same files. Without the prefixes, git requires `**/` to consume a
-            # literal directory, so `internal/recipe/recipes/**/*.toml` misses
-            # every embedded recipe -- they sit flat in that directory. With
-            # them, git matches the way the Actions filter does, where `/**/`
-            # also matches zero directories. Registry recipes under
-            # `recipes/<letter>/` matched either way, which is why the mismatch
-            # went unnoticed while it silently disabled every platform lane for
-            # embedded recipes. Don't drop the prefixes.
-            CHANGED=$(git diff --name-only --diff-filter=d origin/main...HEAD -- ':(glob)recipes/**/*.toml' ':(glob)internal/recipe/recipes/**/*.toml' || true)
+            # `:(glob)` is git pathspec magic (gitglossary(7)) and it is
+            # load-bearing. By default git matches pathspecs with fnmatch,
+            # where `*` also matches `/` -- so `**/` degrades to "anything,
+            # then a slash" and a directory level becomes mandatory. Embedded
+            # recipes sit flat in internal/recipe/recipes/, so the unprefixed
+            # pattern matched none of them while registry recipes under
+            # recipes/<letter>/ still matched, which is why this went unnoticed
+            # while it disabled every platform lane for embedded recipes
+            # (#2445). With `:(glob)` git uses wildmatch, where `/**/` matches
+            # zero or more directories -- the semantics the `on: paths:` filter
+            # above already uses.
+            #
+            # To check a change here, this must print files:
+            #   git ls-files -- ':(glob)internal/recipe/recipes/**/*.toml'
+            # Drop the prefix and it prints nothing.
+            CHANGED=$(git diff --name-only --diff-filter=d origin/main...HEAD -- ':(glob)recipes/**/*.toml' ':(glob)internal/recipe/recipes/**/*.toml')
             if [ -z "$CHANGED" ]; then
               # A real possibility, not necessarily a bug: this workflow also
-              # triggers on changes to itself. The guard step below is what
-              # decides whether finding nothing was legitimate.
+              # triggers on changes to itself. The cross-check step below is
+              # what decides whether finding nothing was legitimate.
               echo "::notice::No recipe files changed in this PR -- no platform lanes will run."
               echo "recipes=[]" >> "$GITHUB_OUTPUT"
               echo "has_recipes=false" >> "$GITHUB_OUTPUT"
@@ -147,50 +165,55 @@ jobs:
 
       # A run that tests nothing looks exactly like a run that tested everything
       # and found no problems: both are green. That is how the pathspec above
-      # stayed broken. This step re-derives the recipe list with a plain grep --
-      # deliberately a different matcher from the pathspec, so the two can
-      # disagree -- and fails the run when the diff holds recipe files that
-      # detect did not pick up.
+      # stayed broken. This step re-derives the recipe list with a grep --
+      # deliberately a different matcher, so the two can disagree -- and fails
+      # the run when detect missed a recipe file the diff contains.
       #
-      # Finding nothing is not itself an error. This workflow triggers on
+      # Finding nothing is not itself an error: this workflow triggers on
       # changes to its own file, so a PR that edits only this workflow really
-      # does change no recipes. What must never pass quietly is detect
-      # disagreeing with the diff it was handed.
+      # does change no recipes.
       #
-      # What no step here can catch: drift in the `on: paths:` filter itself.
-      # Add a recipe location there without adding it to both matchers below
-      # and the job simply never runs for it -- nothing inside a job that
-      # didn't start can notice. Keep all three lists in sync by hand.
-      - name: Guard against a silent no-op
+      # This step cannot catch drift in the `on: paths:` filter -- nothing
+      # inside a job that never started can. See the note on that filter.
+      - name: Cross-check detect against the diff
         if: github.event_name == 'pull_request'
         env:
-          HAS_RECIPES: ${{ steps.detect.outputs.has_recipes }}
+          DETECTED_JSON: ${{ steps.detect.outputs.recipes }}
         run: |
-          # Two statements, not one pipeline: `|| true` on a pipeline would
-          # swallow a failing `git diff` and leave EXPECTED empty, which reads
-          # as "no recipes changed" -- the very thing this step exists to catch.
-          # Split like this, a git failure fails the step.
+          # Two statements, not one pipeline: a pipeline's exit status is its
+          # last command's, so a failing `git diff` inside one is invisible
+          # (the runner's default shell sets -e but not pipefail). The list
+          # would come out empty, which reads as "no recipes changed" -- the
+          # very thing this step exists to catch. Split like this, `set -e`
+          # fails the step on a git error.
           ALL_CHANGED=$(git diff --name-only --diff-filter=d origin/main...HEAD)
-          EXPECTED=$(printf '%s\n' "$ALL_CHANGED" \
-            | grep -E '^(recipes|internal/recipe/recipes)/.*\.toml$' || true)
+          IN_DIFF=$(printf '%s\n' "$ALL_CHANGED" \
+            | grep -E '^(recipes|internal/recipe/recipes)/.*\.toml$' | sort || true)
 
-          if [ -z "$EXPECTED" ]; then
+          if [ -z "$IN_DIFF" ]; then
             echo "No recipe files in this diff -- nothing for the platform lanes to test."
             exit 0
           fi
 
-          if [ "$HAS_RECIPES" != "true" ]; then
-            echo "::error::Recipe files changed in this PR but the detect step found none."
-            echo "The diff contains:"
-            echo "$EXPECTED" | sed 's/^/  /'
+          DETECTED=$(printf '%s' "$DETECTED_JSON" | jq -r '.[].path' | sort)
+
+          # Compare the sets, not just whether detect found something. A
+          # partial disagreement -- detect matching one location but not
+          # another -- is the likelier kind of drift, and leaves the recipes it
+          # missed untested on every platform.
+          MISSED=$(comm -23 <(printf '%s\n' "$IN_DIFF") <(printf '%s\n' "$DETECTED"))
+          if [ -n "$MISSED" ]; then
+            echo "::error::The detect step missed $(printf '%s\n' "$MISSED" | wc -l) recipe file(s) this PR changes."
+            printf '%s\n' "$MISSED" | sed 's/^/  /'
             echo ""
-            echo "The pathspec in the detect step and this grep disagree about what"
-            echo "counts as a recipe file. Reconcile them -- and the 'on: paths:'"
-            echo "filter -- before merging. See issue #2445 for how this fails."
+            echo "Those files would go untested on every platform while this run"
+            echo "reported success. The detect step's git pathspec and this step's"
+            echo "grep disagree about what counts as a recipe file; reconcile them,"
+            echo "and the 'on: paths:' filter at the top of this file, before merging."
             exit 1
           fi
 
-          echo "Detect step and diff agree: $(echo "$EXPECTED" | wc -l) recipe file(s) changed."
+          echo "Detect matched all $(printf '%s\n' "$IN_DIFF" | wc -l) recipe file(s) in the diff."
 
       - name: Split recipes into batches
         id: batch
@@ -292,18 +315,17 @@ jobs:
           # nothing. The platform lanes gate on has_*_batches, not on
           # has_recipes, so a recipe list that survives detection and then
           # collapses to zero batches skips every lane just as quietly as an
-          # empty detection did. jq will do that without complaint -- a batch
-          # size of 0 in .github/ci-batch-config.json makes `range(0; n; 0)`
-          # yield an empty array, and `resolve_bs` treats `max` as usable
-          # whenever it is present rather than positive. Recipes in, no batches
-          # out is always a bug.
+          # empty detection did. Recipes in, no batches out is always a bug.
           if [ "$LINUX_BATCH_COUNT" -eq 0 ] || [ "$DARWIN_BATCH_COUNT" -eq 0 ]; then
             RECIPE_COUNT=$(echo "$RECIPES" | jq 'length')
             echo "::error::$RECIPE_COUNT recipe(s) were detected but batching produced $LINUX_BATCH_COUNT Linux and $DARWIN_BATCH_COUNT Darwin batch(es)."
-            echo "The platform lanes gate on the batch counts, so this would skip every"
-            echo "lane and report green. Check the batch sizes in .github/ci-batch-config.json --"
-            echo "a size of 0, or an ecosystem whose config entry is missing or malformed,"
-            echo "produces an empty batch list without erroring."
+            echo "The platform lanes gate on the batch counts, not on has_recipes, so"
+            echo "this would skip every lane and report green. The cause is almost"
+            echo "certainly a zero batch size reaching jq: check .github/ci-batch-config.json"
+            echo 'for a size of 0, or an entry like {"max": 0, ...}. jq counts 0 as truthy,'
+            echo "so resolve_bs accepts it, and range(0; n; 0) then yields an empty list"
+            echo "without erroring. A missing ecosystem entry cannot cause this -- it"
+            echo "falls back to the default size."
             exit 1
           fi
 
@@ -337,8 +359,7 @@ jobs:
         with:
           path: /tmp/tsuku-shared-downloads
           # hashFiles uses Actions glob semantics, where `**` also matches zero
-          # directories -- so unlike the git pathspec in the detect step, this
-          # already covers the flat embedded recipes. Checked for #2445.
+          # directories, so this covers the flat embedded recipes too.
           key: test-recipe-downloads-linux-amd64-${{ hashFiles('recipes/**/*.toml', 'internal/recipe/recipes/**/*.toml') }}
           restore-keys: |
             test-recipe-downloads-linux-amd64-
@@ -510,8 +531,7 @@ jobs:
         with:
           path: /tmp/tsuku-shared-downloads
           # hashFiles uses Actions glob semantics, where `**` also matches zero
-          # directories -- so unlike the git pathspec in the detect step, this
-          # already covers the flat embedded recipes. Checked for #2445.
+          # directories, so this covers the flat embedded recipes too.
           key: test-recipe-downloads-linux-arm64-${{ hashFiles('recipes/**/*.toml', 'internal/recipe/recipes/**/*.toml') }}
           restore-keys: |
             test-recipe-downloads-linux-arm64-
@@ -686,8 +706,7 @@ jobs:
         with:
           path: /tmp/tsuku-shared-downloads
           # hashFiles uses Actions glob semantics, where `**` also matches zero
-          # directories -- so unlike the git pathspec in the detect step, this
-          # already covers the flat embedded recipes. Checked for #2445.
+          # directories, so this covers the flat embedded recipes too.
           key: test-recipe-downloads-darwin-arm64-${{ hashFiles('recipes/**/*.toml', 'internal/recipe/recipes/**/*.toml') }}
           restore-keys: |
             test-recipe-downloads-darwin-arm64-
@@ -805,8 +824,7 @@ jobs:
         with:
           path: /tmp/tsuku-shared-downloads
           # hashFiles uses Actions glob semantics, where `**` also matches zero
-          # directories -- so unlike the git pathspec in the detect step, this
-          # already covers the flat embedded recipes. Checked for #2445.
+          # directories, so this covers the flat embedded recipes too.
           key: test-recipe-downloads-darwin-amd64-${{ hashFiles('recipes/**/*.toml', 'internal/recipe/recipes/**/*.toml') }}
           restore-keys: |
             test-recipe-downloads-darwin-amd64-

--- a/.github/workflows/test-recipe.yml
+++ b/.github/workflows/test-recipe.yml
@@ -125,7 +125,11 @@ jobs:
             # To check a change here, this must print files:
             #   git ls-files -- ':(glob)internal/recipe/recipes/**/*.toml'
             # Drop the prefix and it prints nothing.
-            CHANGED=$(git diff --name-only --diff-filter=d origin/main...HEAD -- ':(glob)recipes/**/*.toml' ':(glob)internal/recipe/recipes/**/*.toml')
+            #
+            # core.quotePath=false because git otherwise C-quotes any path with
+            # a non-ASCII byte -- `"internal/recipe/recipes/t\303\251st.toml"`,
+            # quotes and all -- which is not a path anything downstream can open.
+            CHANGED=$(git -c core.quotePath=false diff --name-only --diff-filter=d origin/main...HEAD -- ':(glob)recipes/**/*.toml' ':(glob)internal/recipe/recipes/**/*.toml')
             if [ -z "$CHANGED" ]; then
               # A real possibility, not necessarily a bug: this workflow also
               # triggers on changes to itself. The cross-check step below is
@@ -186,7 +190,12 @@ jobs:
           # would come out empty, which reads as "no recipes changed" -- the
           # very thing this step exists to catch. Split like this, `set -e`
           # fails the step on a git error.
-          ALL_CHANGED=$(git diff --name-only --diff-filter=d origin/main...HEAD)
+          #
+          # core.quotePath=false for the same reason as the detect step: a
+          # C-quoted path starts with a `"`, so the anchored grep below would
+          # miss it and this step would go quiet about a file detect mangled --
+          # the failure it exists to catch, through a door it wasn't watching.
+          ALL_CHANGED=$(git -c core.quotePath=false diff --name-only --diff-filter=d origin/main...HEAD)
           IN_DIFF=$(printf '%s\n' "$ALL_CHANGED" \
             | grep -E '^(recipes|internal/recipe/recipes)/.*\.toml$' | sort || true)
 

--- a/.github/workflows/test-recipe.yml
+++ b/.github/workflows/test-recipe.yml
@@ -95,10 +95,24 @@ jobs:
               exit 1
             fi
           else
-            # PR trigger: detect changed recipe files
-            CHANGED=$(git diff --name-only --diff-filter=d origin/main...HEAD -- 'recipes/**/*.toml' 'internal/recipe/recipes/**/*.toml' || true)
+            # PR trigger: detect changed recipe files.
+            #
+            # These patterns mirror the `on: paths:` filter at the top of this
+            # file, and the `:(glob)` prefixes are what keep them matching the
+            # same files. Without the prefixes, git requires `**/` to consume a
+            # literal directory, so `internal/recipe/recipes/**/*.toml` misses
+            # every embedded recipe -- they sit flat in that directory. With
+            # them, git matches the way the Actions filter does, where `/**/`
+            # also matches zero directories. Registry recipes under
+            # `recipes/<letter>/` matched either way, which is why the mismatch
+            # went unnoticed while it silently disabled every platform lane for
+            # embedded recipes. Don't drop the prefixes.
+            CHANGED=$(git diff --name-only --diff-filter=d origin/main...HEAD -- ':(glob)recipes/**/*.toml' ':(glob)internal/recipe/recipes/**/*.toml' || true)
             if [ -z "$CHANGED" ]; then
-              echo "No recipe files changed in this PR."
+              # A real possibility, not necessarily a bug: this workflow also
+              # triggers on changes to itself. The guard step below is what
+              # decides whether finding nothing was legitimate.
+              echo "::notice::No recipe files changed in this PR -- no platform lanes will run."
               echo "recipes=[]" >> "$GITHUB_OUTPUT"
               echo "has_recipes=false" >> "$GITHUB_OUTPUT"
               exit 0
@@ -130,6 +144,48 @@ jobs:
           else
             echo "has_recipes=false" >> "$GITHUB_OUTPUT"
           fi
+
+      # A run that tests nothing looks exactly like a run that tested everything
+      # and found no problems: both are green. That is how the pathspec above
+      # stayed broken. This step re-derives the recipe list with a plain grep --
+      # deliberately a different matcher from the pathspec, so the two can
+      # disagree -- and fails the run when the diff holds recipe files that
+      # detect did not pick up.
+      #
+      # Finding nothing is not itself an error. This workflow triggers on
+      # changes to its own file, so a PR that edits only this workflow really
+      # does change no recipes. What must never pass quietly is detect
+      # disagreeing with the diff it was handed.
+      - name: Guard against a silent no-op
+        if: github.event_name == 'pull_request'
+        env:
+          HAS_RECIPES: ${{ steps.detect.outputs.has_recipes }}
+        run: |
+          # Two statements, not one pipeline: `|| true` on a pipeline would
+          # swallow a failing `git diff` and leave EXPECTED empty, which reads
+          # as "no recipes changed" -- the very thing this step exists to catch.
+          # Split like this, a git failure fails the step.
+          ALL_CHANGED=$(git diff --name-only --diff-filter=d origin/main...HEAD)
+          EXPECTED=$(printf '%s\n' "$ALL_CHANGED" \
+            | grep -E '^(recipes|internal/recipe/recipes)/.*\.toml$' || true)
+
+          if [ -z "$EXPECTED" ]; then
+            echo "No recipe files in this diff -- nothing for the platform lanes to test."
+            exit 0
+          fi
+
+          if [ "$HAS_RECIPES" != "true" ]; then
+            echo "::error::Recipe files changed in this PR but the detect step found none."
+            echo "The diff contains:"
+            echo "$EXPECTED" | sed 's/^/  /'
+            echo ""
+            echo "The pathspec in the detect step and this grep disagree about what"
+            echo "counts as a recipe file. Reconcile them -- and the 'on: paths:'"
+            echo "filter -- before merging. See issue #2445 for how this fails."
+            exit 1
+          fi
+
+          echo "Detect step and diff agree: $(echo "$EXPECTED" | wc -l) recipe file(s) changed."
 
       - name: Split recipes into batches
         id: batch

--- a/.github/workflows/test-recipe.yml
+++ b/.github/workflows/test-recipe.yml
@@ -156,6 +156,11 @@ jobs:
       # changes to its own file, so a PR that edits only this workflow really
       # does change no recipes. What must never pass quietly is detect
       # disagreeing with the diff it was handed.
+      #
+      # What no step here can catch: drift in the `on: paths:` filter itself.
+      # Add a recipe location there without adding it to both matchers below
+      # and the job simply never runs for it -- nothing inside a job that
+      # didn't start can notice. Keep all three lists in sync by hand.
       - name: Guard against a silent no-op
         if: github.event_name == 'pull_request'
         env:
@@ -282,6 +287,25 @@ jobs:
           fi
 
           echo "Generated $DARWIN_BATCH_COUNT Darwin batch(es) of up to $DARWIN_BATCH_SIZE recipes"
+
+          # Batching is the second way this workflow can go green having tested
+          # nothing. The platform lanes gate on has_*_batches, not on
+          # has_recipes, so a recipe list that survives detection and then
+          # collapses to zero batches skips every lane just as quietly as an
+          # empty detection did. jq will do that without complaint -- a batch
+          # size of 0 in .github/ci-batch-config.json makes `range(0; n; 0)`
+          # yield an empty array, and `resolve_bs` treats `max` as usable
+          # whenever it is present rather than positive. Recipes in, no batches
+          # out is always a bug.
+          if [ "$LINUX_BATCH_COUNT" -eq 0 ] || [ "$DARWIN_BATCH_COUNT" -eq 0 ]; then
+            RECIPE_COUNT=$(echo "$RECIPES" | jq 'length')
+            echo "::error::$RECIPE_COUNT recipe(s) were detected but batching produced $LINUX_BATCH_COUNT Linux and $DARWIN_BATCH_COUNT Darwin batch(es)."
+            echo "The platform lanes gate on the batch counts, so this would skip every"
+            echo "lane and report green. Check the batch sizes in .github/ci-batch-config.json --"
+            echo "a size of 0, or an ecosystem whose config entry is missing or malformed,"
+            echo "produces an empty batch list without erroring."
+            exit 1
+          fi
 
   # Linux x86_64: test in sandbox containers for all five families.
   # Recipes are split into batches (one job per batch) and families run in parallel

--- a/.github/workflows/test-recipe.yml
+++ b/.github/workflows/test-recipe.yml
@@ -312,6 +312,9 @@ jobs:
         uses: actions/cache@b7e8d49f17405cc70c1c120101943203c98d3a4b  # v5.0.3
         with:
           path: /tmp/tsuku-shared-downloads
+          # hashFiles uses Actions glob semantics, where `**` also matches zero
+          # directories -- so unlike the git pathspec in the detect step, this
+          # already covers the flat embedded recipes. Checked for #2445.
           key: test-recipe-downloads-linux-amd64-${{ hashFiles('recipes/**/*.toml', 'internal/recipe/recipes/**/*.toml') }}
           restore-keys: |
             test-recipe-downloads-linux-amd64-
@@ -482,6 +485,9 @@ jobs:
         uses: actions/cache@b7e8d49f17405cc70c1c120101943203c98d3a4b  # v5.0.3
         with:
           path: /tmp/tsuku-shared-downloads
+          # hashFiles uses Actions glob semantics, where `**` also matches zero
+          # directories -- so unlike the git pathspec in the detect step, this
+          # already covers the flat embedded recipes. Checked for #2445.
           key: test-recipe-downloads-linux-arm64-${{ hashFiles('recipes/**/*.toml', 'internal/recipe/recipes/**/*.toml') }}
           restore-keys: |
             test-recipe-downloads-linux-arm64-
@@ -655,6 +661,9 @@ jobs:
         uses: actions/cache@b7e8d49f17405cc70c1c120101943203c98d3a4b  # v5.0.3
         with:
           path: /tmp/tsuku-shared-downloads
+          # hashFiles uses Actions glob semantics, where `**` also matches zero
+          # directories -- so unlike the git pathspec in the detect step, this
+          # already covers the flat embedded recipes. Checked for #2445.
           key: test-recipe-downloads-darwin-arm64-${{ hashFiles('recipes/**/*.toml', 'internal/recipe/recipes/**/*.toml') }}
           restore-keys: |
             test-recipe-downloads-darwin-arm64-
@@ -771,6 +780,9 @@ jobs:
         uses: actions/cache@b7e8d49f17405cc70c1c120101943203c98d3a4b  # v5.0.3
         with:
           path: /tmp/tsuku-shared-downloads
+          # hashFiles uses Actions glob semantics, where `**` also matches zero
+          # directories -- so unlike the git pathspec in the detect step, this
+          # already covers the flat embedded recipes. Checked for #2445.
           key: test-recipe-downloads-darwin-amd64-${{ hashFiles('recipes/**/*.toml', 'internal/recipe/recipes/**/*.toml') }}
           restore-keys: |
             test-recipe-downloads-darwin-amd64-

--- a/.github/workflows/validate-recipe-golden-files.yml
+++ b/.github/workflows/validate-recipe-golden-files.yml
@@ -80,6 +80,13 @@ jobs:
         run: |
           # Get list of changed recipe files (exclude deleted files)
           # Check both embedded (internal/recipe/recipes) and registry (recipes/) locations
+          #
+          # KNOWN BUG (#2453): the comment above is not true today. These
+          # patterns need a `:(glob)` prefix to match embedded recipes, which
+          # are flat files -- without it this matches registry recipes only and
+          # reports "No recipe files changed" for embedded ones. The fix and the
+          # explanation are in .github/workflows/test-recipe.yml (#2445); this
+          # workflow is deliberately left alone there so the fix stays scoped.
           CHANGED=$(git diff --name-only --diff-filter=d origin/main...HEAD -- 'internal/recipe/recipes/**/*.toml' 'recipes/**/*.toml')
 
           if [ -z "$CHANGED" ]; then


### PR DESCRIPTION
The `Test Recipe` detect step re-derived its changed-file list with a git pathspec
whose `**` does not mean what the same `**` means in the `on: paths:` filter directly
above it. Git matches pathspecs with fnmatch by default, where `*` also crosses `/`, so
`**/` degrades to "anything, then a slash" and a directory level becomes mandatory.
Embedded recipes are flat files in `internal/recipe/recipes/`, so the workflow triggered
on them and then matched none of them, printing "No recipe files changed in this PR" and
passing green without running a single platform lane. Registry recipes live under
`recipes/<letter>/`, where `**` has a directory to consume, so the lane kept working for
the recipes it usually sees.

Both pathspecs now carry a `:(glob)` prefix, which switches git to wildmatch, where
`/**/` matches zero or more directories. The pattern text stays identical to the trigger
filter above.

Two checks make a no-op loud. `Cross-check detect against the diff` re-derives the recipe
list with a grep, deliberately a different matcher, and fails when detect missed a file
the diff contains. It compares the two sets rather than just whether detect found
anything, so a partial disagreement -- detect matching one recipe location but not
another -- is caught rather than passing on the strength of the files it did match. The
batch step then fails when detected recipes produce zero batches, because the platform
lanes gate on the batch counts rather than on `has_recipes`, which is a second route to
green-having-tested-nothing. Finding no recipes at all stays legitimate: this workflow
also triggers on changes to its own file.

Both `git diff` calls set `core.quotePath=false`, so a path containing a non-ASCII byte
arrives as a usable path rather than a C-quoted string the anchored grep would skip.

The four `hashFiles` cache keys are unchanged and correct: Actions glob semantics let
`**` match zero directories, so they already covered the flat embedded recipes. A comment
at each one records that.

---

Fixes #2445

## Root cause

`git diff -- 'internal/recipe/recipes/**/*.toml'` and the identical string in an Actions
`paths:` filter select different files. That is the whole bug. It stayed invisible
because it only affects flat files, and registry recipes -- the overwhelming majority of
what this lane sees -- are never flat.

## Verification

No recipe was touched to prove this. The shipped shell was extracted from the YAML and
run against real git history, so the check cannot drift from what merges.

| Scenario | Expected | Result |
|---|---|---|
| `origin/main...origin/fix/2441-zig-mirror-unreachable` (flat `zig.toml`) | detect matches | matches |
| `e61b7754^..e61b7754` (`recipes/p/playwright.toml`) | still matches | matches |
| diff touching one registry and one embedded recipe | both matched | both matched |
| this branch (workflow files only) | legitimate no-op, checks quiet | exit 0 |
| embedded diff re-run with the **pre-fix** pathspec | cross-check fires | exit 1 |
| detect that knows only the registry location, mixed diff | cross-check fires | exit 1, names the missed file |
| detected recipes with a batch size of 0 | batch check fires | exit 1 |

The last three are the regression checks: each is a way this workflow used to report
success having tested nothing.

Corroborating evidence from CI history: run 30716595612 on PR #2444, which changes only
`internal/recipe/recipes/zig.toml`, logs "No recipe files changed in this PR." while its
`Linux arm64` and `Linux x86_64` lanes report skipped. The workflow triggered, so the
Actions glob matched the flat file, and the git pathspec did not.

`hashFiles` was checked rather than assumed: `@actions/glob` enumerates the flat
`zig.toml` under `internal/recipe/recipes/**/*.toml`, and the digest changes when that
file is edited.

Also run: `go test ./...` (54 packages, 0 failures), `go vet ./...`,
`.github/scripts/checks/ci-patterns-lint.sh`, `.github/scripts/checks/retired-runners.sh`.

This PR is itself a live test of the no-op path. It changes only workflow files, so
`Test Recipe` should trigger, detect zero recipes, and pass both checks quietly.

## What this turns back on

These lanes have not run for an embedded recipe in a long time, so the next PR touching
one of the 19 files in `internal/recipe/recipes/` will be the first real exercise of it
across all four platforms. If any of them has a latent per-platform failure, it will
surface then, on a PR whose author may have changed one line. That is the coverage the
issue is asking for, but it is worth knowing before it happens rather than after.

## Noted, not fixed here

Two other workflows carry the byte-identical pathspec, verified against the same diff
range:

- `.github/workflows/validate-recipe-golden-files.yml:83` -- its comment claims it
  checks "both embedded and registry locations", which it does not. Golden file
  validation is skipped entirely for embedded-recipe-only PRs. Filed as #2453; this PR
  adds a comment there naming the issue, so the difference from `test-recipe.yml` is not
  read as deliberate, but changes no behaviour.
- `.github/workflows/publish-golden-to-r2.yml:84` -- same pathspec. #2448 covers that
  pipeline, but its stated defects and acceptance criteria never name this bug, so it
  should not be assumed covered. Left untouched to avoid conflicting with work in
  progress there.

The structurally better fix is a static check under `.github/scripts/checks/` that
`lint-workflows.yml` runs, catching all three files and the `on: paths:` lists too. It
is not here because it would fail on the two files above and drag them into this PR;
it's recorded on #2453 as the thing to do once all three can change together.

Separately, `workflow_dispatch` resolves recipes only as `recipes/<letter>/<name>.toml`,
so the manual escape hatch cannot reach an embedded recipe either. It errors loudly
rather than passing green, so it is not the same class of bug, but it does mean there is
still no way to hand-run an embedded recipe against the arm64 lane.
