### PR TITLE
docs: correct version reclamation from prefix matching to state-sourced

### DIFF
--- a/docs/designs/current/DESIGN-nvm-data-root.md
+++ b/docs/designs/current/DESIGN-nvm-data-root.md
@@ -149,9 +149,9 @@ clocks: `GarbageCollectVersions` removes every version state records once it age
 retention, and the install path removes an existing tool directory outright before its
 atomic rename, with no timer at all. The only path a recipe can name under `tools/` is
 `{install_dir}`, which is exactly the directory both of those delete. A directory no
-version claims does survive reclamation today, but only because a per-tool sweep cannot
-prove such a directory belongs to no installed tool — #2482 owns closing that gap, and
-closing it makes `tools/` hostile to stable data again.
+version claims is spared only for as long as reclamation stays per-tool, since a per-tool
+sweep cannot prove such a directory belongs to no installed tool at all; #2482 owns the
+whole-state pass that can. Either side of that, `tools/` is no place for stable data.
 
 **Dropping the export does not restore upstream behavior.** `install_shell_init`
 *copies* `nvm.sh` into `$TSUKU_HOME/share/shell.d`, so self-location lands there, not at

--- a/docs/designs/current/DESIGN-nvm-data-root.md
+++ b/docs/designs/current/DESIGN-nvm-data-root.md
@@ -150,7 +150,7 @@ retention, and the install path removes an existing tool directory outright befo
 atomic rename, with no timer at all. The only path a recipe can name under `tools/` is
 `{install_dir}`, which is exactly the directory both of those delete. A directory no
 version claims does survive reclamation today, but only because a per-tool sweep cannot
-prove such a directory belongs to no installed tool -- #2482 owns closing that gap, and
+prove such a directory belongs to no installed tool — #2482 owns closing that gap, and
 closing it makes `tools/` hostile to stable data again.
 
 **Dropping the export does not restore upstream behavior.** `install_shell_init`

--- a/docs/designs/current/DESIGN-nvm-data-root.md
+++ b/docs/designs/current/DESIGN-nvm-data-root.md
@@ -25,18 +25,19 @@ decision: |
   reports a migration that did not complete and can retry it. tsuku remove nvm
   preserves the data root and prints its path; nothing tsuku ships ever deletes it.
 rationale: |
-  The data root has to leave tools/ entirely, because garbage collection matches a
-  raw name prefix and the install path removes a tool directory before its atomic
-  rename. share/ was rejected as the destination because its defining property is
-  that everything in it is regenerable, which is the opposite of the policy this
-  data needs. Copies beat symlinks for the program files because activate, rollback,
-  and removal-promotion never re-run post-install, so a recipe-placed symlink tracks
-  the last-installed version and goes dangling, breaking nvm exec while every other
-  subcommand stays green. Migration was built and then removed: the export is an
-  absolute literal frozen into a fragment nothing else rewrites, so a migration must
-  run in the same post-install execution as set_env — but that constrains when it
-  runs, not whether it must be Go, and Go is the one place a tool's layout cannot be
-  shipped alongside that tool's recipe.
+  The data root has to leave tools/ entirely, because everything under it is
+  version-scoped and tsuku deletes it on two clocks: garbage collection reclaims a
+  superseded version once it ages past retention, and the install path removes a tool
+  directory before its atomic rename. share/ was rejected as the destination because
+  its defining property is that everything in it is regenerable, which is the opposite
+  of the policy this data needs. Copies beat symlinks for the program files because
+  activate, rollback, and removal-promotion never re-run post-install, so a
+  recipe-placed symlink tracks the last-installed version and goes dangling, breaking
+  nvm exec while every other subcommand stays green. Migration was built and then
+  removed: the export is an absolute literal frozen into a fragment nothing else
+  rewrites, so a migration must run in the same post-install execution as set_env — but
+  that constrains when it runs, not whether it must be Go, and Go is the one place a
+  tool's layout cannot be shipped alongside that tool's recipe.
 ---
 
 # DESIGN: nvm data root
