### PR TITLE
fix(updates): reclaim versions from state, not from directory names

### DIFF
--- a/internal/install/list.go
+++ b/internal/install/list.go
@@ -74,7 +74,7 @@ func (m *Manager) ListWithOptions(includeHidden bool) ([]InstalledTool, error) {
 }
 
 // InstalledVersions returns the versions state records for a tool, sorted. A
-// tool state has no record of yields no versions and no error.
+// tool that state has no record of yields no versions and no error.
 //
 // Callers that need to know which directories under $TSUKU_HOME/tools belong to
 // a tool must ask this rather than matching directory names against a

--- a/internal/install/list.go
+++ b/internal/install/list.go
@@ -73,6 +73,30 @@ func (m *Manager) ListWithOptions(includeHidden bool) ([]InstalledTool, error) {
 	return tools, nil
 }
 
+// InstalledVersions returns the versions state records for a tool, sorted. A
+// tool state has no record of yields no versions and no error.
+//
+// Callers that need to know which directories under $TSUKU_HOME/tools belong to
+// a tool must ask this rather than matching directory names against a
+// "<tool>-" prefix. The registry ships both "git" and "git-lfs", and a prefix
+// match cannot tell one's directory from the other's.
+func (m *Manager) InstalledVersions(name string) ([]string, error) {
+	toolState, err := m.state.GetToolState(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load state: %w", err)
+	}
+	if toolState == nil {
+		return nil, nil
+	}
+
+	versions := make([]string, 0, len(toolState.Versions))
+	for version := range toolState.Versions {
+		versions = append(versions, version)
+	}
+	sort.Strings(versions)
+	return versions, nil
+}
+
 // InstalledApp represents an installed macOS application bundle
 type InstalledApp struct {
 	Name               string // Tool name from recipe

--- a/internal/install/remove.go
+++ b/internal/install/remove.go
@@ -379,22 +379,26 @@ func (m *Manager) executeCleanupActions(ctx context.Context, name, version strin
 // It refuses to touch the active version. Callers that delete directories are
 // expected to protect it themselves; this is the second lock on the door.
 //
-// A version that is not in state, or a tool that is not, is a no-op: the
-// directory is gone either way and there is nothing left to reconcile.
+// It also refuses a version, or a tool, that state has no record of. Every
+// caller is about to delete that version's directory, or has just deleted it,
+// and a version state cannot vouch for is one whose directory this process has
+// no business claiming. Returning nil there would report "reconciled" when
+// nothing was reconciled, which is how a directory belonging to another tool
+// got past this check and deleted.
 func (m *Manager) ReapVersion(name, version string) error {
 	toolState, err := m.state.GetToolState(name)
 	if err != nil {
 		return fmt.Errorf("failed to load state: %w", err)
 	}
 	if toolState == nil {
-		return nil
+		return fmt.Errorf("refusing to reap %s@%s: %s is not installed", name, version, name)
 	}
 	if toolState.ActiveVersion == version {
 		return fmt.Errorf("refusing to reap the active version %s of %s", version, name)
 	}
 	versionState, exists := toolState.Versions[version]
 	if !exists {
-		return nil
+		return fmt.Errorf("refusing to reap %s@%s: state records no such version of %s", name, version, name)
 	}
 
 	affectedShells := m.executeCleanupActions(context.Background(), name, version, versionState.CleanupActions, toolState)

--- a/internal/install/remove.go
+++ b/internal/install/remove.go
@@ -371,10 +371,21 @@ func (m *Manager) executeCleanupActions(ctx context.Context, name, version strin
 	return affectedShells
 }
 
-// ReapVersion drops a version whose directory has already been deleted out of
-// band -- garbage collection removes tool directories directly. It runs that
-// version's cleanup actions (skipping anything another version still records),
-// removes its VersionState, and rebuilds the affected caches.
+// ReapVersion drops a version whose directory is about to be, or has already
+// been, deleted out of band -- garbage collection removes tool directories
+// directly. It runs that version's cleanup actions (skipping anything another
+// version still records), removes its VersionState, and rebuilds the affected
+// caches.
+//
+// Callers are expected to reap before deleting, and the one that exists does.
+// Reconciling first means a failed reap leaves the version installed rather
+// than recorded but absent; deleting first opens a window where it is the other
+// way round. Do not reorder this without reading GarbageCollectVersions.
+//
+// Unlike RemoveVersion, this does not tear down the version's .app bundle or
+// its ~/Applications symlink, so reaping a macOS app tool orphans both -- and
+// dropping the VersionState throws away the only record of where they were.
+// That is a known gap, not a decision; see issue #2490.
 //
 // It refuses to touch the active version. Callers that delete directories are
 // expected to protect it themselves; this is the second lock on the door.

--- a/internal/install/shelld_lifecycle_test.go
+++ b/internal/install/shelld_lifecycle_test.go
@@ -235,7 +235,13 @@ func TestReapVersion_RunsCleanupAndDropsVersionState(t *testing.T) {
 	if err := mgr.ReapVersion("mytool", "2.0.0"); err == nil {
 		t.Error("ReapVersion must refuse the active version")
 	}
-	if err := mgr.ReapVersion("mytool", "9.9.9"); err != nil {
-		t.Errorf("reaping an unknown version should be a no-op, got %v", err)
+	// The caller is about to delete that version's directory. A version state
+	// has no record of is one this tool cannot claim, so refusing is what stops
+	// a directory belonging to something else from being removed.
+	if err := mgr.ReapVersion("mytool", "9.9.9"); err == nil {
+		t.Error("ReapVersion must refuse a version state has no record of")
+	}
+	if err := mgr.ReapVersion("nosuchtool", "1.0.0"); err == nil {
+		t.Error("ReapVersion must refuse a tool state has no record of")
 	}
 }

--- a/internal/install/shelld_lifecycle_test.go
+++ b/internal/install/shelld_lifecycle_test.go
@@ -232,16 +232,37 @@ func TestReapVersion_RunsCleanupAndDropsVersionState(t *testing.T) {
 		t.Error("the active version must survive a reap of another version")
 	}
 
+}
+
+// The refusals are the safety property garbage collection leans on, so they get
+// their own test rather than living at the bottom of the happy path. The caller
+// is about to delete the version's directory; a version that state cannot vouch
+// for is one this tool has no business claiming, and saying so is what stops a
+// directory belonging to something else from being removed.
+func TestReapVersion_RefusesWhatStateCannotVouchFor(t *testing.T) {
+	cfg, cleanup := testutil.NewTestConfig(t)
+	defer cleanup()
+	mgr := New(cfg)
+
+	twoVersionTool(t, mgr, cfg, "mytool", "2.0.0")
+
 	if err := mgr.ReapVersion("mytool", "2.0.0"); err == nil {
 		t.Error("ReapVersion must refuse the active version")
 	}
-	// The caller is about to delete that version's directory. A version state
-	// has no record of is one this tool cannot claim, so refusing is what stops
-	// a directory belonging to something else from being removed.
 	if err := mgr.ReapVersion("mytool", "9.9.9"); err == nil {
-		t.Error("ReapVersion must refuse a version state has no record of")
+		t.Error("ReapVersion must refuse a version that state has no record of")
 	}
 	if err := mgr.ReapVersion("nosuchtool", "1.0.0"); err == nil {
-		t.Error("ReapVersion must refuse a tool state has no record of")
+		t.Error("ReapVersion must refuse a tool that state has no record of")
+	}
+
+	// Refusing must not be a side-effect-free lie: the versions it declined to
+	// reap are still recorded.
+	ts, err := mgr.state.GetToolState("mytool")
+	if err != nil || ts == nil {
+		t.Fatalf("GetToolState() = %v, %v", ts, err)
+	}
+	if _, ok := ts.Versions["2.0.0"]; !ok {
+		t.Error("a refused reap must leave the version recorded")
 	}
 }

--- a/internal/updates/apply.go
+++ b/internal/updates/apply.go
@@ -150,7 +150,12 @@ func MaybeAutoApply(cfg *config.Config, userCfg *userconfig.Config, projectCfg *
 			// store reconciliation handles notices; tool directories are
 			// a separate concern).
 			retention := userCfg.UpdatesVersionRetention()
-			_ = GarbageCollectVersions(mgr, cfg.ToolsDir, entry.Tool, entry.LatestWithinPin, previousVersion, retention, time.Now())
+			if gcErr := GarbageCollectVersions(mgr, cfg.ToolsDir, entry.Tool, entry.LatestWithinPin, previousVersion, retention, time.Now()); gcErr != nil {
+				// Reclamation failing is not a reason to fail the update that
+				// just succeeded, but it should not vanish either: this fires
+				// when state cannot be read, which stops reclamation entirely.
+				log.Default().Debug("auto-apply: garbage collect", "tool", entry.Tool, "error", gcErr)
+			}
 		}
 
 		if applyErr != nil {

--- a/internal/updates/gc.go
+++ b/internal/updates/gc.go
@@ -3,65 +3,83 @@ package updates
 import (
 	"fmt"
 	"os"
-	"strings"
+	"path/filepath"
 	"time"
 
+	"github.com/tsukumogami/tsuku/internal/install"
 	"github.com/tsukumogami/tsuku/internal/log"
 )
 
-// VersionReaper is the slice of install.Manager that garbage collection needs.
-// Removing a version directory is only half the job: the version's shell.d
-// fragments live outside the tool directory, and its VersionState keeps
-// claiming them, which both leaks the files and holds open the
-// "still referenced by another version" skip for a version that no longer
-// exists. Pass nil to skip state reconciliation.
-type VersionReaper interface {
+// VersionStore is the slice of install.Manager that garbage collection needs.
+//
+// It is what makes reclamation safe. Directory names under $TSUKU_HOME/tools
+// look like "<tool>-<version>", but they cannot be taken apart again: tool
+// names collide, and the registry ships 59 pairs where one name prefixes
+// another. Strip "git-" from "git-lfs-3.5.0" and the remainder, "lfs-3.5.0",
+// is a perfectly good version string, so no lexical rule separates another
+// tool's installation from one of this tool's versions. Asking state which
+// versions a tool has, and rebuilding the directory name from that pair, keeps
+// the name out of the delete decision entirely.
+//
+// Removing the directory is also only half the job. The version's shell.d
+// fragments live outside it, and its VersionState keeps claiming them, which
+// both leaks the files and holds open the "still referenced by another version"
+// skip for a version that no longer exists.
+type VersionStore interface {
+	// InstalledVersions returns the versions state records for a tool. A tool
+	// state has no record of yields no versions and no error.
+	InstalledVersions(tool string) ([]string, error)
+	// ReapVersion runs a version's cleanup actions and drops its VersionState.
+	// It refuses a version state does not record.
 	ReapVersion(tool, version string) error
 }
 
 // GarbageCollectVersions removes old version directories for a tool that are
 // past the retention period. It protects the active version and the previous
 // version (rollback target). The now parameter enables clock injection for tests.
-func GarbageCollectVersions(reaper VersionReaper, toolsDir, toolName, activeVersion, previousVersion string, retention time.Duration, now time.Time) error {
-	entries, err := os.ReadDir(toolsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return fmt.Errorf("read tools directory: %w", err)
+//
+// Only versions the store records are candidates. A directory state has no
+// record of stays put: deleting it would mean deleting on the strength of a
+// filesystem name, which is how this function used to remove other people's
+// tools. Reclaiming those needs a pass that can prove a directory belongs to no
+// installed tool at all, which is a different job with a different safety
+// argument.
+func GarbageCollectVersions(store VersionStore, toolsDir, toolName, activeVersion, previousVersion string, retention time.Duration, now time.Time) error {
+	if store == nil {
+		return fmt.Errorf("garbage collection needs a version store to tell it what it may reclaim")
 	}
 
-	prefix := toolName + "-"
-	activeDir := toolName + "-" + activeVersion
-	previousDir := toolName + "-" + previousVersion
+	versions, err := store.InstalledVersions(toolName)
+	if err != nil {
+		return fmt.Errorf("read installed versions for %s: %w", toolName, err)
+	}
 
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		name := entry.Name()
-
-		// Only consider directories matching this tool's naming pattern
-		if !strings.HasPrefix(name, prefix) {
-			continue
-		}
-
+	for _, version := range versions {
 		// Never delete the active version
-		if name == activeDir {
+		if version == activeVersion {
 			continue
 		}
 
 		// Never delete the rollback target
-		if previousVersion != "" && name == previousDir {
+		if previousVersion != "" && version == previousVersion {
+			continue
+		}
+
+		// The version now arrives from state rather than from a directory
+		// listing, so it reaches the path join as data. Anything that could
+		// steer os.RemoveAll out of the tools directory does not get there.
+		if err := install.ValidateVersionString(version); err != nil {
+			log.Default().Debug("gc: skip unusable version", "tool", toolName, "version", version, "error", err)
+			continue
+		}
+
+		dirPath := filepath.Join(toolsDir, toolName+"-"+version)
+		info, err := os.Stat(dirPath)
+		if err != nil || !info.IsDir() {
 			continue
 		}
 
 		// Check age against retention period
-		info, err := entry.Info()
-		if err != nil {
-			continue
-		}
-
 		age := now.Sub(info.ModTime())
 		if age < retention {
 			continue
@@ -69,21 +87,17 @@ func GarbageCollectVersions(reaper VersionReaper, toolsDir, toolName, activeVers
 
 		// Reconcile state before the directory goes, so a failure leaves the
 		// version installed rather than recorded but absent.
-		version := strings.TrimPrefix(name, prefix)
-		if reaper != nil {
-			if err := reaper.ReapVersion(toolName, version); err != nil {
-				log.Default().Debug("gc: reap version state", "tool", toolName, "version", version, "error", err)
-				continue
-			}
+		if err := store.ReapVersion(toolName, version); err != nil {
+			log.Default().Debug("gc: reap version state", "tool", toolName, "version", version, "error", err)
+			continue
 		}
 
 		// Remove the old version directory
-		dirPath := toolsDir + "/" + name
 		if err := os.RemoveAll(dirPath); err != nil {
-			log.Default().Debug("gc: remove old version", "tool", toolName, "dir", name, "error", err)
+			log.Default().Debug("gc: remove old version", "tool", toolName, "version", version, "error", err)
 			continue
 		}
-		log.Default().Debug("gc: removed old version", "tool", toolName, "dir", name, "age", age)
+		log.Default().Debug("gc: removed old version", "tool", toolName, "version", version, "age", age)
 	}
 
 	return nil

--- a/internal/updates/gc.go
+++ b/internal/updates/gc.go
@@ -73,8 +73,10 @@ func GarbageCollectVersions(store VersionStore, toolsDir, toolName, activeVersio
 			continue
 		}
 
+		// Lstat, not Stat: a symlink here is not a version directory this
+		// function installed, and its target's mtime is not this version's age.
 		dirPath := filepath.Join(toolsDir, toolName+"-"+version)
-		info, err := os.Stat(dirPath)
+		info, err := os.Lstat(dirPath)
 		if err != nil || !info.IsDir() {
 			continue
 		}

--- a/internal/updates/gc.go
+++ b/internal/updates/gc.go
@@ -14,12 +14,13 @@ import (
 //
 // It is what makes reclamation safe. Directory names under $TSUKU_HOME/tools
 // look like "<tool>-<version>", but they cannot be taken apart again: tool
-// names collide, and the registry ships 59 pairs where one name prefixes
-// another. Strip "git-" from "git-lfs-3.5.0" and the remainder, "lfs-3.5.0",
-// is a perfectly good version string, so no lexical rule separates another
-// tool's installation from one of this tool's versions. Asking state which
-// versions a tool has, and rebuilding the directory name from that pair, keeps
-// the name out of the delete decision entirely.
+// names collide, and the registry ships dozens of pairs where one name prefixes
+// another -- git/git-lfs, docker/docker-compose, helm/helm-docs. Strip "git-"
+// from "git-lfs-3.5.0" and the remainder, "lfs-3.5.0", is a perfectly good
+// version string, so no lexical rule separates another tool's installation from
+// one of this tool's versions. Asking state which versions a tool has, and
+// rebuilding the directory name from that pair, keeps the name out of the
+// delete decision entirely.
 //
 // Removing the directory is also only half the job. The version's shell.d
 // fragments live outside it, and its VersionState keeps claiming them, which
@@ -27,10 +28,18 @@ import (
 // skip for a version that no longer exists.
 type VersionStore interface {
 	// InstalledVersions returns the versions state records for a tool. A tool
-	// state has no record of yields no versions and no error.
+	// that state has no record of yields no versions and no error.
 	InstalledVersions(tool string) ([]string, error)
 	// ReapVersion runs a version's cleanup actions and drops its VersionState.
-	// It refuses a version state does not record.
+	//
+	// It is called while the version's directory still exists, and it must be:
+	// reconciling first means a failure leaves the version installed rather
+	// than recorded but absent.
+	//
+	// It refuses a version that state does not record, and it refuses the
+	// active version. Both refusals are load-bearing -- they are the second
+	// lock on a door this function is the first lock on -- so an
+	// implementation that answers differently is not a drop-in.
 	ReapVersion(tool, version string) error
 }
 
@@ -38,7 +47,7 @@ type VersionStore interface {
 // past the retention period. It protects the active version and the previous
 // version (rollback target). The now parameter enables clock injection for tests.
 //
-// Only versions the store records are candidates. A directory state has no
+// Only versions the store records are candidates. A directory that state has no
 // record of stays put: deleting it would mean deleting on the strength of a
 // filesystem name, which is how this function used to remove other people's
 // tools. Reclaiming those needs a pass that can prove a directory belongs to no
@@ -68,16 +77,30 @@ func GarbageCollectVersions(store VersionStore, toolsDir, toolName, activeVersio
 		// The version now arrives from state rather than from a directory
 		// listing, so it reaches the path join as data. Anything that could
 		// steer os.RemoveAll out of the tools directory does not get there.
+		//
+		// install's validator, not version's. They disagree, and the rule that
+		// has to apply here is the one that let the directory be created:
+		// version.ValidateVersionString has a stricter charset, so using it
+		// would silently stop reclaiming versions tsuku itself installed.
 		if err := install.ValidateVersionString(version); err != nil {
 			log.Default().Debug("gc: skip unusable version", "tool", toolName, "version", version, "error", err)
 			continue
 		}
 
+		// Same layout as config.ToolDir, which is the canonical builder --
+		// change one and this has to change with it. This function is handed a
+		// tools directory rather than a *config.Config, so it cannot call it.
+		dirPath := filepath.Join(toolsDir, toolName+"-"+version)
+
 		// Lstat, not Stat: a symlink here is not a version directory this
 		// function installed, and its target's mtime is not this version's age.
-		dirPath := filepath.Join(toolsDir, toolName+"-"+version)
+		//
+		// A version state records with no directory on disk is left recorded.
+		// Reconciling that is a repair, and a transient stat failure must not
+		// be able to trigger one.
 		info, err := os.Lstat(dirPath)
 		if err != nil || !info.IsDir() {
+			log.Default().Debug("gc: skip, not a version directory", "tool", toolName, "version", version, "path", dirPath, "error", err)
 			continue
 		}
 

--- a/internal/updates/gc_manager_test.go
+++ b/internal/updates/gc_manager_test.go
@@ -1,0 +1,114 @@
+package updates
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/tsukumogami/tsuku/internal/config"
+	"github.com/tsukumogami/tsuku/internal/install"
+	"github.com/tsukumogami/tsuku/internal/testutil"
+)
+
+// installFixture writes a tool's version directories and the state entry that
+// claims them, the way an install would leave things.
+func installFixture(t *testing.T, mgr *install.Manager, cfg *config.Config, name, active string, versions ...string) {
+	t.Helper()
+
+	recorded := map[string]install.VersionState{}
+	for _, v := range versions {
+		if err := os.MkdirAll(filepath.Join(cfg.ToolDir(name, v), "bin"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		recorded[v] = install.VersionState{
+			Binaries:    []string{filepath.Join("bin", name)},
+			InstalledAt: time.Now(),
+		}
+	}
+
+	if err := mgr.GetState().UpdateTool(name, func(ts *install.ToolState) {
+		ts.ActiveVersion = active
+		ts.Versions = recorded
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// The end-to-end shape of the collision, driven through the real
+// install.Manager rather than a stand-in: git updates, its reclamation runs
+// unattended, and git-lfs must still be installed afterwards -- on disk and in
+// state, since a surviving state entry with a deleted directory is the failure
+// users saw as "command not found" for a tool tsuku list still showed.
+func TestGarbageCollectVersions_RealManagerSparesPrefixSharingTool(t *testing.T) {
+	cfg, cleanup := testutil.NewTestConfig(t)
+	defer cleanup()
+	mgr := install.New(cfg)
+
+	installFixture(t, mgr, cfg, "git", "2.47.0", "2.46.0", "2.47.0")
+	installFixture(t, mgr, cfg, "git-lfs", "3.5.0", "3.5.0")
+
+	lfsDir := cfg.ToolDir("git-lfs", "3.5.0")
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(lfsDir, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := GarbageCollectVersions(mgr, cfg.ToolsDir, "git", "2.47.0", "2.46.0", 7*24*time.Hour, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(lfsDir); err != nil {
+		t.Errorf("reclaiming git deleted %s, an installation of a different tool", lfsDir)
+	}
+
+	installed, err := mgr.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, tool := range installed {
+		if tool.Name == "git-lfs" && tool.Version == "3.5.0" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("git-lfs 3.5.0 should still be installed after git's reclamation")
+	}
+}
+
+// The same fixture with the roles reversed: git-lfs still reclaims its own
+// aged-out version, and git is untouched.
+func TestGarbageCollectVersions_RealManagerReclaimsOwnOldVersion(t *testing.T) {
+	cfg, cleanup := testutil.NewTestConfig(t)
+	defer cleanup()
+	mgr := install.New(cfg)
+
+	installFixture(t, mgr, cfg, "git", "2.47.0", "2.47.0")
+	installFixture(t, mgr, cfg, "git-lfs", "3.5.0", "3.4.0", "3.5.0")
+
+	oldLFS := cfg.ToolDir("git-lfs", "3.4.0")
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(oldLFS, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := GarbageCollectVersions(mgr, cfg.ToolsDir, "git-lfs", "3.5.0", "", 7*24*time.Hour, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(oldLFS); !os.IsNotExist(err) {
+		t.Error("git-lfs 3.4.0 is past retention and should have been reclaimed")
+	}
+	if _, err := os.Stat(cfg.ToolDir("git", "2.47.0")); err != nil {
+		t.Error("reclaiming git-lfs must not touch git")
+	}
+
+	ts, err := mgr.GetState().GetToolState("git-lfs")
+	if err != nil || ts == nil {
+		t.Fatalf("GetToolState() = %v, %v", ts, err)
+	}
+	if _, still := ts.Versions["3.4.0"]; still {
+		t.Error("the reclaimed version should be gone from state, not left dangling")
+	}
+}

--- a/internal/updates/gc_manager_test.go
+++ b/internal/updates/gc_manager_test.go
@@ -37,9 +37,10 @@ func installFixture(t *testing.T, mgr *install.Manager, cfg *config.Config, name
 
 // The end-to-end shape of the collision, driven through the real
 // install.Manager rather than a stand-in: git updates, its reclamation runs
-// unattended, and git-lfs must still be installed afterwards -- on disk and in
-// state, since a surviving state entry with a deleted directory is the failure
-// users saw as "command not found" for a tool tsuku list still showed.
+// unattended, and git-lfs must still be installed afterwards -- on disk and as
+// something Manager.List reports. Both halves matter. List skips a version
+// whose directory is missing, so a deleted directory takes the tool out of
+// tsuku list entirely while its bin/ symlinks stay behind pointing at nothing.
 func TestGarbageCollectVersions_RealManagerSparesPrefixSharingTool(t *testing.T) {
 	cfg, cleanup := testutil.NewTestConfig(t)
 	defer cleanup()

--- a/internal/updates/gc_test.go
+++ b/internal/updates/gc_test.go
@@ -276,6 +276,34 @@ func TestGarbageCollectVersions_RefusesVersionThatEscapesToolsDir(t *testing.T) 
 	}
 }
 
+// A symlink where a version directory should be is not one, and the thing it
+// points at has its own mtime and its own owner. Leave it alone.
+func TestGarbageCollectVersions_DoesNotFollowASymlinkedVersionDir(t *testing.T) {
+	root := t.TempDir()
+	toolsDir := filepath.Join(root, "tools")
+	mkdir(t, toolsDir)
+	target := filepath.Join(root, "elsewhere")
+	mkdir(t, target)
+	setMtime(t, target, time.Now().Add(-30*24*time.Hour))
+
+	link := filepath.Join(toolsDir, "node-18.0.0")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+
+	store := storeFor("node", "18.0.0", "20.1.0")
+	if err := GarbageCollectVersions(store, toolsDir, "node", "20.1.0", "", 7*24*time.Hour, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Lstat(link); err != nil {
+		t.Error("a symlink is not a version directory and should not be reclaimed")
+	}
+	if len(store.reaped) != 0 {
+		t.Errorf("nothing should have been reaped, got %v", store.reaped)
+	}
+}
+
 func TestGarbageCollectVersions_RequiresAStore(t *testing.T) {
 	dir := t.TempDir()
 	mkdir(t, filepath.Join(dir, "node-18.0.0"))

--- a/internal/updates/gc_test.go
+++ b/internal/updates/gc_test.go
@@ -8,6 +8,35 @@ import (
 	"time"
 )
 
+// fakeVersionStore stands in for install.Manager: it answers what state records
+// for each tool and captures the reap calls garbage collection makes.
+type fakeVersionStore struct {
+	versions map[string][]string
+	listErr  error
+	reapErr  error
+	reaped   []string
+}
+
+func (f *fakeVersionStore) InstalledVersions(tool string) ([]string, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.versions[tool], nil
+}
+
+func (f *fakeVersionStore) ReapVersion(tool, version string) error {
+	if f.reapErr != nil {
+		return f.reapErr
+	}
+	f.reaped = append(f.reaped, tool+"@"+version)
+	return nil
+}
+
+// storeFor builds a store that records exactly the versions given for one tool.
+func storeFor(tool string, versions ...string) *fakeVersionStore {
+	return &fakeVersionStore{versions: map[string][]string{tool: versions}}
+}
+
 func TestGarbageCollectVersions_RemovesOldVersions(t *testing.T) {
 	dir := t.TempDir()
 	mkdir(t, filepath.Join(dir, "node-18.0.0"))
@@ -16,7 +45,8 @@ func TestGarbageCollectVersions_RemovesOldVersions(t *testing.T) {
 
 	setMtime(t, filepath.Join(dir, "node-18.0.0"), time.Now().Add(-10*24*time.Hour))
 
-	if err := GarbageCollectVersions(nil, dir, "node", "20.1.0", "20.0.0", 7*24*time.Hour, time.Now()); err != nil {
+	store := storeFor("node", "18.0.0", "20.0.0", "20.1.0")
+	if err := GarbageCollectVersions(store, dir, "node", "20.1.0", "20.0.0", 7*24*time.Hour, time.Now()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -36,7 +66,8 @@ func TestGarbageCollectVersions_ProtectsActive(t *testing.T) {
 	mkdir(t, filepath.Join(dir, "rg-14.0.0"))
 	setMtime(t, filepath.Join(dir, "rg-14.0.0"), time.Now().Add(-30*24*time.Hour))
 
-	if err := GarbageCollectVersions(nil, dir, "rg", "14.0.0", "", 7*24*time.Hour, time.Now()); err != nil {
+	store := storeFor("rg", "14.0.0")
+	if err := GarbageCollectVersions(store, dir, "rg", "14.0.0", "", 7*24*time.Hour, time.Now()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -51,7 +82,8 @@ func TestGarbageCollectVersions_ProtectsPrevious(t *testing.T) {
 	mkdir(t, filepath.Join(dir, "rg-14.0.0"))
 	setMtime(t, filepath.Join(dir, "rg-13.0.0"), time.Now().Add(-30*24*time.Hour))
 
-	if err := GarbageCollectVersions(nil, dir, "rg", "14.0.0", "13.0.0", 7*24*time.Hour, time.Now()); err != nil {
+	store := storeFor("rg", "13.0.0", "14.0.0")
+	if err := GarbageCollectVersions(store, dir, "rg", "14.0.0", "13.0.0", 7*24*time.Hour, time.Now()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -65,7 +97,8 @@ func TestGarbageCollectVersions_RetentionBoundary(t *testing.T) {
 	mkdir(t, filepath.Join(dir, "jq-1.6"))
 	setMtime(t, filepath.Join(dir, "jq-1.6"), time.Now().Add(-6*24*time.Hour))
 
-	if err := GarbageCollectVersions(nil, dir, "jq", "1.7", "", 7*24*time.Hour, time.Now()); err != nil {
+	store := storeFor("jq", "1.6", "1.7")
+	if err := GarbageCollectVersions(store, dir, "jq", "1.7", "", 7*24*time.Hour, time.Now()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -76,7 +109,8 @@ func TestGarbageCollectVersions_RetentionBoundary(t *testing.T) {
 
 func TestGarbageCollectVersions_EmptyDir(t *testing.T) {
 	dir := t.TempDir()
-	if err := GarbageCollectVersions(nil, dir, "node", "20.0.0", "", 7*24*time.Hour, time.Now()); err != nil {
+	store := storeFor("node", "20.0.0")
+	if err := GarbageCollectVersions(store, dir, "node", "20.0.0", "", 7*24*time.Hour, time.Now()); err != nil {
 		t.Fatal("should not error on empty directory")
 	}
 }
@@ -86,7 +120,11 @@ func TestGarbageCollectVersions_IgnoresOtherTools(t *testing.T) {
 	mkdir(t, filepath.Join(dir, "ripgrep-14.0.0"))
 	setMtime(t, filepath.Join(dir, "ripgrep-14.0.0"), time.Now().Add(-30*24*time.Hour))
 
-	if err := GarbageCollectVersions(nil, dir, "node", "20.0.0", "", 7*24*time.Hour, time.Now()); err != nil {
+	store := &fakeVersionStore{versions: map[string][]string{
+		"node":    {"20.0.0"},
+		"ripgrep": {"14.0.0"},
+	}}
+	if err := GarbageCollectVersions(store, dir, "node", "20.0.0", "", 7*24*time.Hour, time.Now()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -95,19 +133,84 @@ func TestGarbageCollectVersions_IgnoresOtherTools(t *testing.T) {
 	}
 }
 
-// recordingReaper captures the (tool, version) pairs GC asks it to reap and can
-// be told to fail, so the "directory survives a failed reap" path is covered.
-type recordingReaper struct {
-	reaped []string
-	err    error
+// The registry ships 59 name pairs where one tool's name prefixes another's --
+// git/git-lfs, docker/docker-compose, helm/helm-docs. Reclaiming the shorter
+// name used to read "git-lfs-3.5.0" as version "lfs-3.5.0" of git and delete a
+// working installation of a different tool.
+func TestGarbageCollectVersions_LeavesToolWhoseNameSharesAPrefix(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, "git-2.46.0"))
+	mkdir(t, filepath.Join(dir, "git-2.47.0"))
+	mkdir(t, filepath.Join(dir, "git-lfs-3.5.0"))
+	// git-lfs was installed and then left alone for a month, so its directory
+	// is well past retention. It is still a different tool.
+	setMtime(t, filepath.Join(dir, "git-lfs-3.5.0"), time.Now().Add(-30*24*time.Hour))
+
+	store := &fakeVersionStore{versions: map[string][]string{
+		"git":     {"2.46.0", "2.47.0"},
+		"git-lfs": {"3.5.0"},
+	}}
+
+	if err := GarbageCollectVersions(store, dir, "git", "2.47.0", "2.46.0", 7*24*time.Hour, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "git-lfs-3.5.0")); err != nil {
+		t.Error("reclaiming git deleted git-lfs-3.5.0, which belongs to another tool")
+	}
+	if len(store.reaped) != 0 {
+		t.Errorf("reclaiming git reaped state that is not its own: %v", store.reaped)
+	}
 }
 
-func (r *recordingReaper) ReapVersion(tool, version string) error {
-	if r.err != nil {
-		return r.err
+// The mirror image: the colliding tool reclaiming its own old version must
+// still work, so the fix is not "never delete anything near a collision".
+func TestGarbageCollectVersions_ReclaimsOwnVersionDespiteCollidingName(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, "git-2.47.0"))
+	mkdir(t, filepath.Join(dir, "git-lfs-3.4.0"))
+	mkdir(t, filepath.Join(dir, "git-lfs-3.5.0"))
+	setMtime(t, filepath.Join(dir, "git-lfs-3.4.0"), time.Now().Add(-30*24*time.Hour))
+
+	store := &fakeVersionStore{versions: map[string][]string{
+		"git":     {"2.47.0"},
+		"git-lfs": {"3.4.0", "3.5.0"},
+	}}
+
+	if err := GarbageCollectVersions(store, dir, "git-lfs", "3.5.0", "", 7*24*time.Hour, time.Now()); err != nil {
+		t.Fatal(err)
 	}
-	r.reaped = append(r.reaped, tool+"@"+version)
-	return nil
+
+	if _, err := os.Stat(filepath.Join(dir, "git-lfs-3.4.0")); !os.IsNotExist(err) {
+		t.Error("git-lfs should still reclaim its own aged-out version")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "git-2.47.0")); err != nil {
+		t.Error("reclaiming git-lfs must not touch git")
+	}
+	if len(store.reaped) != 1 || store.reaped[0] != "git-lfs@3.4.0" {
+		t.Errorf("expected git-lfs@3.4.0 to be reaped, got %v", store.reaped)
+	}
+}
+
+// A directory nothing in state claims is left alone. Reclaiming it would mean
+// deleting on the strength of a filesystem name, which is the mistake this
+// function used to make.
+func TestGarbageCollectVersions_KeepsDirectoryStateDoesNotClaim(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, "node-17.0.0"))
+	setMtime(t, filepath.Join(dir, "node-17.0.0"), time.Now().Add(-30*24*time.Hour))
+
+	store := storeFor("node", "20.1.0")
+	if err := GarbageCollectVersions(store, dir, "node", "20.1.0", "", 7*24*time.Hour, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "node-17.0.0")); err != nil {
+		t.Error("a directory state has no record of should be left where it is")
+	}
+	if len(store.reaped) != 0 {
+		t.Errorf("nothing should have been reaped, got %v", store.reaped)
+	}
 }
 
 func TestGarbageCollectVersions_ReapsStateForRemovedVersions(t *testing.T) {
@@ -116,13 +219,13 @@ func TestGarbageCollectVersions_ReapsStateForRemovedVersions(t *testing.T) {
 	mkdir(t, filepath.Join(dir, "node-20.1.0"))
 	setMtime(t, filepath.Join(dir, "node-18.0.0"), time.Now().Add(-10*24*time.Hour))
 
-	reaper := &recordingReaper{}
-	if err := GarbageCollectVersions(reaper, dir, "node", "20.1.0", "", 7*24*time.Hour, time.Now()); err != nil {
+	store := storeFor("node", "18.0.0", "20.1.0")
+	if err := GarbageCollectVersions(store, dir, "node", "20.1.0", "", 7*24*time.Hour, time.Now()); err != nil {
 		t.Fatal(err)
 	}
 
-	if len(reaper.reaped) != 1 || reaper.reaped[0] != "node@18.0.0" {
-		t.Errorf("expected the GC'd version's state to be reaped, got %v", reaper.reaped)
+	if len(store.reaped) != 1 || store.reaped[0] != "node@18.0.0" {
+		t.Errorf("expected the GC'd version's state to be reaped, got %v", store.reaped)
 	}
 	if _, err := os.Stat(filepath.Join(dir, "node-18.0.0")); !os.IsNotExist(err) {
 		t.Error("expected node-18.0.0 to be removed")
@@ -134,8 +237,9 @@ func TestGarbageCollectVersions_KeepsDirectoryWhenReapFails(t *testing.T) {
 	mkdir(t, filepath.Join(dir, "node-18.0.0"))
 	setMtime(t, filepath.Join(dir, "node-18.0.0"), time.Now().Add(-10*24*time.Hour))
 
-	reaper := &recordingReaper{err: errReapFailed}
-	if err := GarbageCollectVersions(reaper, dir, "node", "20.1.0", "", 7*24*time.Hour, time.Now()); err != nil {
+	store := storeFor("node", "18.0.0", "20.1.0")
+	store.reapErr = errReapFailed
+	if err := GarbageCollectVersions(store, dir, "node", "20.1.0", "", 7*24*time.Hour, time.Now()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -146,7 +250,65 @@ func TestGarbageCollectVersions_KeepsDirectoryWhenReapFails(t *testing.T) {
 	}
 }
 
-var errReapFailed = errors.New("reap failed")
+// A version that could steer the path join out of the tools directory is
+// dropped before anything is removed. state.json is written by tsuku, but it is
+// an editable file on disk and the version now reaches os.RemoveAll from it.
+func TestGarbageCollectVersions_RefusesVersionThatEscapesToolsDir(t *testing.T) {
+	root := t.TempDir()
+	toolsDir := filepath.Join(root, "tools")
+	mkdir(t, toolsDir)
+	victim := filepath.Join(root, "victim")
+	mkdir(t, victim)
+	setMtime(t, victim, time.Now().Add(-30*24*time.Hour))
+
+	// Joined onto the tools directory, "node-1.0.0/../../victim" resolves to
+	// the sibling directory outside it.
+	store := storeFor("node", "1.0.0/../../victim", "20.1.0")
+	if err := GarbageCollectVersions(store, toolsDir, "node", "20.1.0", "", 7*24*time.Hour, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(victim); err != nil {
+		t.Error("a version containing a path separator must not reach os.RemoveAll")
+	}
+	if len(store.reaped) != 0 {
+		t.Errorf("nothing should have been reaped, got %v", store.reaped)
+	}
+}
+
+func TestGarbageCollectVersions_RequiresAStore(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, "node-18.0.0"))
+	setMtime(t, filepath.Join(dir, "node-18.0.0"), time.Now().Add(-30*24*time.Hour))
+
+	// Without state there is no way to tell one tool's directory from
+	// another's, so this must refuse rather than fall back to name matching.
+	if err := GarbageCollectVersions(nil, dir, "node", "20.1.0", "", 7*24*time.Hour, time.Now()); err == nil {
+		t.Error("expected an error when no version store is supplied")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "node-18.0.0")); err != nil {
+		t.Error("nothing should be removed when there is no store to authorize it")
+	}
+}
+
+func TestGarbageCollectVersions_ReturnsStateReadFailure(t *testing.T) {
+	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, "node-18.0.0"))
+	setMtime(t, filepath.Join(dir, "node-18.0.0"), time.Now().Add(-30*24*time.Hour))
+
+	store := &fakeVersionStore{listErr: errStateUnreadable}
+	if err := GarbageCollectVersions(store, dir, "node", "20.1.0", "", 7*24*time.Hour, time.Now()); err == nil {
+		t.Error("expected the state read failure to surface")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "node-18.0.0")); err != nil {
+		t.Error("nothing should be removed when state cannot be read")
+	}
+}
+
+var (
+	errReapFailed      = errors.New("reap failed")
+	errStateUnreadable = errors.New("state unreadable")
+)
 
 func mkdir(t *testing.T, path string) {
 	t.Helper()

--- a/internal/updates/gc_test.go
+++ b/internal/updates/gc_test.go
@@ -93,50 +93,90 @@ func TestGarbageCollectVersions_ProtectsPrevious(t *testing.T) {
 }
 
 func TestGarbageCollectVersions_RetentionBoundary(t *testing.T) {
-	dir := t.TempDir()
-	mkdir(t, filepath.Join(dir, "jq-1.6"))
-	setMtime(t, filepath.Join(dir, "jq-1.6"), time.Now().Add(-6*24*time.Hour))
-
-	store := storeFor("jq", "1.6", "1.7")
-	if err := GarbageCollectVersions(store, dir, "jq", "1.7", "", 7*24*time.Hour, time.Now()); err != nil {
-		t.Fatal(err)
+	retention := 7 * 24 * time.Hour
+	tests := []struct {
+		name    string
+		age     time.Duration
+		removed bool
+	}{
+		{"one day inside retention", retention - 24*time.Hour, false},
+		{"a second inside retention", retention - time.Second, false},
+		{"exactly at retention", retention, true},
+		{"a second past retention", retention + time.Second, true},
 	}
 
-	if _, err := os.Stat(filepath.Join(dir, "jq-1.6")); err != nil {
-		t.Error("version within retention period should not be removed")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			old := filepath.Join(dir, "jq-1.6")
+			mkdir(t, old)
+			now := time.Now()
+			setMtime(t, old, now.Add(-tt.age))
+
+			store := storeFor("jq", "1.6", "1.7")
+			if err := GarbageCollectVersions(store, dir, "jq", "1.7", "", retention, now); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := os.Stat(old)
+			if tt.removed && !os.IsNotExist(err) {
+				t.Errorf("jq-1.6 aged %s against a %s retention should have been removed", tt.age, retention)
+			}
+			if !tt.removed && err != nil {
+				t.Errorf("jq-1.6 aged %s against a %s retention should have been kept", tt.age, retention)
+			}
+		})
 	}
 }
 
-func TestGarbageCollectVersions_EmptyDir(t *testing.T) {
+// State can outlive the directory it names -- someone deletes it by hand. GC
+// has nothing to reclaim then, and must not treat the missing directory as an
+// error or reconcile state on the strength of a failed stat.
+func TestGarbageCollectVersions_VersionWithNoDirectoryOnDisk(t *testing.T) {
 	dir := t.TempDir()
-	store := storeFor("node", "20.0.0")
+	store := storeFor("node", "18.0.0", "20.0.0")
+
 	if err := GarbageCollectVersions(store, dir, "node", "20.0.0", "", 7*24*time.Hour, time.Now()); err != nil {
-		t.Fatal("should not error on empty directory")
+		t.Fatalf("a recorded version with no directory should not be an error: %v", err)
+	}
+	if len(store.reaped) != 0 {
+		t.Errorf("nothing should have been reaped, got %v", store.reaped)
 	}
 }
 
 func TestGarbageCollectVersions_IgnoresOtherTools(t *testing.T) {
 	dir := t.TempDir()
+	mkdir(t, filepath.Join(dir, "node-18.0.0"))
+	mkdir(t, filepath.Join(dir, "node-20.0.0"))
 	mkdir(t, filepath.Join(dir, "ripgrep-14.0.0"))
+	// Both aged out, so GC has real work to do for node while ripgrep sits in
+	// the same directory being equally old and none of its business.
+	setMtime(t, filepath.Join(dir, "node-18.0.0"), time.Now().Add(-30*24*time.Hour))
 	setMtime(t, filepath.Join(dir, "ripgrep-14.0.0"), time.Now().Add(-30*24*time.Hour))
 
 	store := &fakeVersionStore{versions: map[string][]string{
-		"node":    {"20.0.0"},
+		"node":    {"18.0.0", "20.0.0"},
 		"ripgrep": {"14.0.0"},
 	}}
 	if err := GarbageCollectVersions(store, dir, "node", "20.0.0", "", 7*24*time.Hour, time.Now()); err != nil {
 		t.Fatal(err)
 	}
 
+	if _, err := os.Stat(filepath.Join(dir, "node-18.0.0")); !os.IsNotExist(err) {
+		t.Error("node-18.0.0 is node's own aged-out version and should have been removed")
+	}
 	if _, err := os.Stat(filepath.Join(dir, "ripgrep-14.0.0")); err != nil {
 		t.Error("GC should not touch other tools' directories")
 	}
+	if len(store.reaped) != 1 || store.reaped[0] != "node@18.0.0" {
+		t.Errorf("expected only node@18.0.0 to be reaped, got %v", store.reaped)
+	}
 }
 
-// The registry ships 59 name pairs where one tool's name prefixes another's --
-// git/git-lfs, docker/docker-compose, helm/helm-docs. Reclaiming the shorter
-// name used to read "git-lfs-3.5.0" as version "lfs-3.5.0" of git and delete a
-// working installation of a different tool.
+// The registry ships name pairs where one tool's name prefixes another's --
+// git/git-lfs, docker/docker-compose, helm/helm-docs, 59 of them when this was
+// written. Reclaiming the shorter name used to read "git-lfs-3.5.0" as version
+// "lfs-3.5.0" of git and delete a working installation of a different tool.
 func TestGarbageCollectVersions_LeavesToolWhoseNameSharesAPrefix(t *testing.T) {
 	dir := t.TempDir()
 	mkdir(t, filepath.Join(dir, "git-2.46.0"))
@@ -192,9 +232,9 @@ func TestGarbageCollectVersions_ReclaimsOwnVersionDespiteCollidingName(t *testin
 	}
 }
 
-// A directory nothing in state claims is left alone. Reclaiming it would mean
-// deleting on the strength of a filesystem name, which is the mistake this
-// function used to make.
+// A directory that nothing in state claims is left alone. Reclaiming it would
+// mean deleting on the strength of a filesystem name, which is the mistake
+// this function used to make.
 func TestGarbageCollectVersions_KeepsDirectoryStateDoesNotClaim(t *testing.T) {
 	dir := t.TempDir()
 	mkdir(t, filepath.Join(dir, "node-17.0.0"))
@@ -206,7 +246,7 @@ func TestGarbageCollectVersions_KeepsDirectoryStateDoesNotClaim(t *testing.T) {
 	}
 
 	if _, err := os.Stat(filepath.Join(dir, "node-17.0.0")); err != nil {
-		t.Error("a directory state has no record of should be left where it is")
+		t.Error("a directory that state has no record of should be left where it is")
 	}
 	if len(store.reaped) != 0 {
 		t.Errorf("nothing should have been reaped, got %v", store.reaped)

--- a/plugins/tsuku-user/skills/tsuku-user/SKILL.md
+++ b/plugins/tsuku-user/skills/tsuku-user/SKILL.md
@@ -212,8 +212,16 @@ By default, tsuku checks for updates in the background and applies them within y
 1. On most commands, tsuku spawns a background check for newer versions.
 2. If `updates.auto_apply` is enabled, updates within pin boundaries are installed automatically.
 3. After the command finishes, a summary of any updates is displayed.
+4. Superseded versions of the updated tool are reclaimed once they're older than
+   `updates.version_retention`. The active version and the rollback target are always
+   kept.
 
 Exact-pinned tools (`go = "1.23.4"`) are never auto-updated.
+
+Reclamation only touches versions tsuku installed and still records in its state. A
+directory under `$TSUKU_HOME/tools` that tsuku has no record of -- left behind by an
+interrupted install, or put there by hand -- is left alone however old it is. Remove
+those yourself if you want the space back.
 
 ### Controlling Updates
 
@@ -266,7 +274,8 @@ tsuku config set telemetry false
 - `auto_apply` -- auto-install updates within pin boundaries (default: true)
 - `check_interval` -- minimum time between checks, e.g. `"12h"` (default: `"24h"`)
 - `self_update` -- check for tsuku self-updates (default: true)
-- `version_retention` -- how long to keep old versions, e.g. `"168h"` (default: 7 days)
+- `version_retention` -- how long to keep superseded versions of a tool before reclaiming
+  them, e.g. `"168h"` (default: 7 days)
 
 **Registries**: Add third-party recipe sources:
 ```bash


### PR DESCRIPTION
Version reclamation picked its candidates by matching directory names against
`<tool>-`, which meant reclaiming `git` considered `git-lfs-3.5.0` a version of `git`
named `lfs-3.5.0` and deleted a working installation of a different tool. The registry
ships 59 such name pairs. It fired unattended from the auto-apply loop: a tool the user
installed disappeared, and the first they knew of it was `command not found`.

The remainder after the prefix cannot be validated back into a version. `lfs-3.5.0` is a
perfectly good version string as far as `ValidateVersionString` is concerned, and a
stricter rule would have to guess at version shape, which this registry does not support.
So `GarbageCollectVersions` stops parsing directory names: it asks state which versions
the tool has, builds each directory name from the (tool, version) pair the way
`config.ToolDir` does, and reclaims only those. The name is no longer an input to the
delete decision. `VersionReaper` becomes `VersionStore` and gains `InstalledVersions`,
implemented on `install.Manager` alongside `List`, which already worked this way.

`ReapVersion` now refuses a version, or a tool, that state has no record of. Every caller
is about to delete that directory, and returning nil there reported "reconciled" when
nothing was reconciled -- which is how the wrong directory got past the check that looked
like it would stop this. Its doc comment used to open by saying the directory had already
been deleted, while its only caller deliberately reaps first so a failure leaves the
version installed rather than recorded but absent; it now states the ordering callers have
to honor, and records that reaping does not tear down a version's `.app` bundle.

Two smaller changes fall out of sourcing the version from state rather than from a
directory listing. The version passes through `ValidateVersionString` before it reaches
`filepath.Join`, since it now travels from a file on disk into an `os.RemoveAll` path.
And the directory is checked with `Lstat` rather than `Stat`, matching what the old
`ReadDir` scan saw: a symlink is not a version directory this code installed, and its
target's mtime is not that version's age.

A directory that state has no record of is now kept rather than reclaimed. Deleting it
would mean deleting on the strength of a filesystem name, which is the mistake being
fixed.

---

Fixes #2474

## Root cause

`gc.go` filtered candidates with `strings.HasPrefix(name, toolName+"-")` and never
checked the remainder, then trusted `ReapVersion` as a backstop. `ReapVersion` returned
`nil` for a version it did not recognise rather than objecting, so `os.RemoveAll` ran
anyway. Two checks that each looked like the other one's safety net, and neither was.

## The decision, and the alternative

The issue suggested two directions. Validating the remainder lexically does not work:
`internal/version.ValidateVersionString` accepts `[a-zA-Z0-9._+\-@/]+`, so `lfs-3.5.0`
passes. Any rule strict enough to reject it has to invent a version shape, and it is
wrong in both directions -- it rejects a legitimate non-numeric version and accepts a
tool suffix that happens to start with a digit. QA confirmed the practical half of that:
versions tsuku really installs include `2024-01-01`, `3.11.0rc1` and `20240101`.

Reclaiming what state records is the other direction, and it became available a few hours
before this issue was written: #2465 gave `gc.go` a handle on `install.Manager`.
`Manager.List` already demonstrates the safe idiom -- enumerate from state, build the path
with `config.ToolDir`, never parse a directory name. Reclamation was doing the reverse for
no reason.

**What happens to an orphan directory.** This is the one behavior change beyond the bug,
so it is deliberate rather than incidental. A directory under `tools/` that state does not
claim used to be deleted once past retention; now it stays. Keeping it is right:
reclamation runs unattended from the auto-apply loop, and a per-tool sweep genuinely
cannot tell an orphan from another tool's installation -- both are "a directory this
tool's state does not claim", and only a whole-state pass can tell them apart. An orphan
costs disk. A wrong delete costs a working tool. Filed as #2482, which owns proving a
directory belongs to no installed tool at all.

## Two claims in the issue that do not survive contact with the code

The load-bearing ones hold. The prefix filter, the missing remainder check, and the
`ReapVersion` no-op are all as described, and the collision reproduces against the real
function: reclaiming `git` deleted `git-lfs-3.5.0` and reaped `git@lfs-3.5.0`. Two others
do not.

The first is the issue's own suggested direction, "require that the remainder after
`toolName + "-"` parses as a version", for the reason above.

The second is one line of the impact description: "The victim's `state.json` entry
survives, so `tsuku list` keeps showing it while its `bin/` symlinks dangle." The first
half is right and the conclusion is not. `ListWithOptions` stats each version directory
and skips the entry when it is gone (`internal/install/list.go:50-53`), so the victim
drops out of `tsuku list` rather than lingering in it. Same severity, opposite symptom:
the user watches a tool vanish rather than seeing one that claims to be installed. Worth
correcting because that wording would otherwise be reused in a changelog.

## Testing

The regression test creates two real tool directories whose names share a prefix,
reclaims one, and asserts the other survives on disk. It exists at both levels: against a
stand-in store, and end to end through the real `install.Manager` that `apply.go` passes
in production, where it also checks `Manager.List` still reports `git-lfs` afterwards.
Both halves matter, for the reason above.

The mirror case is covered too: `git-lfs` still reclaims its own aged-out version, so the
fix is not "never delete anything near a collision".

### Mutation testing

Fourteen defects injected one at a time, each reverted after the run. All fourteen killed.

| Defect injected | Test that caught it |
|---|---|
| `gc.go` selects candidates by directory-name prefix again | `LeavesToolWhoseNameSharesAPrefix` |
| Drop the version-string guard before the path join | `RefusesVersionThatEscapesToolsDir` |
| Accept a nil store and fall through | `RequiresAStore` |
| Swallow the state read failure | `ReturnsStateReadFailure` |
| Stop protecting the active version | `ProtectsActive` |
| Stop protecting the rollback target | `ProtectsPrevious` |
| Ignore the retention period | `RetentionBoundary` |
| Retention comparison off by one (`<` to `<=`) | `RetentionBoundary/exactly_at_retention` |
| Delete even when reaping the version state failed | `KeepsDirectoryWhenReapFails` |
| `Lstat` back to `Stat` | `DoesNotFollowASymlinkedVersionDir` |
| `ReapVersion` no-ops for an unknown version again | `RefusesWhatStateCannotVouchFor` |
| `ReapVersion` no-ops for an unknown tool | `RefusesWhatStateCannotVouchFor` |
| `ReapVersion` stops refusing the active version | `RefusesWhatStateCannotVouchFor` |
| Both locks off at once: prefix scan **and** a no-op `ReapVersion` | `RealManagerSparesPrefixSharingTool` |

The last row is the interesting one. Restoring the prefix scan alone does **not** fail the
real-manager test, because `ReapVersion` refuses the version and the directory survives.
The two changes are independent locks and the end-to-end test only fails when both are
broken. That is the backstop the issue asked for, demonstrated rather than asserted -- and
the reason the `remove.go` change should not be dropped as redundant with the `gc.go` one.

An earlier round of this had two tests whose fixtures short-circuited before the behavior
they were named for: both recorded only the active version, so the loop skipped at the
active-version guard and never reached the code under test. `IgnoresOtherTools` now gives
`node` a real aged-out version to reclaim, so it fails if reclamation stops working at
all, and the missing-directory branch got a test of its own.

## Checks

`go build`, `go vet`, `gofmt`, `golangci-lint run` and `go test ./...` are all clean
(54 packages, exit 0).

`TestGolangCILint` failed locally until `golangci-lint cache clean`. Every issue it
reported lived in a different checkout on the same machine, and the identical failure
reproduced on an unmodified `main`, so it was stale shared-cache contamination rather
than anything in this branch.

This change does not arm `validate-golden-code.yml`; none of the touched files are on its
path allowlist.

## Plugin maintenance

`internal/updates/` is on the plugin-maintenance table, mapped to `tsuku-user`. The skill
documented `version_retention` as a setting but never said reclamation happens, and it now
has a user-visible rule worth stating: only versions tsuku installed and still records are
reclaimed, so a directory it has no record of stays put however old. Added to the
auto-update workflow section, and the setting's description now says what it retains
against.

## Filed separately

The same prefix idiom appears in two other places, both read-only rather than destructive,
both reachable:

- #2480 -- `actions/eval_deps.go` reports an eval dependency on `git` satisfied when only
  `git-lfs` is installed, so the missing-dependency prompt never fires.
- #2481 -- `install/library.go` returns `source-8.5.0` as the installed version of
  `libcurl` when `libcurl-source` is present. Two colliding library pairs today.

Review turned up three more, none of them this bug:

- #2482 -- the orphan sweep described above.
- #2488 -- three current design docs state the old prefix-matching behavior as fact, one
  of them as load-bearing rationale. Filed rather than fixed here because the nvm
  data-root work is in flight in that file.
- #2489 -- `ReapVersion` refuses the active version but not the rollback target, and
  clears `PreviousVersion` as it goes. Latent, since no caller passes an empty
  `previousVersion` today.
- #2490 -- `ReapVersion` does not tear down a version's `.app` bundle or `~/Applications`
  symlink the way `RemoveVersion` does, and dropping the `VersionState` throws away the
  only record of where they were. Predates this change; the doc comment now names the gap
  so it is not silent while it waits.

## Reviewer notes

Two suggestions were weighed and declined, both about collapsing the seam rather than the
fix itself. `VersionStore` has one implementation and one caller, so it could be a
concrete `*install.Manager`; the interface arrived with #2465 days ago and reversing that
here is a larger change than this bug warrants. `GarbageCollectVersions` could take a
`*config.Config` so it can call `config.ToolDir` instead of building the same path by
hand; that is a signature change beyond the bug, it fails safe today (a layout mismatch
just fails `Lstat` and reclamation stops), and the site is now commented so a layout
change finds it.

Users already hit by the old bug get no repair from this change -- their tool is gone and
tsuku will not notice. Reinstalling fixes it. That is scope this PR does not take on.
