### PR TITLE
fix(actions): ask state whether an eval dependency is installed

### DIFF
--- a/internal/actions/eval_deps.go
+++ b/internal/actions/eval_deps.go
@@ -44,7 +44,10 @@ func checkEvalDepsInHome(deps []string, tsukuHome string) []string {
 	// resolvers that go looking for the binary afterwards -- ResolveGo,
 	// ResolveCargo, ResolvePythonStandalone -- and they all read GetToolsDir,
 	// so answering from a different directory than they read would put the
-	// check and the thing it guards out of step.
+	// check and the thing it guards out of step. Both of them ignore
+	// config.DefaultHomeOverride, which is a real divergence from the rest of
+	// the CLI and is tracked as issue #2501; fixing it here alone would only
+	// widen the gap.
 	//
 	// HomeDir locates state.json and ToolsDir locates the version
 	// directories. Those two fields are all this reads.

--- a/internal/actions/eval_deps.go
+++ b/internal/actions/eval_deps.go
@@ -2,7 +2,10 @@ package actions
 
 import (
 	"os"
-	"strings"
+	"path/filepath"
+
+	"github.com/tsukumogami/tsuku/internal/config"
+	"github.com/tsukumogami/tsuku/internal/install"
 )
 
 // GetEvalDeps returns the eval-time dependencies for an action.
@@ -17,44 +20,79 @@ func GetEvalDeps(action string) []string {
 }
 
 // CheckEvalDeps checks which eval-time dependencies are not installed.
-// It looks for tools in $TSUKU_HOME/tools/ directory.
+// It asks what state records under $TSUKU_HOME for each one.
 // Returns a list of missing dependency names.
 func CheckEvalDeps(deps []string) []string {
 	if len(deps) == 0 {
 		return nil
 	}
 
-	toolsDir := GetToolsDir()
-	if toolsDir == "" {
-		// Can't determine tools directory, assume all deps are missing
+	tsukuHome := resolveTsukuHome()
+	if tsukuHome == "" {
+		// Can't determine the tsuku home directory, assume all deps are missing
 		return deps
 	}
 
-	return checkEvalDepsInDir(deps, toolsDir)
+	return checkEvalDepsInHome(deps, tsukuHome)
 }
 
-// checkEvalDepsInDir checks which dependencies are missing from the given tools directory.
-func checkEvalDepsInDir(deps []string, toolsDir string) []string {
+// checkEvalDepsInHome checks which dependencies are missing from the given
+// tsuku home directory.
+func checkEvalDepsInHome(deps []string, tsukuHome string) []string {
+	// The home comes from resolveTsukuHome, the same place GetToolsDir gets
+	// it, rather than from config.DefaultConfig. This check gates the
+	// resolvers that go looking for the binary afterwards -- ResolveGo,
+	// ResolveCargo, ResolvePythonStandalone -- and they all read GetToolsDir,
+	// so answering from a different directory than they read would put the
+	// check and the thing it guards out of step.
+	//
+	// HomeDir locates state.json and ToolsDir locates the version
+	// directories. Those two fields are all this reads.
+	cfg := &config.Config{
+		HomeDir:  tsukuHome,
+		ToolsDir: filepath.Join(tsukuHome, "tools"),
+	}
+
+	mgr := install.New(cfg)
+
 	var missing []string
 	for _, dep := range deps {
-		if !isToolInstalled(toolsDir, dep) {
+		if !isToolInstalled(mgr, cfg, dep) {
 			missing = append(missing, dep)
 		}
 	}
 	return missing
 }
 
-// isToolInstalled checks if a tool is installed in the tools directory.
-// A tool is considered installed if there's a directory matching the pattern name-*.
-func isToolInstalled(toolsDir, name string) bool {
-	entries, err := os.ReadDir(toolsDir)
+// isToolInstalled reports whether some version of a tool is installed.
+//
+// The versions come from state. They must not come from the names of the
+// directories under $TSUKU_HOME/tools: those look like "<tool>-<version>" but
+// cannot be taken apart again, because the registry ships dozens of pairs
+// where one tool's name prefixes another's -- go/go-task, rust/rust-analyzer,
+// git/git-lfs. Strip "go-" off "go-task-3.44.0" and the remainder,
+// "task-3.44.0", is a perfectly good version string, so no lexical rule
+// separates another tool's installation from one of this tool's versions.
+// Matching the prefix reported go installed when the user had only go-task,
+// and plan generation went off to decompose against a Go toolchain that was
+// never there instead of offering to install one.
+//
+// State says which versions belong to the tool. The directory check says one
+// of them is still on disk, which is what the decomposer about to run the
+// binary needs to be true.
+func isToolInstalled(mgr *install.Manager, cfg *config.Config, name string) bool {
+	versions, err := mgr.InstalledVersions(name)
 	if err != nil {
 		return false
 	}
 
-	prefix := name + "-"
-	for _, entry := range entries {
-		if entry.IsDir() && strings.HasPrefix(entry.Name(), prefix) {
+	for _, version := range versions {
+		// Lstat, not Stat, and IsDir on top of it: that is what the ReadDir
+		// scan this replaced reported, since DirEntry.IsDir does not follow
+		// symlinks either. Nothing tsuku installs puts a symlink here -- the
+		// per-tool symlinks live under tools/current -- so following one
+		// would only widen what counts as installed.
+		if info, err := os.Lstat(cfg.ToolDir(name, version)); err == nil && info.IsDir() {
 			return true
 		}
 	}

--- a/internal/actions/eval_deps_test.go
+++ b/internal/actions/eval_deps_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/tsukumogami/tsuku/internal/config"
+	"github.com/tsukumogami/tsuku/internal/install"
 )
 
 func TestGetEvalDeps(t *testing.T) {
@@ -36,61 +39,207 @@ func TestGetEvalDeps(t *testing.T) {
 	}
 }
 
-func TestCheckEvalDeps_AllMissing(t *testing.T) {
-	t.Parallel()
-
-	// Use a temp directory that doesn't have any installed tools
-	toolsDir := t.TempDir()
-
-	deps := []string{"nodejs", "go"}
-	missing := checkEvalDepsInDir(deps, toolsDir)
-
-	if len(missing) != 2 {
-		t.Errorf("checkEvalDepsInDir() returned %d missing, want 2", len(missing))
+// testHome returns a config rooted at an empty tsuku home.
+func testHome(t *testing.T) *config.Config {
+	t.Helper()
+	home := t.TempDir()
+	return &config.Config{
+		HomeDir:  home,
+		ToolsDir: filepath.Join(home, "tools"),
 	}
 }
 
-func TestCheckEvalDeps_SomeInstalled(t *testing.T) {
-	t.Parallel()
-
-	// Use a temp directory with one installed tool
-	toolsDir := t.TempDir()
-	nodejsDir := filepath.Join(toolsDir, "nodejs-20.0.0")
-	if err := os.MkdirAll(nodejsDir, 0755); err != nil {
-		t.Fatalf("failed to create nodejs dir: %v", err)
+// installTool leaves a tool behind the way tsuku does when it installs an
+// eval-time dependency: a version directory under $TSUKU_HOME/tools and an
+// entry in state.json. Both halves matter -- the point of the check is that
+// the directory on its own does not make a tool installed.
+func installTool(t *testing.T, cfg *config.Config, name, version string) {
+	t.Helper()
+	if err := os.MkdirAll(cfg.ToolDir(name, version), 0o755); err != nil {
+		t.Fatalf("create %s-%s directory: %v", name, version, err)
 	}
-
-	deps := []string{"nodejs", "go"}
-	missing := checkEvalDepsInDir(deps, toolsDir)
-
-	if len(missing) != 1 {
-		t.Errorf("checkEvalDepsInDir() returned %d missing, want 1", len(missing))
-	}
-	if len(missing) > 0 && missing[0] != "go" {
-		t.Errorf("checkEvalDepsInDir() missing[0] = %q, want 'go'", missing[0])
+	if err := install.New(cfg).EnsureDependencyEntry(name, version, "", nil); err != nil {
+		t.Fatalf("record %s-%s in state: %v", name, version, err)
 	}
 }
 
-func TestCheckEvalDeps_AllInstalled(t *testing.T) {
+func assertMissing(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("missing = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("missing = %v, want %v", got, want)
+		}
+	}
+}
+
+// A tool whose name is a prefix of another tool's is not that other tool. The
+// registry ships dozens of these pairs, so "a directory starting with <dep>-"
+// was never a safe way to answer whether <dep> is installed.
+func TestCheckEvalDepsInHome_AsksStateNotDirectoryNames(t *testing.T) {
 	t.Parallel()
 
-	// Use a temp directory with both tools installed
-	toolsDir := t.TempDir()
-	nodejsDir := filepath.Join(toolsDir, "nodejs-20.0.0")
-	goDir := filepath.Join(toolsDir, "go-1.21.0")
-	if err := os.MkdirAll(nodejsDir, 0755); err != nil {
-		t.Fatalf("failed to create nodejs dir: %v", err)
-	}
-	if err := os.MkdirAll(goDir, 0755); err != nil {
-		t.Fatalf("failed to create go dir: %v", err)
+	type tool struct{ name, version string }
+
+	tests := []struct {
+		name        string
+		installed   []tool
+		deps        []string
+		wantMissing []string
+	}{
+		{
+			name:        "go-task does not satisfy go",
+			installed:   []tool{{"go-task", "3.44.0"}},
+			deps:        []string{"go"},
+			wantMissing: []string{"go"},
+		},
+		{
+			name:        "git-lfs does not satisfy git",
+			installed:   []tool{{"git-lfs", "3.5.0"}},
+			deps:        []string{"git"},
+			wantMissing: []string{"git"},
+		},
+		{
+			name:      "go satisfies go",
+			installed: []tool{{"go", "1.23.4"}},
+			deps:      []string{"go"},
+		},
+		{
+			name:      "go satisfies go with go-task alongside it",
+			installed: []tool{{"go", "1.23.4"}, {"go-task", "3.44.0"}},
+			deps:      []string{"go"},
+		},
+		{
+			name:        "nothing installed",
+			deps:        []string{"nodejs", "go"},
+			wantMissing: []string{"nodejs", "go"},
+		},
+		{
+			name:        "rust-analyzer does not satisfy rust, nodejs satisfies nodejs",
+			installed:   []tool{{"nodejs", "20.0.0"}, {"rust-analyzer", "2025.1.1"}},
+			deps:        []string{"nodejs", "rust"},
+			wantMissing: []string{"rust"},
+		},
 	}
 
-	deps := []string{"nodejs", "go"}
-	missing := checkEvalDepsInDir(deps, toolsDir)
-
-	if len(missing) != 0 {
-		t.Errorf("checkEvalDepsInDir() returned %d missing, want 0", len(missing))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := testHome(t)
+			for _, installed := range tc.installed {
+				installTool(t, cfg, installed.name, installed.version)
+			}
+			assertMissing(t, checkEvalDepsInHome(tc.deps, cfg.HomeDir), tc.wantMissing)
+		})
 	}
+}
+
+// State claiming a version whose directory is gone is not an installed tool.
+// The decomposer that runs next needs the binary, so reporting the dependency
+// missing is what gets it reinstalled instead of failing mid-decomposition.
+func TestCheckEvalDepsInHome_StateWithoutDirectory(t *testing.T) {
+	t.Parallel()
+
+	cfg := testHome(t)
+	installTool(t, cfg, "go", "1.23.4")
+	if err := os.RemoveAll(cfg.ToolDir("go", "1.23.4")); err != nil {
+		t.Fatalf("remove go directory: %v", err)
+	}
+
+	assertMissing(t, checkEvalDepsInHome([]string{"go"}, cfg.HomeDir), []string{"go"})
+}
+
+// A directory with no state entry behind it is not an installed tool either.
+// That is the shape a hand-made directory leaves, and it is also all the old
+// prefix match was ever really keying on.
+func TestCheckEvalDepsInHome_DirectoryWithoutState(t *testing.T) {
+	t.Parallel()
+
+	cfg := testHome(t)
+	if err := os.MkdirAll(cfg.ToolDir("go", "1.23.4"), 0o755); err != nil {
+		t.Fatalf("create go directory: %v", err)
+	}
+
+	assertMissing(t, checkEvalDepsInHome([]string{"go"}, cfg.HomeDir), []string{"go"})
+}
+
+// Only a real directory at $TSUKU_HOME/tools/<tool>-<version> counts, which
+// is what the ReadDir scan this replaced reported: DirEntry.IsDir is false for
+// a plain file and does not follow symlinks.
+func TestCheckEvalDepsInHome_OnlyARealDirectoryCounts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		place func(t *testing.T, path string)
+	}{
+		{
+			name: "a file where the version directory should be",
+			place: func(t *testing.T, path string) {
+				if err := os.WriteFile(path, []byte("not a tool"), 0o644); err != nil {
+					t.Fatalf("write %s: %v", path, err)
+				}
+			},
+		},
+		{
+			name: "a symlink where the version directory should be",
+			place: func(t *testing.T, path string) {
+				target := filepath.Join(t.TempDir(), "elsewhere")
+				if err := os.MkdirAll(target, 0o755); err != nil {
+					t.Fatalf("create %s: %v", target, err)
+				}
+				if err := os.Symlink(target, path); err != nil {
+					t.Fatalf("symlink %s: %v", path, err)
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := testHome(t)
+			installTool(t, cfg, "go", "1.23.4")
+			if err := os.RemoveAll(cfg.ToolDir("go", "1.23.4")); err != nil {
+				t.Fatalf("remove go directory: %v", err)
+			}
+			tc.place(t, cfg.ToolDir("go", "1.23.4"))
+
+			assertMissing(t, checkEvalDepsInHome([]string{"go"}, cfg.HomeDir), []string{"go"})
+		})
+	}
+}
+
+// A state file that cannot be read answers nothing, and nothing is not
+// "installed". Reporting the dependency satisfied here would put the caller
+// back where the prefix match left it: decomposing against a binary no one
+// established was there.
+func TestCheckEvalDepsInHome_UnreadableState(t *testing.T) {
+	t.Parallel()
+
+	cfg := testHome(t)
+	installTool(t, cfg, "go", "1.23.4")
+	if err := os.WriteFile(filepath.Join(cfg.HomeDir, "state.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("corrupt state.json: %v", err)
+	}
+
+	assertMissing(t, checkEvalDepsInHome([]string{"go"}, cfg.HomeDir), []string{"go"})
+}
+
+// The exported entry point reads $TSUKU_HOME, so drive it that way once.
+func TestCheckEvalDeps_ResolvesTsukuHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("TSUKU_HOME", home)
+
+	cfg := &config.Config{HomeDir: home, ToolsDir: filepath.Join(home, "tools")}
+
+	installTool(t, cfg, "go-task", "3.44.0")
+	assertMissing(t, CheckEvalDeps([]string{"go"}), []string{"go"})
+
+	installTool(t, cfg, "go", "1.23.4")
+	assertMissing(t, CheckEvalDeps([]string{"go"}), nil)
 }
 
 func TestCheckEvalDeps_EmptyList(t *testing.T) {
@@ -104,32 +253,6 @@ func TestCheckEvalDeps_EmptyList(t *testing.T) {
 	missing = CheckEvalDeps([]string{})
 	if missing != nil {
 		t.Errorf("CheckEvalDeps([]) = %v, want nil", missing)
-	}
-}
-
-func TestIsToolInstalled(t *testing.T) {
-	t.Parallel()
-
-	// Create temp directory with a tool
-	tmpDir := t.TempDir()
-	nodejsDir := filepath.Join(tmpDir, "nodejs-20.0.0")
-	if err := os.MkdirAll(nodejsDir, 0755); err != nil {
-		t.Fatalf("failed to create nodejs dir: %v", err)
-	}
-
-	// Test installed tool
-	if !isToolInstalled(tmpDir, "nodejs") {
-		t.Error("isToolInstalled() = false, want true for installed nodejs")
-	}
-
-	// Test not installed tool
-	if isToolInstalled(tmpDir, "go") {
-		t.Error("isToolInstalled() = true, want false for missing go")
-	}
-
-	// Test non-existent directory
-	if isToolInstalled("/nonexistent/path", "nodejs") {
-		t.Error("isToolInstalled() = true, want false for non-existent directory")
 	}
 }
 
@@ -149,43 +272,5 @@ func TestGetEvalDeps_KnownAction(t *testing.T) {
 	// gem_install has ruby as eval-time dep
 	if len(deps) == 0 {
 		t.Error("GetEvalDeps(gem_install) should return eval-time deps")
-	}
-}
-
-// -- eval_deps.go: CheckEvalDeps --
-
-func TestCheckEvalDeps_EmptyDeps(t *testing.T) {
-	t.Parallel()
-	result := CheckEvalDeps(nil)
-	if result != nil {
-		t.Errorf("CheckEvalDeps(nil) = %v, want nil", result)
-	}
-}
-
-// -- eval_deps.go: checkEvalDepsInDir additional paths --
-
-func TestCheckEvalDepsInDir_MixedInstalled(t *testing.T) {
-	t.Parallel()
-	tmpDir := t.TempDir()
-
-	if err := os.MkdirAll(filepath.Join(tmpDir, "go-1.21.0"), 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Join(tmpDir, "rust-1.76.0"), 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	missing := checkEvalDepsInDir([]string{"go", "python", "rust"}, tmpDir)
-	if len(missing) != 1 || missing[0] != "python" {
-		t.Errorf("checkEvalDepsInDir() = %v, want [python]", missing)
-	}
-}
-
-func TestCheckEvalDepsInDir_EmptyDir(t *testing.T) {
-	t.Parallel()
-	tmpDir := t.TempDir()
-	missing := checkEvalDepsInDir([]string{"go"}, tmpDir)
-	if len(missing) != 1 {
-		t.Errorf("checkEvalDepsInDir() = %v, want [go]", missing)
 	}
 }

--- a/internal/actions/eval_deps_test.go
+++ b/internal/actions/eval_deps_test.go
@@ -102,6 +102,16 @@ func TestCheckEvalDepsInHome_AsksStateNotDirectoryNames(t *testing.T) {
 			wantMissing: []string{"git"},
 		},
 		{
+			name:      "git satisfies git",
+			installed: []tool{{"git", "2.47.1"}},
+			deps:      []string{"git"},
+		},
+		{
+			name:      "git satisfies git with git-lfs alongside it",
+			installed: []tool{{"git", "2.47.1"}, {"git-lfs", "3.5.0"}},
+			deps:      []string{"git"},
+		},
+		{
 			name:      "go satisfies go",
 			installed: []tool{{"go", "1.23.4"}},
 			deps:      []string{"go"},

--- a/internal/executor/eval_deps_gate_test.go
+++ b/internal/executor/eval_deps_gate_test.go
@@ -1,0 +1,113 @@
+package executor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tsukumogami/tsuku/internal/actions"
+	"github.com/tsukumogami/tsuku/internal/config"
+	"github.com/tsukumogami/tsuku/internal/install"
+	"github.com/tsukumogami/tsuku/internal/recipe"
+)
+
+// installUnderHome leaves a tool behind the way tsuku does: a version
+// directory under $TSUKU_HOME/tools and an entry in state.json.
+func installUnderHome(t *testing.T, home, name, version string) {
+	t.Helper()
+	cfg := &config.Config{HomeDir: home, ToolsDir: filepath.Join(home, "tools")}
+	if err := os.MkdirAll(cfg.ToolDir(name, version), 0o755); err != nil {
+		t.Fatalf("create %s-%s directory: %v", name, version, err)
+	}
+	if err := install.New(cfg).EnsureDependencyEntry(name, version, "", nil); err != nil {
+		t.Fatalf("record %s-%s in state: %v", name, version, err)
+	}
+}
+
+func goInstallStep() recipe.Step {
+	return recipe.Step{
+		Action: "go_install",
+		Params: map[string]interface{}{
+			"module":      "github.com/example/tool",
+			"executables": []interface{}{"tool"},
+		},
+	}
+}
+
+// The eval-deps gate is what stands between a user who has not installed go
+// and a decomposition that shells out to it. go_install declares go as an
+// eval-time dependency, and go-task is a real registry entry whose name starts
+// with "go-", so a user who installed go-task and not go used to walk straight
+// past this gate. What they got was a decomposition failure; what they should
+// get is the offer to install go.
+//
+// resolveStep is called directly rather than through GeneratePlan because
+// GeneratePlan resolves a version over the network first. Nothing on the
+// Executor is read before the gate.
+func TestResolveStep_PrefixSharingToolDoesNotSatisfyEvalDep(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("TSUKU_HOME", home)
+	installUnderHome(t, home, "go-task", "3.44.0")
+
+	var offered []string
+	autoAccept := false
+	cfg := PlanConfig{
+		AutoAcceptEvalDeps: true,
+		OnEvalDepsNeeded: func(deps []string, auto bool) error {
+			offered = append(offered, deps...)
+			autoAccept = auto
+			// Stand in for the user declining, or the install failing. Either
+			// way resolveStep must stop rather than decompose.
+			return errors.New("declined")
+		},
+	}
+
+	e := &Executor{}
+	_, err := e.resolveStep(context.Background(), goInstallStep(), nil, nil, cfg, &actions.EvalContext{VersionTag: "v1.0.0"})
+
+	if err == nil {
+		t.Fatal("resolveStep decomposed go_install with go missing")
+	}
+	if !strings.Contains(err.Error(), "eval-time dependencies not satisfied") {
+		t.Errorf("resolveStep error = %q, want the eval-deps surface", err)
+	}
+	if len(offered) != 1 || offered[0] != "go" {
+		t.Errorf("offered to install %v, want [go]", offered)
+	}
+	if !autoAccept {
+		t.Error("the install path auto-accepts eval deps; the callback was told otherwise")
+	}
+}
+
+// The other half: go itself still satisfies the dependency, with the
+// prefix-sharing neighbor installed alongside it. Decomposition goes ahead
+// and fails on its own terms -- the fixture has no real Go toolchain in it --
+// which is fine. What matters is that the gate did not stop it.
+func TestResolveStep_InstalledEvalDepPassesTheGate(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("TSUKU_HOME", home)
+	installUnderHome(t, home, "go-task", "3.44.0")
+	installUnderHome(t, home, "go", "1.23.4")
+
+	called := false
+	cfg := PlanConfig{
+		AutoAcceptEvalDeps: true,
+		OnEvalDepsNeeded: func(deps []string, auto bool) error {
+			called = true
+			return nil
+		},
+	}
+
+	e := &Executor{}
+	_, err := e.resolveStep(context.Background(), goInstallStep(), nil, nil, cfg, &actions.EvalContext{VersionTag: "v1.0.0"})
+
+	if called {
+		t.Error("resolveStep asked to install go while go was installed")
+	}
+	if err != nil && strings.Contains(err.Error(), "eval-time dependencies not satisfied") {
+		t.Errorf("resolveStep error = %q, want the gate to have passed", err)
+	}
+}

--- a/plugins/tsuku-recipes/skills/recipe-test/SKILL.md
+++ b/plugins/tsuku-recipes/skills/recipe-test/SKILL.md
@@ -135,6 +135,8 @@ export TSUKU_HOME=$(mktemp -d)
 
 **Exit code 8 -- dependency failed.** A required dependency isn't available or its recipe is broken. Test the dependency in isolation: `tsuku eval <dep>`.
 
+**"go not found" (or cargo, or python) during eval, with the toolchain apparently installed.** Eval-time dependency detection asks tsuku's state which tools are installed; it does not read directory names under `$TSUKU_HOME/tools`. A toolchain staged there by hand is not installed as far as `tsuku eval` is concerned, and neither is a tool whose name merely starts the same way -- `go-task` is not `go`. Install the dependency with `tsuku install <dep>`, or let `--install-deps` do it.
+
 **Sandbox won't start.** Docker/Podman not running or not in PATH. Run `docker --version` or `podman --version` to confirm. Sandbox failures typically surface as exit code 6 (installation failed).
 
 **Verification fails after successful install.** Run the tool manually (e.g., `my-tool --version`) to see what it actually prints. Then update the recipe's `[verify]` section: set `command` to the correct binary, `pattern` to match the actual output format, and add `strip_v = true` if the tool prints a `v` prefix. Check that `verify.command` matches the installed binary name and that it lands on PATH.


### PR DESCRIPTION
The eval-time dependency check decided a tool was installed by scanning
`$TSUKU_HOME/tools` for any directory starting with `<tool>-`, so a user who had
go-task and not go passed the check that exists to offer them go. Eleven `go-*`
recipes ship in the registry, plus rust-analyzer against rust.

The remainder after the prefix cannot be validated back into a version --
`task-3.44.0` is a perfectly good version string -- so `isToolInstalled` stops
parsing directory names. It asks `Manager.InstalledVersions` which versions state
records for the tool, rebuilds each directory name from the (tool, version) pair
the way `Config.ToolDir` does, and reports installed when one of those is on disk.
The name is no longer an input.

The test seam moves with it, from `checkEvalDepsInDir` to `checkEvalDepsInHome`,
because state.json and the tools directory both hang off the home. The home still
comes from `resolveTsukuHome`, the same source `GetToolsDir` uses, so this check
and the resolvers it guards read one directory.

Two cases the prefix match got wrong in the other direction now report missing as
well: a state entry whose directory has been deleted, and a directory with no
state entry behind it. Both are tools the decomposer could not have run.

---

Fixes #2480

## The consequence, checked

The issue says a false positive means the "install with: `tsuku install X`" prompt
never fires. That is right, and the sharper version is worth stating: on the
install path there is no prompt to suppress. `cmd/tsuku/helpers.go:244` and
`cmd/tsuku/install_deps.go:143` both set `AutoAcceptEvalDeps: true`, so a missing
eval dependency is normally installed for the user without asking. The false
positive turns that silent recovery into a hard failure.

Traced end to end for `go`: `resolveStep` calls `CheckEvalDeps`, which said go was
installed because `go-task-3.44.0` was on disk; decomposition then ran and
`ResolveGo` returned `""`, because it happens to carry its own guard requiring a
digit after `go-`. The user got `go not found: install go first (tsuku install go)`
out of plan generation, having never been offered the install that would have
fixed it. `ResolveCargo` has no such guard, which is a separate defect --
see below.

Which dependencies can actually reach this: the registry's eval-time deps are go,
nodejs, rust, ruby and python-standalone. Of those, go and rust have
prefix-sharing registry entries (eleven `go-*` recipes, and rust-analyzer). The
issue's git/git-lfs pair is not itself an eval dependency, so the regression test
covers both -- go/go-task for the reachable path and git/git-lfs for the
acceptance criterion as written.

## The decision, and the alternative

Same conclusion as #2474: validating the remainder after `<tool>-` cannot work,
because `ValidateVersionString` accepts `[a-zA-Z0-9._+\-@/]+` and any stricter
rule has to invent a version shape. So this asks state, exactly as
`GarbageCollectVersions` now does.

Whether state alone is enough was the one real choice. It is not, and the
directory check stays: a version state records with no directory on disk is a
tool the decomposer cannot run, and reporting it installed would land the user
back in the failure this fixes. State answers which directories belong to the
tool; the filesystem answers whether one is there.

The home comes from `resolveTsukuHome` rather than `config.DefaultConfig` so this
check reads the same directory as the resolvers it gates. That source ignores
`config.DefaultHomeOverride`, which is a real divergence but a pre-existing one --
filed as #2501 rather than widened into this PR.

## Mutation testing

Five defects injected one at a time, each reverted after:

| Defect | Test that failed |
|---|---|
| Restore the `strings.HasPrefix(entry.Name(), name+"-")` scan | `TestCheckEvalDepsInHome_AsksStateNotDirectoryNames` (go-task, git-lfs, rust-analyzer subtests), `TestCheckEvalDepsInHome_DirectoryWithoutState`, `TestCheckEvalDeps_ResolvesTsukuHome`, `TestResolveStep_PrefixSharingToolDoesNotSatisfyEvalDep` |
| Trust state, drop the on-disk check | `TestCheckEvalDepsInHome_StateWithoutDirectory`, `TestCheckEvalDepsInHome_OnlyARealDirectoryCounts` (both subtests) |
| `os.Lstat` to `os.Stat` (follow symlinks) | `TestCheckEvalDepsInHome_OnlyARealDirectoryCounts/a_symlink_where_the_version_directory_should_be` |
| Drop the `info.IsDir()` guard | `TestCheckEvalDepsInHome_OnlyARealDirectoryCounts` (both subtests) |
| A state read error reports the tool installed | `TestCheckEvalDepsInHome_UnreadableState` |

The unreadable-state case was added because of this pass: the first suite let that
mutant live, since nothing drove `InstalledVersions` to an error.

## Found while working, filed rather than fixed

- **#2500** -- `ResolveCargo` picks the lexicographically last `rust-*` directory,
  and `rust-analyzer-2025.1.1` sorts after `rust-1.80.0`. Confirmed against a
  temporary `$TSUKU_HOME`: cargo is found with rust alone and lost the moment
  rust-analyzer is installed next to it, so every cargo recipe breaks for a user
  whose Rust toolchain is fine. `ResolveGo`'s digit heuristic is the only thing
  protecting the go path from the same shape.
- **#2501** -- `internal/actions` resolves `$TSUKU_HOME` itself and ignores
  `config.DefaultHomeOverride`, so a `make build` binary installs into
  `.tsuku-dev` and looks for tools in `~/.tsuku`.

## Skills

`internal/actions` is on the plugin-maintenance list. No action names, parameters
or `Dependencies()` results change here, so nothing tsuku-recipe-author documents
moved. One behavior does narrow for recipe authors: a toolchain staged into
`$TSUKU_HOME/tools` by hand is no longer seen as installed. Added to
tsuku-recipe-test's failure patterns, next to the other "it looks installed but
isn't" entries.

## Golden plans

Not armed. `.github/workflows/validate-golden-code.yml` triggers on a path
allowlist that names `internal/actions/decomposable.go`, `action.go`,
`composites.go`, `download.go` and the package-manager decomposers; `eval_deps.go`
is not among them, and neither are the two test files.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l`, `golangci-lint run ./...` and
`go test ./... -short` all clean on this branch.