@@ -75,12 +76,12 @@ Three paths now bear on that data, on very different clocks:
   period. On the normal path `mgr.IsVersionInstalled` short-circuits at
   `cmd/tsuku/install_deps.go:508` first, so this needs an external plan file naming an
   installed version — narrow, but it is a deletion with no timer at all.
-- **Later, unattended.** `GarbageCollectVersions` (`internal/updates/gc.go`) keeps only
-  the active and previous versions and deletes the rest past
-  `DefaultVersionRetention` (7 days). Its single call site is the background auto-apply
-  loop (`internal/updates/apply.go:153`), reached only after that same tool has
-  successfully auto-updated, and it protects the just-superseded directory as
-  `previousVersion`. In practice this needs two nvm releases plus seven days.
+- **Later, unattended.** `GarbageCollectVersions` (`internal/updates/gc.go`) asks state
+  which versions it records for the tool, keeps only the active and previous, and
+  deletes the rest past `DefaultVersionRetention` (7 days). Its single call site is the
+  background auto-apply loop (`internal/updates/apply.go:153`), reached only after that
+  same tool has successfully auto-updated, and it protects the just-superseded directory
+  as `previousVersion`. In practice this needs two nvm releases plus seven days.
 
 The issue frames this as a garbage-collection bug. That framing is the least urgent of
 the three: a fix scoped to GC leaves the bug that fires in one second untouched while
@@ -142,9 +143,15 @@ version string into a path nvm does string-prefix arithmetic on
 (`nvm_tree_contains_path`, `nvm_change_path`, `nvm_sanitize_path`). "Smallest diff" is
 not a differentiator.
 
-**Nothing stable can live under `tools/`.** `GarbageCollectVersions` matches a raw
-`strings.HasPrefix(name, toolName+"-")` and `ReapVersion` returns nil for an
-unrecognized version rather than objecting, so `os.RemoveAll` runs anyway.
+**Nothing stable can live under `tools/`.** Every directory there is a
+`<tool>-<version>` pair tsuku expects to reclaim, and it gets deleted on two independent
+clocks: `GarbageCollectVersions` removes every version state records once it ages past
+retention, and the install path removes an existing tool directory outright before its
+atomic rename, with no timer at all. The only path a recipe can name under `tools/` is
+`{install_dir}`, which is exactly the directory both of those delete. A directory no
+version claims does survive reclamation today, but only because a per-tool sweep cannot
+prove such a directory belongs to no installed tool -- #2482 owns closing that gap, and
+closing it makes `tools/` hostile to stable data again.
 
 **Dropping the export does not restore upstream behavior.** `install_shell_init`
 *copies* `nvm.sh` into `$TSUKU_HOME/share/shell.d`, so self-location lands there, not at
@@ -605,7 +612,8 @@ directory it can name in `doctor` output and size reporting.
   `set_env`'s emitted form for every future consumer and stands on its own.
 - **`GarbageCollectVersions` deleting other tools' directories on recipe-name prefix
   collisions (#2474)** (`git`/`git-lfs`, `docker`/`docker-compose` — 59 pairs, verified
-  empirically). A real bug, independent of this one.
+  empirically). A real bug, independent of this one. Fixed since, in #2491, by sourcing
+  the candidate versions from state instead of from the directory listing.
 - **The archive extractor's containment is purely lexical (#2473).**
   `isPathWithinDirectory` and `validateSymlinkTarget` (`internal/actions/extract.go:19-55`)
   compare cleaned strings and resolve with `filepath.Join`, so a symlink chain in a

--- a/docs/designs/current/DESIGN-resilience.md
+++ b/docs/designs/current/DESIGN-resilience.md
@@ -100,7 +100,7 @@ After a successful auto-apply for a tool, ask `state.json` which versions it rec
 3. Build the directory path from the (tool, version) pair the way `config.ToolDir` does, and check its mtime against the retention period (configurable via `updates.version_retention`, default 7 days)
 4. Remove if older than the retention period
 
