### PR TITLE
feat(install): add --reinstall so an existing install can pick up a fix

### DIFF
--- a/cmd/tsuku/install.go
+++ b/cmd/tsuku/install.go
@@ -37,6 +37,7 @@ var installEnv []string
 var installSkipSecurity bool
 var installYes bool
 var installNoShellInit bool
+var installReinstall bool
 
 var installCmd = &cobra.Command{
 	Use:   "install [tool]...",
@@ -51,6 +52,10 @@ Examples:
   tsuku install kubectl
   tsuku install kubectl@v1.29.0
   tsuku install terraform@latest
+
+Repair an install that is already present:
+  tsuku install kubectl --reinstall
+  tsuku install kubectl@v1.29.0 --reinstall
 
 Project install (batch from .tsuku.toml):
   tsuku install                    # install all project tools
@@ -372,6 +377,7 @@ func init() {
 	installCmd.Flags().BoolVar(&installDryRun, "dry-run", false, "Show what would be installed without making changes")
 	installCmd.Flags().BoolVar(&installForce, "force", false, "Skip security warnings and proceed without prompts")
 	installCmd.Flags().BoolVar(&installFresh, "fresh", false, "Force fresh plan generation, bypassing cached plans")
+	installCmd.Flags().BoolVar(&installReinstall, "reinstall", false, "Re-run the installation even if the version is already installed, replacing the files on disk")
 	installCmd.Flags().BoolVar(&installJSON, "json", false, "Emit structured JSON error output on failure")
 	installCmd.Flags().StringVar(&installPlanPath, "plan", "", "Install from a pre-computed plan file (use '-' for stdin)")
 	installCmd.Flags().BoolVar(&installSandbox, "sandbox", false, "Run installation in an isolated container for testing")

--- a/cmd/tsuku/install_deps.go
+++ b/cmd/tsuku/install_deps.go
@@ -178,6 +178,28 @@ type installArgs struct {
 	Parent            string
 	Reporter          progress.Reporter
 	TelemetryClient   *telemetry.Client
+
+	// Reinstall re-runs the installation for a version that is already
+	// installed, instead of reporting it as present and returning. It lives on
+	// the args rather than being read from the --reinstall flag directly
+	// because the dependency walk derives child invocations from this struct:
+	// a package-level read would silently cascade the reinstall into every
+	// dependency, and reinstall is scoped to the tool the user named.
+	Reinstall bool
+}
+
+// withInstallFlags applies the install command's package-level flags to a set
+// of arguments. It exists so the flags reach the pipeline from one place: the
+// install command builds installArgs at seven call sites, and a flag added to
+// six of them is a flag that silently does nothing on the seventh.
+//
+// runInstall applies it; runInstallWithReporter does not. That is not an
+// oversight -- only `tsuku update` and the auto-apply path call the borrowed-
+// reporter entry point, and neither registers an install flag, so applying them
+// there would read every value as false and claim a wiring that does not exist.
+func withInstallFlags(args installArgs) installArgs {
+	args.Reinstall = installReinstall
+	return args
 }
 
 func runInstall(ctx context.Context, args installArgs) error {
@@ -187,7 +209,7 @@ func runInstall(ctx context.Context, args installArgs) error {
 		reporter.FlushDeferred()
 	}()
 	args.Reporter = reporter
-	return installWithDependencies(ctx, args, make(map[string]bool))
+	return installWithDependencies(ctx, withInstallFlags(args), make(map[string]bool))
 }
 
 // runInstallWithReporter runs the install flow using a caller-provided
@@ -207,6 +229,7 @@ func installWithDependencies(ctx context.Context, args installArgs, visited map[
 	parent := args.Parent
 	reporter := args.Reporter
 	telemetryClient := args.TelemetryClient
+	reinstall := args.Reinstall
 
 	// Initialize manager for state updates. The event bus dispatches
 	// lifecycle events to the notices and telemetry subscribers; src
@@ -226,7 +249,11 @@ func installWithDependencies(ctx context.Context, args installArgs, visited map[
 	// entry already records, so taking this shortcut for `tsuku install foo@2`
 	// while foo@1 sits there hidden would hand the user version 1 and report
 	// success. Falling through installs the version they named.
-	if isExplicit && parent == "" && reqVersion == "" && versionConstraint == "" {
+	//
+	// Not under --reinstall either. Exposing only creates symlinks; it never
+	// touches the payload. Someone repairing a hidden tool's files would get
+	// links to the same broken files and a success message.
+	if isExplicit && parent == "" && reqVersion == "" && versionConstraint == "" && !reinstall {
 		wasHidden, err := install.CheckAndExposeHidden(ctx, mgr, toolName)
 		if err != nil {
 			reporter.Warn("failed to check hidden status: %v", err)
@@ -312,7 +339,7 @@ func installWithDependencies(ctx context.Context, args installArgs, visited map[
 
 	// Check if this is a library recipe
 	if r.IsLibrary() {
-		return installLibrary(ctx, toolName, reqVersion, mgr, telemetryClient, reporter)
+		return installLibrary(ctx, toolName, reqVersion, reinstall, mgr, telemetryClient, reporter)
 	}
 
 	// Check and display system dependency instructions (for explicit installs only)
@@ -359,6 +386,11 @@ func installWithDependencies(ctx context.Context, args installArgs, visited map[
 			sub.Parent = toolName
 			sub.ReqVersion = ""
 			sub.VersionConstraint = ""
+			// Reinstall is scoped to the tool the user named. A dependency that
+			// is already installed stays as it is; one that is missing is
+			// installed normally. Carrying the flag down would rewrite every
+			// tree in the dependency graph for a repair aimed at one tool.
+			sub.Reinstall = false
 			if err := installWithDependencies(ctx, sub, visited); err != nil {
 				return fmt.Errorf("failed to install dependency '%s': %w", dep, err)
 			}
@@ -398,6 +430,8 @@ func installWithDependencies(ctx context.Context, args installArgs, visited map[
 			sub.Parent = ""
 			sub.ReqVersion = ""
 			sub.VersionConstraint = ""
+			// Same scoping as the install-time dependency loop above.
+			sub.Reinstall = false
 			if err := installWithDependencies(ctx, sub, visited); err != nil {
 				return fmt.Errorf("failed to install runtime dependency '%s': %w", dep, err)
 			}
@@ -515,7 +549,13 @@ func installWithDependencies(ctx context.Context, args installArgs, visited map[
 	// the user without the command they just asked for. CheckAndExposeHidden
 	// above already took the cheap path when the entry knew its own binaries;
 	// reaching here means it did not, and a real install is the fix.
-	if mgr.IsVersionInstalled(toolName, planVersion) && !isHiddenTool(mgr, toolName) {
+	//
+	// --reinstall is the other way past this. It is what makes an existing
+	// install able to pick up a fix: the plan runs again and the manager
+	// replaces the tool directory, so files written by older code are rewritten
+	// by the current code. Nothing else reaches that path -- `--force` only
+	// suppresses security prompts, and `--fresh` only regenerates the plan.
+	if mgr.IsVersionInstalled(toolName, planVersion) && !isHiddenTool(mgr, toolName) && !reinstall {
 		reporter.Status(fmt.Sprintf("%s@%s is already installed", toolName, planVersion))
 		if err := recordInstallRelationship(mgr, toolName, parent, isExplicit); err != nil {
 			reporter.Warn("failed to update state: %v", err)
@@ -557,6 +597,18 @@ func installWithDependencies(ctx context.Context, args installArgs, visited map[
 	isSystemDep := isSystemDependencyPlan(plan)
 
 	if !isSystemDep {
+		// Snapshot what the version being replaced wrote outside its own tool
+		// directory, before InstallWithOptions resets its VersionState. Only a
+		// reinstall can reach this with a prior record under the same version
+		// key -- every other path either short-circuits or writes a new key --
+		// and without the snapshot a fragment the recipe has since stopped
+		// writing would be orphaned: gone from state, still on disk, still
+		// concatenated into the user's shell by the init cache.
+		var priorCleanup []install.CleanupAction
+		if reinstall {
+			priorCleanup = recordedCleanupFor(mgr, toolName, version)
+		}
+
 		// Extract binaries from recipe to store in state
 		binaries := r.ExtractBinaries()
 		installOpts := install.DefaultInstallOptions()
@@ -594,6 +646,15 @@ func installWithDependencies(ctx context.Context, args installArgs, visited map[
 		// Record the cleanup actions post-install produced and refresh the
 		// shell caches they touched.
 		finishPostInstall(cfg, mgr, toolName, version, exec.GetCleanupActions(), reporter.Warn)
+
+		// Delete what the replaced install wrote outside the tool directory and
+		// this one no longer writes. Recording comes first, so ExecuteStaleCleanup
+		// reads the new record when it checks whether some other installed
+		// version still claims the path.
+		if reinstall {
+			newCleanup := convertCleanupActions(exec.GetCleanupActions())
+			mgr.ExecuteStaleCleanup(install.StaleCleanupActions(priorCleanup, newCleanup))
+		}
 
 		// Update state with explicit flag, parent, and dependencies
 		// via semantic Manager methods.
@@ -725,6 +786,22 @@ func resolveRuntimeDeps(r *recipe.Recipe, mgr *install.Manager, reporter progres
 func isHiddenTool(mgr *install.Manager, toolName string) bool {
 	ts, err := mgr.GetToolState(toolName)
 	return err == nil && ts != nil && ts.IsHidden
+}
+
+// recordedCleanupFor returns the cleanup actions state currently records for
+// one version of a tool -- the files that version wrote outside its own install
+// directory. Returns nil when the tool or the version has no entry, which is
+// the ordinary case for a first install.
+func recordedCleanupFor(mgr *install.Manager, toolName, version string) []install.CleanupAction {
+	ts, err := mgr.GetToolState(toolName)
+	if err != nil || ts == nil {
+		return nil
+	}
+	vs, ok := ts.Versions[version]
+	if !ok {
+		return nil
+	}
+	return vs.CleanupActions
 }
 
 func recordInstallRelationship(mgr *install.Manager, toolName, parent string, isExplicit bool) error {

--- a/cmd/tsuku/install_lib.go
+++ b/cmd/tsuku/install_lib.go
@@ -23,7 +23,13 @@ import (
 // (Issue 4 adds the four library event types). The Source extraction in
 // installevents.SourceFromContext at the publish callsite is set up by callers
 // who wrap globalCtx with installevents.WithSource.
-func installLibrary(ctx context.Context, libName, reqVersion string, mgr *install.Manager, telemetryClient *telemetry.Client, reporter progress.Reporter) error {
+//
+// reinstall re-runs the install for a version that is already present. Both
+// reuse checks below are skipped when it is set: `tsuku verify` tells the user
+// to run `tsuku install <library> --reinstall` when a library's files no longer
+// match their recorded checksums, and a flag that took either shortcut would
+// answer that with "reusing" and change nothing.
+func installLibrary(ctx context.Context, libName, reqVersion string, reinstall bool, mgr *install.Manager, telemetryClient *telemetry.Client, reporter progress.Reporter) error {
 	// Load recipe
 	r, err := loader.Get(libName, recipe.LoaderOptions{})
 	if err != nil {
@@ -33,7 +39,7 @@ func installLibrary(ctx context.Context, libName, reqVersion string, mgr *instal
 	// Check if we can skip installation (reuse existing version)
 	// For now, just check if any version is installed
 	existingVersion := mgr.GetInstalledLibraryVersion(libName)
-	if existingVersion != "" && reqVersion == "" {
+	if existingVersion != "" && reqVersion == "" && !reinstall {
 		reporter.Status(fmt.Sprintf("Library %s@%s already installed, reusing", libName, existingVersion))
 		return nil
 	}
@@ -153,7 +159,7 @@ func installLibrary(ctx context.Context, libName, reqVersion string, mgr *instal
 	}
 
 	// Check if this specific version is already installed
-	if mgr.IsLibraryInstalled(libName, version) {
+	if mgr.IsLibraryInstalled(libName, version) && !reinstall {
 		reporter.Status(fmt.Sprintf("Library %s@%s already installed", libName, version))
 		return nil
 	}

--- a/cmd/tsuku/install_reinstall_test.go
+++ b/cmd/tsuku/install_reinstall_test.go
@@ -724,3 +724,79 @@ func TestReinstall_FromCommandEntryPoint(t *testing.T) {
 		t.Errorf("marker content = %q, want %q", got, reinstallGoodContent)
 	}
 }
+
+// TestReinstall_CachedPlanVersusFresh pins which kind of fix --reinstall picks
+// up on its own.
+//
+// getOrGeneratePlan prefers the plan stored in state.json, and only --fresh
+// bypasses it. ValidateCachedPlan checks the format version and the platform;
+// CacheKeyFor never populates ContentHash, so a recipe that has changed since
+// the plan was stored does not invalidate it.
+//
+// So the two cases differ. A fix in tsuku's own code reaches the user through a
+// plain --reinstall, because the stored steps are re-executed by the new
+// binary. A fix in the recipe does not: the stored plan still describes the old
+// steps, and regenerating it takes --fresh as well.
+func TestReinstall_CachedPlanVersusFresh(t *testing.T) {
+	// The harness's stored plan writes reinstallGoodContent; the recipe
+	// registered below writes something else, so which plan ran is visible in
+	// the file.
+	const recipeContent = "written-by-the-current-recipe\n"
+
+	tests := []struct {
+		name  string
+		fresh bool
+		want  string
+	}{
+		{
+			name:  "--reinstall alone replays the stored plan",
+			fresh: false,
+			want:  reinstallGoodContent,
+		},
+		{
+			name:  "--fresh --reinstall regenerates from the recipe",
+			fresh: true,
+			want:  recipeContent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newReinstallHarness(t)
+
+			// Re-register the recipe so a freshly generated plan writes
+			// different content than the stored plan does. This stands in for a
+			// recipe that has been fixed since the tool was installed.
+			loader.CacheRecipe(reinstallTool, &recipe.Recipe{
+				Metadata: recipe.MetadataSection{
+					Name:     reinstallTool,
+					Binaries: []string{"bin/" + reinstallTool},
+				},
+				Steps: []recipe.Step{
+					{
+						Action: "run_command",
+						Params: map[string]any{
+							"command": "mkdir -p {install_dir}/bin {install_dir}/share && " +
+								"printf '#!/bin/sh\\necho ok\\n' > {install_dir}/bin/" + reinstallTool + " && " +
+								"chmod 0755 {install_dir}/bin/" + reinstallTool + " && " +
+								"printf '" + recipeContent + "' > {install_dir}/share/marker.txt",
+						},
+					},
+				},
+				Verify: &recipe.VerifySection{Command: "true"},
+			})
+
+			origFresh := installFresh
+			t.Cleanup(func() { installFresh = origFresh })
+			installFresh = tt.fresh
+
+			if err := h.run(true); err != nil {
+				t.Fatalf("install(reinstall=true, fresh=%v) error = %v", tt.fresh, err)
+			}
+
+			if got := h.markerContent(); got != tt.want {
+				t.Errorf("marker content = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/tsuku/install_reinstall_test.go
+++ b/cmd/tsuku/install_reinstall_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -357,9 +358,21 @@ func TestReinstall_ShellFragmentMatchesFreshHash(t *testing.T) {
 	}
 
 	recorded := h.recordedCleanup()
-	if len(recorded) == 0 {
-		t.Fatalf("no cleanup actions recorded after reinstall")
+
+	// The record has to name exactly the fragments this install writes -- one
+	// per shell set_env covers. Anything more means the stale entry was kept
+	// alongside the fresh one.
+	var gotPaths []string
+	for _, ca := range recorded {
+		gotPaths = append(gotPaths, ca.Path)
 	}
+	slices.Sort(gotPaths)
+	wantPaths := []string{fragmentPath("bash"), fragmentPath("zsh")}
+	slices.Sort(wantPaths)
+	if !slices.Equal(gotPaths, wantPaths) {
+		t.Fatalf("recorded cleanup paths = %v, want %v", gotPaths, wantPaths)
+	}
+
 	for _, ca := range recorded {
 		abs := filepath.Join(h.home, ca.Path)
 		if got := sha256File(t, abs); got != ca.ContentHash {

--- a/cmd/tsuku/install_reinstall_test.go
+++ b/cmd/tsuku/install_reinstall_test.go
@@ -1,0 +1,713 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/tsukumogami/tsuku/internal/config"
+	"github.com/tsukumogami/tsuku/internal/executor"
+	"github.com/tsukumogami/tsuku/internal/install"
+	"github.com/tsukumogami/tsuku/internal/recipe"
+)
+
+// --reinstall exists so an install that is already on disk can pick up a fix.
+// The only way to tell whether it did is to look at the files afterwards: the
+// flag parsing, the short-circuit, and the state write are all one layer short
+// of what the user experiences. Every test here therefore tampers with the
+// installed tree, runs the install, and reads the tree back.
+//
+// The install runs offline. A tool that is already installed has its plan in
+// state.json, and getOrGeneratePlan prefers that cached plan, so seeding state
+// the way a previous install would have left it is enough to drive the real
+// installWithDependencies path without touching the network.
+
+const (
+	reinstallTool    = "reinstalltool"
+	reinstallVersion = "dev"
+
+	// reinstallGoodContent is what the plan writes. reinstallBadContent stands
+	// in for whatever the tool's files became -- a bad write from an older
+	// tsuku, or a modification tsuku verify reported.
+	reinstallGoodContent = "installed-by-the-plan\n"
+	reinstallBadContent  = "tampered-with\n"
+
+	// reinstallEnvVar is the variable the recipe's set_env step exports. The
+	// fragment carrying it is the file written outside the tool directory.
+	reinstallEnvVar = "TSUKU_REINSTALL_MARKER"
+)
+
+// reinstallHarness owns a throwaway $TSUKU_HOME with one tool already
+// installed, plus the recipe and cached plan that installed it.
+type reinstallHarness struct {
+	t    *testing.T
+	home string
+	cfg  *config.Config
+	mgr  *install.Manager
+}
+
+// markerPathFor is the file inside a tool's directory that its plan writes and
+// the tests tamper with.
+func (h *reinstallHarness) markerPathFor(tool string) string {
+	return filepath.Join(h.cfg.ToolDir(tool, reinstallVersion), "share", "marker.txt")
+}
+
+func (h *reinstallHarness) markerPath() string {
+	return h.markerPathFor(reinstallTool)
+}
+
+// binaryPath is the tool's binary inside its install directory.
+func (h *reinstallHarness) binaryPath() string {
+	return filepath.Join(h.cfg.ToolDir(reinstallTool, reinstallVersion), "bin", reinstallTool)
+}
+
+// fragmentPath is where the set_env step's bash fragment lands, relative to
+// $TSUKU_HOME. Shell fragments are keyed by tool and version, so a reinstall of
+// the same version writes this same path rather than a second one.
+func fragmentPath(shell string) string {
+	return filepath.Join("share", "shell.d", "00-env-"+reinstallTool+"@"+reinstallVersion+"."+shell)
+}
+
+// reinstallPlanSteps is the installation a cached plan describes: a binary, a
+// marker file with known content, and a set_env step that writes a shell
+// fragment outside the tool directory.
+//
+// run_command is marked evaluable so plan validation accepts it; set_env's own
+// default phase is post-install, so it runs after the tool reaches its
+// permanent directory without the recipe having to name a phase.
+func reinstallPlanSteps(tool string) []executor.ResolvedStep {
+	return []executor.ResolvedStep{
+		{
+			Action:    "run_command",
+			Evaluable: true,
+			Params: map[string]any{
+				"command": "mkdir -p {install_dir}/bin {install_dir}/share && " +
+					"printf '#!/bin/sh\\necho ok\\n' > {install_dir}/bin/" + tool + " && " +
+					"chmod 0755 {install_dir}/bin/" + tool + " && " +
+					"printf '" + reinstallGoodContent + "' > {install_dir}/share/marker.txt",
+			},
+		},
+		{
+			Action:    "set_env",
+			Evaluable: true,
+			Params: map[string]any{
+				"vars": []any{
+					map[string]any{"name": reinstallEnvVar, "value": "{install_dir}"},
+				},
+			},
+		},
+	}
+}
+
+// newReinstallHarness sets up $TSUKU_HOME, registers the recipe, and puts the
+// tool on disk and in state exactly as a completed install would have left it --
+// including the cached plan that installWithDependencies will re-execute.
+func newReinstallHarness(t *testing.T) *reinstallHarness {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("TSUKU_HOME", home)
+
+	cfg, err := config.DefaultConfig()
+	if err != nil {
+		t.Fatalf("config.DefaultConfig() error = %v", err)
+	}
+	if err := cfg.EnsureDirectories(); err != nil {
+		t.Fatalf("EnsureDirectories() error = %v", err)
+	}
+
+	// The install path threads globalCtx into plan execution; main sets it and
+	// tests have to.
+	origCtx := globalCtx
+	t.Cleanup(func() { globalCtx = origCtx })
+	globalCtx = lifecycleCtx()
+
+	// Swap the package-level loader so the synthetic recipes resolve without
+	// consulting the registry.
+	origLoader := loader
+	t.Cleanup(func() { loader = origLoader })
+	loader = recipe.NewLoader()
+
+	h := &reinstallHarness{t: t, home: home, cfg: cfg, mgr: install.New(cfg)}
+	h.seedInstalledTool(reinstallTool, nil, nil)
+	return h
+}
+
+// seedInstalledTool registers a recipe and leaves the tool on disk and in state
+// exactly as a completed install would have -- including the cached plan that
+// getOrGeneratePlan prefers, which is what lets the reinstall re-execute
+// offline.
+//
+// The recipe has no [version] section, so version resolution fails and falls
+// back to "dev". That keeps the resolved version deterministic, which is what
+// makes the cached-plan lookup hit.
+func (h *reinstallHarness) seedInstalledTool(tool string, deps, runtimeDeps []string) {
+	h.t.Helper()
+
+	loader.CacheRecipe(tool, &recipe.Recipe{
+		Metadata: recipe.MetadataSection{
+			Name:                tool,
+			Binaries:            []string{"bin/" + tool},
+			Dependencies:        deps,
+			RuntimeDependencies: runtimeDeps,
+		},
+		Steps: []recipe.Step{
+			{
+				Action: "run_command",
+				Params: map[string]any{"command": "true"},
+			},
+		},
+		Verify: &recipe.VerifySection{Command: "true"},
+	})
+
+	plan := &executor.InstallationPlan{
+		FormatVersion: executor.PlanFormatVersion,
+		Tool:          tool,
+		Version:       reinstallVersion,
+		Platform:      executor.Platform{OS: runtime.GOOS, Arch: runtime.GOARCH},
+		Steps:         reinstallPlanSteps(tool),
+	}
+
+	if err := h.mgr.GetState().UpdateTool(tool, func(ts *install.ToolState) {
+		ts.Version = reinstallVersion
+		ts.ActiveVersion = reinstallVersion
+		ts.IsExplicit = true
+		ts.Versions = map[string]install.VersionState{
+			reinstallVersion: {
+				Binaries: []string{"bin/" + tool},
+				Plan:     executor.ToStoragePlan(plan),
+			},
+		}
+	}); err != nil {
+		h.t.Fatalf("seeding state for %s: %v", tool, err)
+	}
+
+	h.writeTreeFor(tool, reinstallGoodContent)
+}
+
+// writeInstalledTree lays down the tool directory with the given marker
+// content, standing in for whatever the previous install left behind.
+func (h *reinstallHarness) writeInstalledTree(markerContent string) {
+	h.t.Helper()
+	h.writeTreeFor(reinstallTool, markerContent)
+}
+
+func (h *reinstallHarness) writeTreeFor(tool, markerContent string) {
+	h.t.Helper()
+
+	toolDir := h.cfg.ToolDir(tool, reinstallVersion)
+	for _, sub := range []string{"bin", "share"} {
+		if err := os.MkdirAll(filepath.Join(toolDir, sub), 0755); err != nil {
+			h.t.Fatalf("creating %s: %v", sub, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(toolDir, "bin", tool), []byte("#!/bin/sh\necho ok\n"), 0755); err != nil {
+		h.t.Fatalf("writing binary: %v", err)
+	}
+	if err := os.WriteFile(h.markerPathFor(tool), []byte(markerContent), 0644); err != nil {
+		h.t.Fatalf("writing marker: %v", err)
+	}
+}
+
+// run drives the real install path, with reinstall on or off.
+func (h *reinstallHarness) run(reinstall bool) error {
+	h.t.Helper()
+	return installWithDependencies(lifecycleCtx(), installArgs{
+		Tool:       reinstallTool,
+		IsExplicit: true,
+		Reinstall:  reinstall,
+		Reporter:   &countingReporter{},
+	}, make(map[string]bool))
+}
+
+// markerContent reads back the file inside the tool directory.
+func (h *reinstallHarness) markerContent() string {
+	h.t.Helper()
+	data, err := os.ReadFile(h.markerPath())
+	if err != nil {
+		h.t.Fatalf("reading marker: %v", err)
+	}
+	return string(data)
+}
+
+// recordedCleanup returns what state records for the installed version.
+func (h *reinstallHarness) recordedCleanup() []install.CleanupAction {
+	h.t.Helper()
+	ts, err := h.mgr.GetToolState(reinstallTool)
+	if err != nil || ts == nil {
+		h.t.Fatalf("GetToolState() = %v, %v", ts, err)
+	}
+	return ts.Versions[reinstallVersion].CleanupActions
+}
+
+// sha256File hashes a file the same way the cleanup record does.
+func sha256File(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// TestReinstall_ReplacesTamperedFiles is the acceptance criterion at the level
+// a user feels it. A file inside the install directory is wrong; the reinstall
+// has to make it right, and the command has to still be there afterwards.
+//
+// The control case matters as much as the flag case: plain `tsuku install` on
+// an already-installed version must stay idempotent, or every install of a
+// satisfied dependency starts re-downloading.
+func TestReinstall_ReplacesTamperedFiles(t *testing.T) {
+	tests := []struct {
+		name      string
+		reinstall bool
+		want      string
+	}{
+		{
+			name:      "with --reinstall the modification is gone",
+			reinstall: true,
+			want:      reinstallGoodContent,
+		},
+		{
+			name:      "without --reinstall the install stays idempotent",
+			reinstall: false,
+			want:      reinstallBadContent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newReinstallHarness(t)
+			h.writeInstalledTree(reinstallBadContent)
+
+			if err := h.run(tt.reinstall); err != nil {
+				t.Fatalf("install(reinstall=%v) error = %v", tt.reinstall, err)
+			}
+
+			if got := h.markerContent(); got != tt.want {
+				t.Errorf("marker content = %q, want %q", got, tt.want)
+			}
+
+			// The binary has to survive either way. A reinstall that restored
+			// the marker by removing the tool directory and stopping there
+			// would pass the check above and leave the user without a command.
+			info, err := os.Stat(h.binaryPath())
+			if err != nil {
+				t.Fatalf("binary missing after install: %v", err)
+			}
+			if info.Mode().Perm()&0111 == 0 {
+				t.Errorf("binary mode = %v, want executable", info.Mode().Perm())
+			}
+		})
+	}
+}
+
+// TestReinstall_RestoresMissingFile covers the other half of what `tsuku verify`
+// reports: not a modified file but a deleted one.
+func TestReinstall_RestoresMissingFile(t *testing.T) {
+	h := newReinstallHarness(t)
+	if err := os.Remove(h.markerPath()); err != nil {
+		t.Fatalf("removing marker: %v", err)
+	}
+
+	if err := h.run(true); err != nil {
+		t.Fatalf("install(reinstall=true) error = %v", err)
+	}
+
+	if got := h.markerContent(); got != reinstallGoodContent {
+		t.Errorf("marker content = %q, want %q", got, reinstallGoodContent)
+	}
+}
+
+// TestReinstall_ShellFragmentMatchesFreshHash covers the acceptance criterion
+// about files written outside the tool directory. The seeded state describes a
+// fragment whose recorded hash no longer matches the file on disk -- the shape
+// of the shell.d repair the issue names. After the reinstall the file and the
+// record have to agree, and there has to be exactly one fragment per shell
+// rather than the old one plus a new one.
+func TestReinstall_ShellFragmentMatchesFreshHash(t *testing.T) {
+	h := newReinstallHarness(t)
+
+	// A fragment the previous install left behind, with a stale recorded hash.
+	stalePath := filepath.Join(h.home, fragmentPath("bash"))
+	if err := os.MkdirAll(filepath.Dir(stalePath), 0755); err != nil {
+		t.Fatalf("creating shell.d: %v", err)
+	}
+	if err := os.WriteFile(stalePath, []byte("export "+reinstallEnvVar+"=wrong\n"), 0644); err != nil {
+		t.Fatalf("writing stale fragment: %v", err)
+	}
+	if err := h.mgr.GetState().UpdateTool(reinstallTool, func(ts *install.ToolState) {
+		vs := ts.Versions[reinstallVersion]
+		vs.CleanupActions = []install.CleanupAction{
+			{Action: "delete_file", Path: fragmentPath("bash"), ContentHash: "stalehash"},
+		}
+		ts.Versions[reinstallVersion] = vs
+	}); err != nil {
+		t.Fatalf("seeding stale cleanup: %v", err)
+	}
+
+	if err := h.run(true); err != nil {
+		t.Fatalf("install(reinstall=true) error = %v", err)
+	}
+
+	recorded := h.recordedCleanup()
+	if len(recorded) == 0 {
+		t.Fatalf("no cleanup actions recorded after reinstall")
+	}
+	for _, ca := range recorded {
+		abs := filepath.Join(h.home, ca.Path)
+		if got := sha256File(t, abs); got != ca.ContentHash {
+			t.Errorf("%s: file hash %s, recorded %s", ca.Path, got, ca.ContentHash)
+		}
+	}
+
+	// The stale hash must be gone from the record, not sitting alongside the
+	// fresh one.
+	for _, ca := range recorded {
+		if ca.ContentHash == "stalehash" {
+			t.Errorf("stale cleanup record survived the reinstall: %+v", ca)
+		}
+	}
+
+	// One fragment per shell, not one per install.
+	entries, err := os.ReadDir(filepath.Join(h.home, "share", "shell.d"))
+	if err != nil {
+		t.Fatalf("reading shell.d: %v", err)
+	}
+	count := 0
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) != "" && e.Name()[0] != '.' {
+			count++
+		}
+	}
+	if count != len(recorded) {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("shell.d holds %d fragment(s) %v but state records %d", count, names, len(recorded))
+	}
+}
+
+// TestReinstall_DeletesOrphanedFragment covers the case where the recipe has
+// stopped writing a file the previous install wrote. Nothing else would ever
+// delete it: removal only consults what state records for the version, and the
+// reinstall replaces that record wholesale. Without the stale-cleanup pass the
+// file stays on disk forever, still concatenated into the user's shell by the
+// init cache.
+func TestReinstall_DeletesOrphanedFragment(t *testing.T) {
+	h := newReinstallHarness(t)
+
+	orphanRel := filepath.Join("share", "shell.d", "legacy-"+reinstallTool+"@"+reinstallVersion+".bash")
+	orphanAbs := filepath.Join(h.home, orphanRel)
+	if err := os.MkdirAll(filepath.Dir(orphanAbs), 0755); err != nil {
+		t.Fatalf("creating shell.d: %v", err)
+	}
+	if err := os.WriteFile(orphanAbs, []byte("export "+reinstallEnvVar+"=legacy\n"), 0644); err != nil {
+		t.Fatalf("writing orphan fragment: %v", err)
+	}
+	if err := h.mgr.GetState().UpdateTool(reinstallTool, func(ts *install.ToolState) {
+		vs := ts.Versions[reinstallVersion]
+		vs.CleanupActions = []install.CleanupAction{
+			{Action: "delete_file", Path: orphanRel},
+		}
+		ts.Versions[reinstallVersion] = vs
+	}); err != nil {
+		t.Fatalf("seeding orphan cleanup: %v", err)
+	}
+
+	if err := h.run(true); err != nil {
+		t.Fatalf("install(reinstall=true) error = %v", err)
+	}
+
+	if _, err := os.Stat(orphanAbs); !os.IsNotExist(err) {
+		t.Errorf("orphaned fragment %s survived the reinstall (stat err = %v)", orphanRel, err)
+	}
+
+	// The fragments this install does write must still be there -- a
+	// stale-cleanup pass that deleted everything the previous install recorded
+	// would also pass the check above.
+	for _, ca := range h.recordedCleanup() {
+		if _, err := os.Stat(filepath.Join(h.home, ca.Path)); err != nil {
+			t.Errorf("fragment %s recorded but missing: %v", ca.Path, err)
+		}
+	}
+}
+
+// TestReinstall_DoesNotCascadeToDependencies pins the scoping decision:
+// --reinstall repairs the tool the user named and leaves its dependencies
+// alone. Both dependency kinds are covered because they take different routes.
+// An install-time dependency is installed with IsExplicit false and returns at
+// the already-installed check near the top of installWithDependencies; a
+// runtime dependency is installed with IsExplicit true and runs all the way to
+// the version short-circuit, which is where a cascaded flag would push it into
+// a full re-execution.
+func TestReinstall_DoesNotCascadeToDependencies(t *testing.T) {
+	tests := []struct {
+		name    string
+		runtime bool
+	}{
+		{name: "install-time dependency", runtime: false},
+		{name: "runtime dependency", runtime: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const dep = "reinstalldep"
+
+			h := newReinstallHarness(t)
+			h.seedInstalledTool(dep, nil, nil)
+
+			// Re-register the parent recipe with the dependency declared.
+			if tt.runtime {
+				h.seedInstalledTool(reinstallTool, nil, []string{dep})
+			} else {
+				h.seedInstalledTool(reinstallTool, []string{dep}, nil)
+			}
+
+			// Both trees are wrong. Only the named tool's may be repaired.
+			h.writeTreeFor(reinstallTool, reinstallBadContent)
+			h.writeTreeFor(dep, reinstallBadContent)
+
+			if err := h.run(true); err != nil {
+				t.Fatalf("install(reinstall=true) error = %v", err)
+			}
+
+			if got := h.markerContent(); got != reinstallGoodContent {
+				t.Errorf("named tool marker = %q, want %q (the reinstall must repair it)", got, reinstallGoodContent)
+			}
+
+			depMarker, err := os.ReadFile(h.markerPathFor(dep))
+			if err != nil {
+				t.Fatalf("reading dependency marker: %v", err)
+			}
+			if string(depMarker) != reinstallBadContent {
+				t.Errorf("dependency marker = %q, want %q (reinstall must not cascade)", depMarker, reinstallBadContent)
+			}
+		})
+	}
+}
+
+// TestReinstall_RepairsHiddenTool covers the other shortcut on the way in.
+// A hidden tool -- one installed as somebody's execution dependency -- is
+// normally handled by exposing it, which only creates symlinks and never looks
+// at the payload. Someone repairing a hidden tool's files that way would get
+// links to the same broken files and a success message.
+func TestReinstall_RepairsHiddenTool(t *testing.T) {
+	h := newReinstallHarness(t)
+	if err := h.mgr.GetState().UpdateTool(reinstallTool, func(ts *install.ToolState) {
+		ts.IsHidden = true
+		ts.IsExecutionDependency = true
+		ts.Binaries = []string{"bin/" + reinstallTool}
+	}); err != nil {
+		t.Fatalf("marking tool hidden: %v", err)
+	}
+	h.writeInstalledTree(reinstallBadContent)
+
+	if err := h.run(true); err != nil {
+		t.Fatalf("install(reinstall=true) error = %v", err)
+	}
+
+	if got := h.markerContent(); got != reinstallGoodContent {
+		t.Errorf("marker content = %q, want %q (exposing a hidden tool does not repair it)", got, reinstallGoodContent)
+	}
+}
+
+// TestReinstallLibrary_ReplacesTamperedFiles covers the second message
+// `tsuku verify` prints. Libraries take their own install path with their own
+// two reuse checks -- one before the plan runs and one after -- and a flag that
+// existed but hit either of them would answer an integrity failure with
+// "reusing" and change nothing on disk.
+func TestReinstallLibrary_ReplacesTamperedFiles(t *testing.T) {
+	tests := []struct {
+		name      string
+		reinstall bool
+		want      string
+	}{
+		{
+			name:      "with --reinstall the modification is gone",
+			reinstall: true,
+			want:      reinstallGoodContent,
+		},
+		{
+			name:      "without --reinstall the existing install is reused",
+			reinstall: false,
+			want:      reinstallBadContent,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const lib = "reinstalllib"
+
+			home := t.TempDir()
+			t.Setenv("TSUKU_HOME", home)
+
+			cfg, err := config.DefaultConfig()
+			if err != nil {
+				t.Fatalf("config.DefaultConfig() error = %v", err)
+			}
+			if err := cfg.EnsureDirectories(); err != nil {
+				t.Fatalf("EnsureDirectories() error = %v", err)
+			}
+
+			origCtx := globalCtx
+			t.Cleanup(func() { globalCtx = origCtx })
+			globalCtx = lifecycleCtx()
+
+			origLoader := loader
+			t.Cleanup(func() { loader = origLoader })
+			loader = recipe.NewLoader()
+			loader.CacheRecipe(lib, &recipe.Recipe{
+				Metadata: recipe.MetadataSection{Name: lib, Type: "library"},
+				Steps: []recipe.Step{
+					{Action: "run_command", Params: map[string]any{
+						"command": "mkdir -p {install_dir}/lib && " +
+							"printf '" + reinstallGoodContent + "' > {install_dir}/lib/marker.txt",
+					}},
+				},
+			})
+
+			mgr := install.New(cfg)
+			run := func(reinstall bool) error {
+				return installWithDependencies(lifecycleCtx(), installArgs{
+					Tool:       lib,
+					IsExplicit: true,
+					Reinstall:  reinstall,
+					Reporter:   &countingReporter{},
+				}, make(map[string]bool))
+			}
+
+			if err := run(false); err != nil {
+				t.Fatalf("first install error = %v", err)
+			}
+
+			version := mgr.GetInstalledLibraryVersion(lib)
+			if version == "" {
+				t.Fatalf("library not installed after first install")
+			}
+			marker := filepath.Join(mgr.LibDir(lib, version), "lib", "marker.txt")
+			if err := os.WriteFile(marker, []byte(reinstallBadContent), 0644); err != nil {
+				t.Fatalf("tampering with library marker: %v", err)
+			}
+
+			if err := run(tt.reinstall); err != nil {
+				t.Fatalf("second install(reinstall=%v) error = %v", tt.reinstall, err)
+			}
+
+			got, err := os.ReadFile(marker)
+			if err != nil {
+				t.Fatalf("reading library marker: %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("library marker = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestInstallAdviceNamesRegisteredFlags is the guard for the defect that
+// produced this issue: `tsuku verify` told users to run
+// `tsuku install <tool> --reinstall` for two releases while no such flag was
+// registered, so the advice failed with an unknown-flag error at exactly the
+// moment the user needed it.
+//
+// The check reads every Go source in this package, finds each line that offers
+// a `tsuku install` command with flags on it, and requires the install command
+// to actually have them. It deliberately covers the whole package rather than
+// the two known messages, because the next stale suggestion will be somewhere
+// else.
+func TestInstallAdviceNamesRegisteredFlags(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("reading package directory: %v", err)
+	}
+
+	// A flag on a line that also offers "tsuku install". The trailing class
+	// stops at the first character that cannot be part of a flag name, so
+	// "--fresh\n" and "--reinstall'" both yield the bare name.
+	flagPattern := regexp.MustCompile(`--([a-z][a-z0-9-]*)`)
+
+	checked := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		data, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("reading %s: %v", name, err)
+		}
+		for i, line := range strings.Split(string(data), "\n") {
+			idx := strings.Index(line, "tsuku install ")
+			if idx < 0 {
+				continue
+			}
+			for _, m := range flagPattern.FindAllStringSubmatch(line[idx:], -1) {
+				checked++
+				if installCmd.Flags().Lookup(m[1]) == nil {
+					t.Errorf("%s:%d suggests 'tsuku install ... --%s', which is not a registered install flag:\n  %s",
+						name, i+1, m[1], strings.TrimSpace(line))
+				}
+			}
+		}
+	}
+
+	// A pattern that matched nothing would make this test pass forever without
+	// looking at anything.
+	if checked == 0 {
+		t.Fatal("found no 'tsuku install' suggestions with flags; the scan is not looking at anything")
+	}
+}
+
+// TestWithInstallFlags_CarriesReinstall pins the wiring between the parsed flag
+// and the install pipeline. Registering --reinstall and never reading it would
+// leave the two `tsuku verify` messages pointing at a flag that parses and does
+// nothing, which is a worse outcome than the unknown-flag error they used to
+// produce.
+func TestWithInstallFlags_CarriesReinstall(t *testing.T) {
+	orig := installReinstall
+	t.Cleanup(func() { installReinstall = orig })
+
+	for _, want := range []bool{true, false} {
+		installReinstall = want
+		if got := withInstallFlags(installArgs{Tool: reinstallTool}).Reinstall; got != want {
+			t.Errorf("withInstallFlags() Reinstall = %v, want %v", got, want)
+		}
+	}
+
+	// Fields the caller set have to survive.
+	installReinstall = true
+	got := withInstallFlags(installArgs{Tool: reinstallTool, ReqVersion: "1.2.3", IsExplicit: true})
+	if got.Tool != reinstallTool || got.ReqVersion != "1.2.3" || !got.IsExplicit {
+		t.Errorf("withInstallFlags() clobbered caller fields: %+v", got)
+	}
+}
+
+// TestReinstall_FromCommandEntryPoint runs the whole chain the CLI runs: the
+// package-level flag cobra writes into, the entry point that turns it into
+// install arguments, and the install itself. The other tests call
+// installWithDependencies directly and would all still pass if the entry point
+// stopped applying the flags.
+func TestReinstall_FromCommandEntryPoint(t *testing.T) {
+	h := newReinstallHarness(t)
+	h.writeInstalledTree(reinstallBadContent)
+
+	orig := installReinstall
+	t.Cleanup(func() { installReinstall = orig })
+	installReinstall = true
+
+	if err := runInstall(lifecycleCtx(), installArgs{Tool: reinstallTool, IsExplicit: true}); err != nil {
+		t.Fatalf("runInstall() error = %v", err)
+	}
+
+	if got := h.markerContent(); got != reinstallGoodContent {
+		t.Errorf("marker content = %q, want %q", got, reinstallGoodContent)
+	}
+}

--- a/docs/designs/current/DESIGN-shell-d-lifecycle.md
+++ b/docs/designs/current/DESIGN-shell-d-lifecycle.md
@@ -434,9 +434,11 @@ assumption. No `state.json` schema change, no import surgery, no hot-path cost.
 **Negative.** The blast radius is wide: twelve non-test files across six packages, and
 five consumers that must change or the rename regresses. One of those —
 `StaleCleanupActions` — is a defect this design creates, whose failure mode is deleting a
-live file that no existing test covers. Repair is structurally impossible: a user who
-deletes a shell.d file has no recovery but remove-and-reinstall, made worse by the
-already-installed short-circuit that `--force` does not bypass. Pre-existing
+live file that no existing test covers. Repair was structurally impossible when this was
+written: a user who deleted a shell.d file had no recovery but remove-and-reinstall, made
+worse by the already-installed short-circuit that `--force` does not bypass. Issue #2463
+closed that gap. `tsuku install <tool> --reinstall` re-executes the plan and rewrites the
+fragment, so the repair path now exists. Pre-existing
 multi-version corruption is grandfathered. Disk use grows by one fragment per installed
 version per shell — for nvm, ~324 KB per extra version, against a tool directory that
 already holds a full copy of the same file.
@@ -469,6 +471,13 @@ fixed in the same change.
 - **The already-installed short-circuit** returns before running any steps and `--force`
   does not bypass it, so an existing install never picks up a fix. `tsuku verify`
   recommends a `--reinstall` flag that does not exist; separate issue.
+  *Resolved in issue #2463: `tsuku install <tool> --reinstall` bypasses the
+  short-circuit and re-executes the plan, so an existing install can pick up a fix and
+  a deleted or modified shell.d fragment has a repair. The flag also bypasses the
+  hidden-tool expose and the library path's two reuse checks, and runs
+  `StaleCleanupActions` against the record the replaced install left, so a fragment the
+  recipe no longer writes is deleted rather than orphaned. Reinstall is scoped to the
+  named tool; its dependencies are left alone.*
 - **`recipes/n/nvm.toml`'s `NVM_DIR` model.** `NVM_DIR` is nvm's data root as well as its
   program directory — it holds `versions/node/`, `alias/`, `.cache/`, and
   `default-packages`. Pointing it at a tsuku-versioned directory puts every node version

--- a/docs/guides/GUIDE-troubleshooting-verification.md
+++ b/docs/guides/GUIDE-troubleshooting-verification.md
@@ -76,10 +76,9 @@ Error: Dependency validation failed: libunknown.so.1 - UNKNOWN
    Some tools have optional dependencies that aren't automatically detected. Check the tool's documentation.
 
 3. **Verify the binary:**
-   The binary may be malformed or built incorrectly. Try reinstalling:
+   The binary may be malformed or built incorrectly. Reinstall it:
    ```bash
-   tsuku remove yourtool
-   tsuku install yourtool
+   tsuku install yourtool --reinstall
    ```
 
 ### Symptom: Limited validation for old library installations
@@ -92,8 +91,7 @@ Warning: Library installed before Tier 2 support - limited validation available
 
 **Solution**: Reinstall the library to populate metadata:
 ```bash
-tsuku remove libfoo
-tsuku install libfoo
+tsuku install libfoo --reinstall
 ```
 
 ## Tier 1: Header Validation Failures
@@ -108,8 +106,7 @@ Error: Header validation failed: invalid ELF magic number
 
 **Solution**: Reinstall the tool/library:
 ```bash
-tsuku remove yourtool
-tsuku install yourtool
+tsuku install yourtool --reinstall
 ```
 
 ### Symptom: Architecture mismatch
@@ -154,8 +151,7 @@ Error: dlopen failed: permission denied
 chmod +x $TSUKU_HOME/tools/yourtool-1.0.0/lib/libfoo.so
 
 # Or reinstall
-tsuku remove yourtool
-tsuku install yourtool
+tsuku install yourtool --reinstall
 ```
 
 ## Tier 4: Integrity Verification Failures
@@ -174,9 +170,13 @@ Got: def456...
 
 1. **Reinstall if unexpected:**
    ```bash
-   tsuku remove yourtool
-   tsuku install yourtool
+   tsuku install yourtool --reinstall
    ```
+
+   This re-runs the installation and replaces the files on disk. Plain
+   `tsuku install` will not do it: an already-installed version is reported as
+   present and nothing is rewritten. Anything the tool keeps in
+   `$TSUKU_HOME/data/<tool>/` is left alone.
 
 2. **If you intentionally modified the file:**
    This is expected behavior. Tier 4 detects post-installation changes. You can skip integrity checks:

--- a/plugins/tsuku-user/skills/tsuku-user/SKILL.md
+++ b/plugins/tsuku-user/skills/tsuku-user/SKILL.md
@@ -59,8 +59,8 @@ tsuku finds `.tsuku.toml` by walking up from the current directory, stopping at 
 
 | Command | Description | Common Flags |
 |---------|-------------|--------------|
-| `tsuku install <tool>` | Install a tool (supports `@version` suffix) | `--force`, `--sandbox`, `--dry-run` |
-| `tsuku install` | Install all tools from `.tsuku.toml` | `--yes`, `--dry-run`, `--fresh` |
+| `tsuku install <tool>` | Install a tool (supports `@version` suffix) | `--force`, `--sandbox`, `--dry-run`, `--reinstall` |
+| `tsuku install` | Install all tools from `.tsuku.toml` | `--yes`, `--dry-run`, `--fresh`, `--reinstall` |
 | `tsuku remove <tool>` | Remove a tool (or specific version with `@version`) | `--force` |
 | `tsuku update <tool>` | Update within pin boundaries | `--dry-run` |
 | `tsuku update --all` | Update all tools (skips exact-pinned) | `--dry-run` |
@@ -70,6 +70,15 @@ tsuku finds `.tsuku.toml` by walking up from the current directory, stopping at 
 | `tsuku outdated` | Show tools with available updates | `--json` |
 
 **Tool data outlives the tool**: a few tools keep things for you rather than just being a program — nvm holds every Node version you install, their global npm packages, and your `default` alias. Those live in `$TSUKU_HOME/data/<tool>/`, which is separate from the versioned directory tsuku installs into and recycles. Upgrading the tool leaves them alone, and so does `tsuku remove`. Nothing tsuku ships deletes that directory, so reclaim the space with `rm -rf "$TSUKU_HOME/data/<tool>"`. Data an older tsuku left somewhere else is not moved for you — see `docs/tool-data-directory.md`. Note this makes `rm -rf $TSUKU_HOME` destructive to data you cannot get back cheaply.
+
+**Reinstalling**: plain `tsuku install <tool>` is idempotent — if the version it
+resolves to is already installed, it says so and stops. `--reinstall` makes it run
+the installation again and replace the files on disk, which is how an existing
+install picks up a fix and how a modified install gets repaired. It reinstalls the
+tool you name and leaves its dependencies alone, so reinstall a dependency by
+naming it. Anything the tool keeps in `$TSUKU_HOME/data/<tool>/` is untouched.
+With no tool argument, `tsuku install --reinstall` reinstalls every tool declared
+in `.tsuku.toml`.
 
 **Switching versions**: `activate` and `rollback` both re-point everything tsuku
 owns for that tool — the `$TSUKU_HOME/bin` symlinks and the shell integration.
@@ -197,6 +206,11 @@ tsuku doctor
 tsuku verify <tool>
 ```
 This checks that the binary exists, its version matches the recorded state, and runs the tool's verification command if one is defined.
+
+If verify reports files were modified after installation, put the original files back:
+```bash
+tsuku install <tool> --reinstall
+```
 
 **Registry out of date?** Refresh it:
 ```bash

--- a/plugins/tsuku-user/skills/tsuku-user/SKILL.md
+++ b/plugins/tsuku-user/skills/tsuku-user/SKILL.md
@@ -59,7 +59,7 @@ tsuku finds `.tsuku.toml` by walking up from the current directory, stopping at 
 
 | Command | Description | Common Flags |
 |---------|-------------|--------------|
-| `tsuku install <tool>` | Install a tool (supports `@version` suffix) | `--force`, `--sandbox`, `--dry-run`, `--reinstall` |
+| `tsuku install <tool>` | Install a tool (supports `@version` suffix) | `--force`, `--sandbox`, `--dry-run`, `--reinstall`, `--fresh` |
 | `tsuku install` | Install all tools from `.tsuku.toml` | `--yes`, `--dry-run`, `--fresh`, `--reinstall` |
 | `tsuku remove <tool>` | Remove a tool (or specific version with `@version`) | `--force` |
 | `tsuku update <tool>` | Update within pin boundaries | `--dry-run` |
@@ -73,12 +73,17 @@ tsuku finds `.tsuku.toml` by walking up from the current directory, stopping at 
 
 **Reinstalling**: plain `tsuku install <tool>` is idempotent — if the version it
 resolves to is already installed, it says so and stops. `--reinstall` makes it run
-the installation again and replace the files on disk, which is how an existing
-install picks up a fix and how a modified install gets repaired. It reinstalls the
-tool you name and leaves its dependencies alone, so reinstall a dependency by
-naming it. Anything the tool keeps in `$TSUKU_HOME/data/<tool>/` is untouched.
-With no tool argument, `tsuku install --reinstall` reinstalls every tool declared
-in `.tsuku.toml`.
+the installation again and replace the files on disk, which is how a modified
+install gets repaired. It reinstalls the tool you name and leaves its dependencies
+alone, so reinstall a dependency by naming it. Anything the tool keeps in
+`$TSUKU_HOME/data/<tool>/` is untouched. With no tool argument,
+`tsuku install --reinstall` reinstalls every tool declared in `.tsuku.toml`.
+
+`--reinstall` re-runs the plan stored when the tool was installed, so it picks up
+a fix in tsuku itself but not a fix in the recipe — the stored plan still
+describes the old steps. Add `--fresh` to regenerate the plan from the current
+recipe: `tsuku install <tool> --fresh --reinstall`. Repairing modified files is
+the case where you want the stored plan, since it is what produced the originals.
 
 **Switching versions**: `activate` and `rollback` both re-point everything tsuku
 owns for that tool — the `$TSUKU_HOME/bin` symlinks and the shell integration.

--- a/plugins/tsuku-user/skills/tsuku-user/evals/evals.json
+++ b/plugins/tsuku-user/skills/tsuku-user/evals/evals.json
@@ -104,6 +104,18 @@
         "Output does not recommend 'tsuku remove' as the only way to reinstall"
       ],
       "files": []
+    },
+    {
+      "id": 10,
+      "name": "reinstall-after-recipe-fix",
+      "prompt": "The recipe for a tool I already have installed was fixed upstream. I ran tsuku install <tool> --reinstall and I still get the old behavior. What am I missing?",
+      "expected_output": "Skill triggers on the plan-cache interaction. Agent explains that --reinstall re-runs the plan stored at install time, which does not reflect a changed recipe, and that --fresh regenerates the plan from the current recipe.",
+      "assertions": [
+        "Output explains that --reinstall re-runs the plan stored when the tool was installed",
+        "Output names '--fresh' as the flag that regenerates the plan from the current recipe",
+        "Output does not claim --reinstall alone picks up recipe changes"
+      ],
+      "files": []
     }
   ]
 }

--- a/plugins/tsuku-user/skills/tsuku-user/evals/evals.json
+++ b/plugins/tsuku-user/skills/tsuku-user/evals/evals.json
@@ -92,6 +92,18 @@
         "Agent does NOT confuse recipe validation with tool installation or shell setup"
       ],
       "files": []
+    },
+    {
+      "id": 9,
+      "name": "reinstall-modified-files",
+      "prompt": "tsuku verify says my tool's binary was modified after installation. How do I put the original files back without losing anything?",
+      "expected_output": "Skill triggers on install repair. Agent points at tsuku install <tool> --reinstall, explains that plain tsuku install is idempotent and will not re-run for an already-installed version, and notes that data under $TSUKU_HOME/data/<tool> is not touched.",
+      "assertions": [
+        "Output names 'tsuku install <tool> --reinstall' as the repair",
+        "Output explains that plain 'tsuku install' does nothing for an already-installed version",
+        "Output does not recommend 'tsuku remove' as the only way to reinstall"
+      ],
+      "files": []
     }
   ]
 }

--- a/test/functional/features/install.feature
+++ b/test/functional/features/install.feature
@@ -16,6 +16,25 @@ Feature: Install
     When I run "tsuku install nonexistent-tool-xyz-12345"
     Then the exit code is 3
 
+  # The middle step is the point: a plain install of an already-installed
+  # version reports success and changes nothing, which is why a broken install
+  # had no recovery before --reinstall existed.
+  @critical
+  Scenario: Reinstall repairs a modified install
+    When I run "tsuku install actionlint --force"
+    Then the exit code is 0
+    When I create home file "tools/current/actionlint" with content:
+      """
+      corrupted-by-the-test
+      """
+    And I run "tsuku install actionlint --force"
+    Then the exit code is 0
+    And the file "tools/current/actionlint" contains "corrupted-by-the-test"
+    When I run "tsuku install actionlint --force --reinstall"
+    Then the exit code is 0
+    And the file "tools/current/actionlint" does not contain "corrupted-by-the-test"
+    And I can run "actionlint -version"
+
   Scenario: Install with --from generates recipe and installs
     When I run "tsuku install shfmt --from homebrew:shfmt --force --deterministic-only"
     Then the exit code is 0

--- a/test/functional/features/rollback.feature
+++ b/test/functional/features/rollback.feature
@@ -12,4 +12,4 @@ Feature: Rollback and notices
   Scenario: Notices command with no notices
     When I run "tsuku notices"
     Then the exit code is 0
-    And the output contains "No update failure notices"
+    And the output contains "No update notices."


### PR DESCRIPTION
`tsuku install <tool>` could not reinstall a version it already had. The short-circuit in `installWithDependencies` returned before executing anything, and no flag went past it -- `--force` only suppresses security prompts and `--fresh` only regenerates the plan. A user whose files were written by buggy code, or modified after installation, had no command that would rewrite them. `tsuku verify` has been telling them to run `tsuku install <tool> --reinstall` in two places for a flag that did not exist.

`--reinstall` skips the three shortcuts on the way in: the hidden-tool expose, which only creates symlinks and never touches the payload, and the already-installed checks on the tool and library paths. Everything after that was already in place. `InstallWithOptions` stages the new tree, removes the existing tool directory, and renames staging in; it replaces the version's state entry wholesale rather than merging into it, so the recorded binaries, checksums and cleanup actions describe the reinstall's files.

Files a tool writes outside its own directory need one more step. The version state that recorded them is replaced, so a fragment the recipe has stopped writing would be gone from state and still on disk, still concatenated into the user's shell by the init cache. The reinstall snapshots the prior record before the reset and runs the same stale-cleanup pass an update runs.

The flag is applied in one place, `withInstallFlags`, rather than at each of the seven sites where the install command builds its arguments.

---

Fixes #2463

## Dependency scope

`--reinstall` reinstalls the tool you name. Its dependencies are installed if missing and left alone if present.

The flag is a repair aimed at one tool. Cascading would rewrite every tree in the dependency graph -- an unbounded amount of work on things the user did not name -- and a dependency that is itself broken can be named directly. The install path derives child invocations by copy-and-override on `installArgs`, so this is not automatic: both recursive calls clear `sub.Reinstall` explicitly.

## Libraries

One of the two `tsuku verify` messages advertises `--reinstall` for a library, and libraries take their own install path with their own two reuse checks. A flag that existed but hit either of them would answer an integrity failure with "reusing" and change nothing on disk, which is a worse outcome than the unknown-flag error it replaced. Both checks are now skipped under the flag.

## Verifying the data-loss precondition

Wiping a tool directory is only safe because a tool's data no longer lives in it. Checked against HEAD rather than assumed: `recipes/n/nvm.toml` points `NVM_DIR` at `{data_dir}` (`$TSUKU_HOME/data/nvm`), and it is the only recipe in the registry that references `data_dir` or aims a state-bearing variable at `{install_dir}`. `docs/tool-data-directory.md` already states that reinstalling does not touch `$TSUKU_HOME/data/`.

One narrow case does not fit that: unreleased builds between the shell.d lifecycle fix and the data-directory move left Node versions inside the versioned tool directory. Those are already reclaimed on the existing 7-day GC timer, so `--reinstall` disposes of nothing that was not already scheduled for disposal. `docs/tool-data-directory.md` covers the migration.

## What `--reinstall` alone does and does not pick up

`getOrGeneratePlan` prefers the plan stored in `state.json` and only `--fresh` bypasses it. `ValidateCachedPlan` checks the format version and the platform; `CacheKeyFor` never populates `ContentHash`, so a recipe that changed since the plan was stored does not invalidate it.

That splits the issue's "pick up a fix" into two cases. A fix in tsuku's own code reaches the user through a plain `--reinstall`, because the stored steps are re-executed by the new binary -- that is the shell.d repair the issue is about. A fix in the recipe does not: the stored plan still describes the old steps, and regenerating it takes `--fresh --reinstall`.

Left as is rather than making `--reinstall` imply `--fresh`. The advertised use case is the one `tsuku verify` prints, restoring files modified after installation, and there the stored plan is precisely what you want -- it is what produced the originals. Regenerating by default would also put version resolution and download-backed decomposition on the path of a repair that needs neither. `--fresh` already exists for the other case.

`TestReinstall_CachedPlanVersusFresh` pins both halves: the same tool, one subtest per flag combination, asserting which plan's content is on disk afterwards. The `tsuku-user` skill documents the distinction and carries an eval for it.

## Documentation the change makes stale

`docs/guides/GUIDE-troubleshooting-verification.md` told users to run `tsuku remove` then `tsuku install` in five places, including under "Checksum mismatch" -- the moment a user has just been told their files were modified, and the one where reaching for `remove` first reads as the destructive option. All five now name `--reinstall`. One of them is a library whose soname metadata predates Tier 2 support; that works because the library path repopulates sonames after installing, which the flag now reaches.

`docs/designs/current/DESIGN-shell-d-lifecycle.md` is the design the issue cites. It deferred this short-circuit under "Deliberately out of scope" and separately called repair "structurally impossible" because a deleted shell.d fragment had no recovery but remove-and-reinstall. The deferral gets the same italicized resolved-in-issue note the dependency-path bullet above it already carries, and the consequences paragraph now says the repair path exists. Status stays `Current`: one deferral inside the design closed, the design itself is not superseded.

## Acceptance criteria

| Criterion | Where |
|---|---|
| `--reinstall` re-executes the plan for an installed version | `TestReinstall_ReplacesTamperedFiles`, `TestReinstall_RestoresMissingFile` |
| Cleanup actions and content hashes describe the reinstall's files | `TestReinstall_ShellFragmentMatchesFreshHash` |
| Files written outside the tool directory replaced, not duplicated or orphaned | `TestReinstall_ShellFragmentMatchesFreshHash`, `TestReinstall_DeletesOrphanedFragment` |
| Both `verify.go` messages name a flag that exists | `TestInstallAdviceNamesRegisteredFlags` |
| Plain `tsuku install` stays idempotent | `TestReinstall_ReplacesTamperedFiles` control subtest |
| A test reinstalls a tool that writes shell integration and checks the file against the fresh hash | `TestReinstall_ShellFragmentMatchesFreshHash` |

The unit tests drive the real `installWithDependencies` path offline. A tool that is already installed has its plan in `state.json` and `getOrGeneratePlan` prefers that cached plan, so seeding state the way a previous install would have left it is enough to re-execute without touching the network. Every test tampers with the installed tree and reads the tree back afterwards; none of them assert that the flag parsed or that the short-circuit was skipped.

`test/functional/features/install.feature` adds a `@critical` scenario that installs actionlint, corrupts the binary, confirms a plain install reports success and changes nothing, then reinstalls and runs the tool. Verified locally against the real binary: 21 scenarios, 101 steps, all passing.

## Mutation testing

Each guard got one injected defect, a named test run, and a revert. 14 of 15 killed.

| # | Defect | Result |
|---|---|---|
| 1 | Short-circuit ignores `--reinstall` | KILLED -- `TestReinstall_ReplacesTamperedFiles` +4 |
| 2 | Short-circuit removed entirely | KILLED -- idempotence subtest |
| 3 | Reinstall cascades into runtime dependencies | KILLED -- `TestReinstall_DoesNotCascadeToDependencies/runtime_dependency` |
| 4 | Reinstall cascades into install-time dependencies | SURVIVED (expected, see below) |
| 5 | Stale-cleanup pass removed | KILLED -- `TestReinstall_DeletesOrphanedFragment` |
| 6 | Prior-cleanup snapshot taken after the state reset | KILLED -- `TestReinstall_DeletesOrphanedFragment` |
| 7 | Hidden-expose shortcut ignores `--reinstall` | KILLED -- `TestReinstall_RepairsHiddenTool` |
| 8 | Fresh cleanup actions never recorded | KILLED -- `TestReinstall_ShellFragmentMatchesFreshHash` |
| 9 | Library pre-plan reuse check ignores the flag | KILLED -- `TestReinstallLibrary_ReplacesTamperedFiles` |
| 10 | Library post-plan reuse check ignores the flag | KILLED -- `TestReinstallLibrary_ReplacesTamperedFiles` |
| 11 | `--reinstall` not registered on `installCmd` | KILLED -- `TestInstallAdviceNamesRegisteredFlags` |
| 12 | Flag registered but never read into the args | KILLED -- `TestWithInstallFlags_CarriesReinstall`, `TestReinstall_FromCommandEntryPoint` |
| 13 | Install entry point drops the flags | KILLED -- `TestReinstall_FromCommandEntryPoint` |
| 15 | `--fresh` no longer bypasses the plan cache | KILLED -- `TestReinstall_CachedPlanVersusFresh` |
| 16 | Reinstall always regenerates, cache never consulted | KILLED -- `TestReinstall_ReplacesTamperedFiles` +3 |

**Expected survivor (4).** An install-time dependency is installed with `IsExplicit` false and returns at the already-installed check near the top of `installWithDependencies`, before the version short-circuit the flag guards. Clearing `sub.Reinstall` there cannot change behavior today, so no test can distinguish it. The line stays for symmetry with the runtime-dependency loop, where it is load-bearing: a reviewer reading one loop should not have to prove the other's early return holds. Recorded here rather than dropped from the table.

Two mutations found real gaps rather than confirming coverage. 12 originally survived because every test called `installWithDependencies` directly and nothing exercised the flag's route from cobra into the pipeline; that is what produced `withInstallFlags` and `TestReinstall_FromCommandEntryPoint`. 14 -- dropping the flags in `runInstallWithReporter` -- survived because only `tsuku update` reaches that entry point and it registers no install flags, so the call there was removed as an untestable claim and the reason recorded in the doc comment.

## One unrelated fix, needed for a green build

`test/functional/features/rollback.feature` asserted that `tsuku notices` prints "No update failure notices". It has printed "No update notices." since #2380 broadened notices beyond failures. The scenario has been failing on `main` ever since -- confirmed by building a binary at `origin/main` and running the suite against `main`'s own feature files -- and no PR surfaced it because the full functional suite only runs when a PR touches `test/functional/`. This PR touches it, so the run armed and went red.

One line, changing the assertion to the text the command prints. Called out here because it is unrelated to `--reinstall` and a reviewer should not have to work out why it is in the diff.

## Three defects found and filed rather than fixed

- **#2485** -- `ToStoragePlan` and `FromStoragePlan` do not carry `ResolvedStep.Phase`, so a plan read back from `state.json` runs an explicitly declared post-install step in the install phase. Latent today: nothing in `recipes/` declares `phase`. It is worth filing now because `--reinstall` is the first path that routinely re-executes a stored plan.
- **#2486** -- `InstallLibrary` copies straight into the live directory instead of staging and renaming, so a library reinstall overwrites the plan's files but leaves anything else in the directory, and a failed copy leaves the library half-replaced. The tool path cannot reach either state.
- **#2492** -- two assertions in `check-deps.feature` are undefined steps, because the step pattern's character class cannot carry escaped quotes. `godog.Options` does not set `Strict`, so they do not fail the run; they simply never execute. The scenario reports as passing on its other steps. Found while reading the same full-suite output as the notices failure above.

## Adjacent issues, deliberately untouched

`--reinstall` makes **#2103** (`update` does not switch the active version when the target is already installed) easier: the mechanism it needs, a supported way to re-run an install for a version already on disk, now exists, though the fix itself is about activation rather than reinstallation.

It makes **#2104** (`install` executes a full plan before detecting the version is already installed) marginally harder. Anything that moves the already-installed detection earlier now has one more caller to satisfy, since `--reinstall` has to reach plan execution while the default path must not. The short-circuit still sits after plan retrieval for the same reason as before -- the resolved version comes out of the plan.

## Checks

`go build ./...`, `go vet ./...`, `gofmt -l .` and `golangci-lint run ./...` are clean; `go test -short ./...` exits 0. The full functional suite passes locally: 133 scenarios, 617 steps, one of which is the new `@critical` reinstall scenario. Does not touch any path on the golden-plan workflow's allowlist, so that workflow is not armed.