-Sourcing the candidates from state rather than from a directory listing is what keeps a directory name out of the delete decision. A directory state has no record of is left alone -- see Implementation Amendments below.
+Sourcing the candidates from state rather than from a directory listing is what keeps a directory name out of the delete decision. What that leaves unreclaimed, and why, is in Implementation Amendments below.
 
 GC runs per-tool after each successful apply, not as a global sweep. This keeps the scope narrow and the duration short. A global `tsuku gc` command is out of scope for this feature.
 
@@ -269,13 +269,14 @@ existing `List` already worked this way.
 
 Two consequences worth stating, both deliberate:
 
-- **A directory state has no record of is now kept, not reclaimed.** Deleting it would
-  mean deleting on the strength of a filesystem name, which is the mistake being fixed. A
-  per-tool sweep genuinely cannot tell an orphan from another tool's installation. #2482
-  owns the whole-state pass that can.
-- **`ReapVersion` refuses a version, or a tool, that state does not record.** It used to
-  return nil, which reported "reconciled" when nothing was, and that is how the wrong
-  directory got past the check that looked like it would stop this.
+- **#2491 stopped reclaiming a directory state has no record of.** Deleting it would mean
+  deleting on the strength of a filesystem name, which is the mistake being fixed. A
+  per-tool sweep genuinely cannot tell an orphan from another tool's installation, so
+  reclaiming those needs a pass over the whole state rather than one tool's slice of it.
+  #2482 owns that pass.
+- **#2491 made `ReapVersion` refuse a version, or a tool, that state does not record.** It
+  used to return nil, which reported "reconciled" when nothing was, and that is how the
+  wrong directory got past the check that looked like it would stop this.
 
 The rest of the design held. GC still runs post-apply, still protects the active version
 and the rollback target, still keys on mtime against `updates.version_retention`, and is

--- a/docs/designs/current/DESIGN-resilience.md
+++ b/docs/designs/current/DESIGN-resilience.md
@@ -94,11 +94,13 @@ Key assumptions:
 
 #### Chosen: Post-apply GC in MaybeAutoApply
 
-After a successful auto-apply for a tool, scan `$TSUKU_HOME/tools/` for directories matching `<tool>-*`. For each:
-1. Skip if it's the active version directory
-2. Skip if it's the PreviousVersion directory
-3. Check the directory's mtime against the retention period (configurable via `updates.version_retention`, default 7 days)
+After a successful auto-apply for a tool, ask `state.json` which versions it records for that tool. For each:
+1. Skip if it's the active version
+2. Skip if it's the PreviousVersion
+3. Build the directory path from the (tool, version) pair the way `config.ToolDir` does, and check its mtime against the retention period (configurable via `updates.version_retention`, default 7 days)
 4. Remove if older than the retention period
+
+Sourcing the candidates from state rather than from a directory listing is what keeps a directory name out of the delete decision. A directory state has no record of is left alone -- see Implementation Amendments below.
 
 GC runs per-tool after each successful apply, not as a global sweep. This keeps the scope narrow and the duration short. A global `tsuku gc` command is out of scope for this feature.
 
@@ -120,7 +122,7 @@ Three changes, each targeted at a specific rough edge.
 
 For consecutive-failure suppression, `Notice` gains a `ConsecutiveFailures` field. `MaybeAutoApply` reads the existing notice before writing, increments the counter on transient failures, and pre-marks notices below the threshold as shown. Actionable errors (classified by pattern-matching the error string for "checksum", "disk", "recipe") bypass the counter. `DisplayNotifications` already skips shown notices, so no rendering changes are needed.
 
-For version GC, `MaybeAutoApply` calls a new `GarbageCollectVersions(toolsDir, toolName, activeVersion, previousVersion, retention, now)` function after each successful apply. It lists directories matching `<tool>-*`, skips active and previous, and removes those with mtime older than the retention period. A new `updates.version_retention` config key controls the period (default "168h" = 7 days).
+For version GC, `MaybeAutoApply` calls a new `GarbageCollectVersions(store, toolsDir, toolName, activeVersion, previousVersion, retention, now)` function after each successful apply. It asks the store which versions state records for the tool, skips active and previous, rebuilds each remaining version's directory path, and removes those with mtime older than the retention period. A new `updates.version_retention` config key controls the period (default "168h" = 7 days).
 
 For offline degradation, no new code is needed in the core path. The background checker already writes error entries when resolution fails, and `MaybeAutoApply` already skips entries with errors. The design adds two doctor checks: orphaned staging directories (leftover temp files in `$TSUKU_HOME/tools/` matching `.staging-*`) and stale notices (files in `$TSUKU_HOME/notices/` older than 30 days).
 
@@ -145,7 +147,8 @@ internal/updates/apply.go (MODIFIED)
   +-- MaybeAutoApply: call GarbageCollectVersions after successful apply
 
 internal/updates/gc.go (NEW)
-  +-- GarbageCollectVersions(toolsDir, toolName, active, previous, retention, now)
+  +-- VersionStore interface (InstalledVersions, ReapVersion) -- satisfied by install.Manager
+  +-- GarbageCollectVersions(store, toolsDir, toolName, active, previous, retention, now)
 
 internal/userconfig/userconfig.go (MODIFIED)
   +-- UpdatesVersionRetention() config accessor
@@ -159,7 +162,12 @@ cmd/tsuku/doctor.go (MODIFIED)
 
 ```go
 // internal/updates/gc.go
-func GarbageCollectVersions(toolsDir, toolName, activeVersion, previousVersion string, retention time.Duration, now time.Time) error
+type VersionStore interface {
+    InstalledVersions(tool string) ([]string, error)
+    ReapVersion(tool, version string) error
+}
+
+func GarbageCollectVersions(store VersionStore, toolsDir, toolName, activeVersion, previousVersion string, retention time.Duration, now time.Time) error
 
 // internal/notices/notices.go (extended struct)
 type Notice struct {
@@ -219,7 +227,7 @@ Deliverables:
 
 ## Security Considerations
 
-These are hardening changes with no new external inputs. GC deletes directories that tsuku itself created, scoped to `$TSUKU_HOME/tools/`. The deletion path validates the directory name matches `<tool>-<version>` format before removing. No new network access, permissions, or data exposure.
+These are hardening changes with no new external inputs. GC deletes directories that tsuku itself created, scoped to `$TSUKU_HOME/tools/`. It never takes a path from the filesystem: each candidate is a version string state records, and that string passes `install.ValidateVersionString` before it reaches the path join, so nothing that could steer `os.RemoveAll` out of the tools directory gets there. The directory is then checked with `Lstat`, so a symlink sitting where a version directory should be is skipped rather than followed. No new network access, permissions, or data exposure.
 
 ## Consequences
 
@@ -241,6 +249,37 @@ These are hardening changes with no new external inputs. GC deletes directories 
 - The `omitempty` tag means existing notice files without the field parse correctly (counter defaults to 0, treated as first failure)
 - The retention period is configurable. Users who need longer retention can set `updates.version_retention = "720h"` (30 days)
 - `tsuku doctor` warns about conditions, it doesn't auto-fix them
+
+## Implementation Amendments
+
+### GC candidate selection: directory listing → state
+
+As originally implemented, `GarbageCollectVersions` picked its candidates by listing
+`$TSUKU_HOME/tools/` and keeping every directory whose name started with `<tool>-`. That
+was a data-loss bug (#2474): the remainder after the prefix cannot be validated back into
+a version, so reclaiming `git` treated `git-lfs-3.5.0` as a version of `git` named
+`lfs-3.5.0` and deleted a working installation of a different tool. The registry ships 59
+such name pairs, and the delete fired unattended from the auto-apply loop.
+
+#2491 fixed it by inverting where the candidate list comes from. The function gained a
+`VersionStore` first parameter, asks it which versions state records for the tool, and
+rebuilds each directory name from the (tool, version) pair. A directory name is no longer
+an input to the delete decision. `install.Manager` satisfies the interface, and its
+existing `List` already worked this way.
+
+Two consequences worth stating, both deliberate:
+
+- **A directory state has no record of is now kept, not reclaimed.** Deleting it would
+  mean deleting on the strength of a filesystem name, which is the mistake being fixed. A
+  per-tool sweep genuinely cannot tell an orphan from another tool's installation. #2482
+  owns the whole-state pass that can.
+- **`ReapVersion` refuses a version, or a tool, that state does not record.** It used to
+  return nil, which reported "reconciled" when nothing was, and that is how the wrong
+  directory got past the check that looked like it would stop this.
+
+The rest of the design held. GC still runs post-apply, still protects the active version
+and the rollback target, still keys on mtime against `updates.version_retention`, and is
+still per-tool rather than a global sweep.
 
 ## Implementation Issues
 

--- a/docs/designs/current/DESIGN-shell-d-lifecycle.md
+++ b/docs/designs/current/DESIGN-shell-d-lifecycle.md
@@ -220,10 +220,14 @@ $TSUKU_HOME/share/shell.d/00-env-<name>@<version>.<shell>
 
 `@` is the separator because it is already tsuku's user-facing tool-version separator
 (`tsuku install nvm@0.40.6`), so a directory listing reads itself. `-` is unavailable:
-`GarbageCollectVersions` and `config.ToolDir` already match versioned directories by the
-`name + "-"` prefix, which is ambiguous for a tool whose name contains a hyphen, and
-copying that convention into the one place we are making a bug unrepresentable would
-import a latent one.
+`config.ToolDir` already names versioned directories `name + "-" + version`, which is
+ambiguous for a tool whose name contains a hyphen, and code that reads that layout back
+by prefix cannot recover the pair. `isToolInstalled` (`internal/actions/eval_deps.go`)
+still does, and reports an eval dependency on `git` satisfied when only `git-lfs` is
+installed (#2480); `GetInstalledLibraryVersion` (`internal/install/library.go`) does the
+same over `libs/` and returns `source-8.5.0` as the installed version of `libcurl` when
+`libcurl-source` is present (#2481). Copying that convention into the one place we are
+making a bug unrepresentable would import a latent one.
 
 `install_shell_init`'s preflight gains `target` must match `^[A-Za-z_][A-Za-z0-9._-]*$`.
 This runs in recipe-validation CI, subsumes the prototype's narrower

--- a/docs/designs/current/DESIGN-shell-d-lifecycle.md
+++ b/docs/designs/current/DESIGN-shell-d-lifecycle.md
@@ -220,13 +220,13 @@ $TSUKU_HOME/share/shell.d/00-env-<name>@<version>.<shell>
 
 `@` is the separator because it is already tsuku's user-facing tool-version separator
 (`tsuku install nvm@0.40.6`), so a directory listing reads itself. `-` is unavailable:
-`config.ToolDir` already names versioned directories `name + "-" + version`, which is
-ambiguous for a tool whose name contains a hyphen, and code that reads that layout back
-by prefix cannot recover the pair. `isToolInstalled` (`internal/actions/eval_deps.go`)
-still does, and reports an eval dependency on `git` satisfied when only `git-lfs` is
-installed (#2480); `GetInstalledLibraryVersion` (`internal/install/library.go`) does the
-same over `libs/` and returns `source-8.5.0` as the installed version of `libcurl` when
-`libcurl-source` is present (#2481). Copying that convention into the one place we are
+`config.ToolDir` names versioned directories `name + "-" + version`, and that mapping is
+not injective — a tool whose name contains a hyphen collides with a shorter-named tool at
+a hyphenated version. Nothing can read the layout back by prefix and recover the pair,
+and every place that has tried has produced a real bug: reclamation deleting a
+prefix-sharing tool's entire directory (#2474), an eval dependency on `git` reported
+satisfied when only `git-lfs` is installed (#2480), and `libcurl` resolving to
+`libcurl-source`'s version (#2481). Copying that convention into the one place we are
 making a bug unrepresentable would import a latent one.
 
 `install_shell_init`'s preflight gains `target` must match `^[A-Za-z_][A-Za-z0-9._-]*$`.


### PR DESCRIPTION
Three current design docs describe version reclamation as matching directory names
against a `<tool>-` prefix. It stopped doing that in #2491: `GarbageCollectVersions`
asks state which versions a tool has, builds each directory name from the (tool,
version) pair the way `config.ToolDir` does, and reclaims only those. A directory name
is no longer an input to the delete decision, and `ReapVersion` refuses a version state
has no record of rather than returning nil.

The nvm data-root doc was the load-bearing one. It used the old behavior as
justification -- the data root has to leave `tools/` *because* garbage collection
matches a raw name prefix -- and that half is now false while the conclusion still
stands. It now rests on the half that survives: everything under `tools/` is
version-scoped, and it gets deleted on two independent clocks, retention reclamation and
the install path removing an existing tool directory before its atomic rename. The only
path a recipe can name there is `{install_dir}`, which is exactly what both delete. A
sibling directory no version claims is spared only for as long as reclamation stays
per-tool, since a per-tool sweep cannot prove such a directory belongs to no installed
tool at all; #2482 owns the whole-state pass that can.

The resilience doc gets the current signature, the `VersionStore` interface it takes, and
a corrected security paragraph -- it claimed the deletion path validates the directory
name against a `<tool>-<version>` format, where the code validates the version string
before the path join and then `Lstat`s the result. An Implementation Amendments section
records what changed and why, so the audit trail survives the inline corrections; that
section follows the convention `DESIGN-batch-recipe-generation.md` already uses.

The shell.d doc keeps its prefix-ambiguity argument. The argument is correct and is why
#2474 was filed -- it just needed a citation that does not rot. It now rests on the
layout rather than on any call site: `config.ToolDir` names versioned directories
`name + "-" + version`, that mapping is not injective, so nothing can read it back by
prefix and recover the pair. The three bugs the idiom produced are cited as history by
issue number -- reclamation deleting a prefix-sharing tool's directory (#2474), an eval
dependency on `git` reported satisfied by `git-lfs` (#2480), `libcurl` resolving to
`libcurl-source`'s version (#2481). See "A citation that would have gone stale" below
for why this is phrased that way.

---

Fixes #2488

## Beyond the three sites the issue names

The issue names three passages and does not claim to be exhaustive, so I grepped
`docs/designs/current/` rather than stopping there. Four more assert the old behavior:

- `DESIGN-nvm-data-root.md` -- the unattended-deletion bullet, and an out-of-scope entry
  that describes the prefix-collision bug in the present tense when it has since been
  fixed.
- `DESIGN-resilience.md` -- the chosen-option steps, the Decision Outcome summary, the
  component sketch, and the Security Considerations paragraph. The security one is the
  substantive one of the four; the rest are the same claim restated.

## What was checked and deliberately left alone

Three nearby passages mention GC and survive contact with the code, so they are
untouched:

- `DESIGN-nvm-data-root.md`'s rejection of "record a `delete_dir` cleanup so
  `tsuku remove nvm` takes the data". The scenario still fires: install v1, install v2
  with `--no-shell-init`, let v1 age past retention. v1 *is* recorded in state, so
  `ReapVersion`'s new refusal never triggers, and the cross-version guard still compares
  on exact string equality against another installed version's recorded actions -- which
  `--no-shell-init` guarantees are absent.
- The same doc's note that GC keeps the rollback target.
- `DESIGN-shell-d-lifecycle.md`'s forced-consumer row for `GarbageCollectVersions`. It
  says GC must run the deleted version's cleanups and drop its `VersionState`, which is
  exactly what `ReapVersion` does.

Archived design docs are the historical record and were not touched.

## One claim in the issue that no longer holds

The issue explains itself with "The nvm data-root work is in flight, so editing that
design doc from the reclamation fix would collide with it." That work merged as #2467, so
the collision it was avoiding no longer exists. Splitting it out was still right -- each
change reads on its own -- but a reader should not go looking for an in-flight branch.

## A citation that would have gone stale

Review caught this and it was right. The first version of the shell.d edit justified
rejecting `-` by naming two functions that still read `<name>-<version>` back by prefix,
one of them `isToolInstalled`. #2503 has since merged and removed exactly that behaviour,
so the new citation was already false on `main` -- I would have replaced one stale claim
with another, in the branch whose whole purpose is removing stale claims.

The fix is to stop asserting present-tense behaviour of a named function. The argument
the doc actually needs is a property of the layout, not of any call site: `name + "-" +
version` is not injective, so no reader of that string can recover the pair, and that is
true regardless of who is currently making the mistake. The bugs are cited by issue
number as history -- which is durable whether each is open, fixed, or fixed tomorrow --
and three instances of one idiom failing is a stronger argument than one live example
anyway.

I swept the rest of the diff for the same exposure and found two more, both reworded:

- The nvm data-root paragraph said an unclaimed directory survives reclamation "today".
  That goes false the moment #2482 lands. It now says it survives for as long as
  reclamation stays per-tool, which holds either side of it.
- The resilience Implementation Amendments described the post-#2491 state in the present
  tense. They now describe what #2491 changed, which cannot rot.

Claims deliberately left in the present tense, with the reason: `config.ToolDir` builds
`name + "-" + version` (the canonical builder; no open PR touches it), the install path
removes an existing tool directory before its atomic rename (`manager.go:182-183`,
re-verified on `main`; #2518 touches `manager.go` but only for library staging under
`libs/`), and the `GarbageCollectVersions` signature and `VersionStore` interface (no open
PR touches `internal/updates/gc.go`).

## Acceptance criteria

| Criterion | Where |
|---|---|
| The nvm data-root rationale states a reason true of the current code | `DESIGN-nvm-data-root.md` frontmatter `rationale`, and the "Nothing stable can live under `tools/`" paragraph. Stated as current truth rather than marked as reasoning-at-the-time; the audit trail is preserved by naming the issues that changed the behavior. |
| The resilience doc's `GarbageCollectVersions` signature matches the code | `DESIGN-resilience.md` Key interfaces, now identical to `internal/updates/gc.go:56`, with `VersionStore` shown alongside it. |
| The shell.d doc's prefix-ambiguity argument cites something that still does prefix matching | `DESIGN-shell-d-lifecycle.md`. It cites the layout `config.ToolDir` builds, which is not injective, and the three bugs that idiom produced (#2474, #2480, #2481) as history. `GetInstalledLibraryVersion` still prefix-matches on `main`, so a live example does exist; the doc does not name it, deliberately -- see below. |

Nothing deferred.

## Checks

Documentation only -- no code path changed, so there is nothing to mutation-test and no
new test to add.

`go build ./...`, `go vet ./...`, `gofmt -l .` and `go test ./...` are all clean (exit 0,
every package). The docs checks CI runs were also run locally: `shirabe validate` reports
0 errors on all three files, `status-directory.sh` passes on all three, and the
`check-artifacts` condition holds (no `wip/`). `validate-diagram-classes` skips -- none of
the three docs contains a mermaid diagram.

`TestGolangCILint` failed once before the baseline, with every issue it reported located
in a different checkout on the same machine that no longer exists on disk. Stale
shared-cache contamination, not this branch; `golangci-lint cache clean` fixes it, and the
identical failure and fix are recorded in #2491.

Rebased onto `bc6403dc` (current `main`, which includes #2503) so the staleness above is
checked against the tree as it actually stands, not as it stood when the branch opened.

This change does not arm `validate-golden-code.yml`; no file on its path allowlist is
touched. No plugin skill needed updating -- no file on the plugin-maintenance table is in
this diff, and `plugins/tsuku-user` already documents state-sourced reclamation, added by
#2491.

