### PR TITLE
fix(actions): stop accepting fish in install_shell_init

### DIFF
--- a/internal/actions/completions.go
+++ b/internal/actions/completions.go
@@ -8,6 +8,21 @@ import (
 	"strings"
 )
 
+// completionShells is the hardcoded allowlist for install_completions' shell
+// values. Arbitrary strings are rejected to prevent template injection.
+//
+// fish belongs here even though install_shell_init declines it. What rules fish
+// out there is the POSIX init cache every fragment has to pass through;
+// completions are written as standalone per-shell files and never touch it, so
+// that constraint does not apply. Note this says nothing about whether a shell
+// ever finds the file -- nothing currently puts share/completions on any
+// lookup path. See #2520.
+var completionShells = map[string]bool{
+	"bash": true,
+	"zsh":  true,
+	"fish": true,
+}
+
 // InstallCompletionsAction copies a source file or runs a source command
 // to produce shell completion scripts at
 // $TSUKU_HOME/share/completions/{shell}/{target} for each configured shell.
@@ -42,7 +57,7 @@ func (a *InstallCompletionsAction) Preflight(params map[string]interface{}) *Pre
 
 	if shells, ok := GetStringSlice(params, "shells"); ok {
 		for _, s := range shells {
-			if !allowedShells[s] {
+			if !completionShells[s] {
 				result.AddErrorf("install_completions: invalid shell %q (allowed: bash, zsh, fish)", s)
 			}
 		}
@@ -68,7 +83,7 @@ func (a *InstallCompletionsAction) Execute(ctx *ExecutionContext, params map[str
 	shells := defaultShells
 	if s, ok := GetStringSlice(params, "shells"); ok && len(s) > 0 {
 		for _, sh := range s {
-			if !allowedShells[sh] {
+			if !completionShells[sh] {
 				return fmt.Errorf("install_completions: invalid shell %q (allowed: bash, zsh, fish)", sh)
 			}
 		}

--- a/internal/actions/completions_test.go
+++ b/internal/actions/completions_test.go
@@ -513,3 +513,55 @@ func TestCompletionFileName(t *testing.T) {
 		})
 	}
 }
+
+// TestInstallCompletionsAction_StillAcceptsFish guards the narrowing done for
+// issue #2471. install_shell_init dropped fish because init fragments only
+// reach a shell through the POSIX init cache; a completion script has no such
+// constraint, so fish must keep working here. If a future change shares one
+// allowlist between the two actions again, this fails.
+func TestInstallCompletionsAction_StillAcceptsFish(t *testing.T) {
+	a := &InstallCompletionsAction{}
+
+	tsukuHome := t.TempDir()
+	toolsDir := filepath.Join(tsukuHome, "tools")
+	toolInstallDir := filepath.Join(toolsDir, "gh-2.0")
+	if err := os.MkdirAll(toolInstallDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	completionBody := "complete -c gh\n"
+	if err := os.WriteFile(filepath.Join(toolInstallDir, "gh.fish"), []byte(completionBody), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := &ExecutionContext{
+		Version:        "2.0.0",
+		InstallDir:     toolInstallDir,
+		ToolInstallDir: toolInstallDir,
+		ToolsDir:       toolsDir,
+	}
+
+	if err := a.Execute(ctx, map[string]interface{}{
+		"source_file": "gh.fish",
+		"target":      "gh",
+		"shells":      []interface{}{"fish"},
+	}); err != nil {
+		t.Fatalf("install_completions should still accept fish: %v", err)
+	}
+
+	fishPath := filepath.Join(tsukuHome, "share", "completions", "fish", "gh")
+	content, err := os.ReadFile(fishPath)
+	if err != nil {
+		t.Fatalf("expected fish completion at %s: %v", fishPath, err)
+	}
+	if string(content) != completionBody {
+		t.Errorf("fish completion content = %q, want %q", string(content), completionBody)
+	}
+
+	if result := a.Preflight(map[string]interface{}{
+		"source_file": "gh.fish",
+		"target":      "gh",
+		"shells":      []interface{}{"fish"},
+	}); result.HasErrors() {
+		t.Errorf("Preflight should still accept fish for completions: %v", result.Errors)
+	}
+}

--- a/internal/actions/shell_init.go
+++ b/internal/actions/shell_init.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,12 +13,31 @@ import (
 	"strings"
 )
 
-// allowedShells is the hardcoded allowlist for shell values.
-// Arbitrary strings are rejected to prevent template injection.
-var allowedShells = map[string]bool{
+// shellInitShells is the hardcoded allowlist for install_shell_init's shell
+// values. Arbitrary strings are rejected to prevent template injection.
+//
+// fish is absent for the same reason it is absent from set_env's envShells:
+// fragments only reach a shell through the init cache, and the file that
+// sources that cache -- config.EnvFileContent, written to $TSUKU_HOME/env --
+// is POSIX shell that fish cannot parse. A fish fragment would be written,
+// hashed, and never loaded. Accepting the value would advertise support the
+// delivery path does not have, so it is rejected at validation instead.
+var shellInitShells = map[string]bool{
 	"bash": true,
 	"zsh":  true,
-	"fish": true,
+}
+
+// shellInitShellError explains a rejected shell value. fish gets a message
+// naming what does work, because a recipe author reaching for it has a real
+// need that other parts of tsuku do serve; anything else is a typo and only
+// needs the allowed set.
+func shellInitShellError(shell string) string {
+	if shell == "fish" {
+		return fmt.Sprintf("install_shell_init: shell %q is not supported (allowed: bash, zsh) -- "+
+			"init fragments load from the cache that $TSUKU_HOME/env sources, which is POSIX shell fish cannot parse. "+
+			"fish users get tsuku on PATH with 'tsuku shellenv | source', and install_completions still accepts fish", shell)
+	}
+	return fmt.Sprintf("install_shell_init: invalid shell %q (allowed: bash, zsh)", shell)
 }
 
 // shellDTargetPattern constrains the target segment of a shell.d filename.
@@ -89,8 +109,8 @@ func (a *InstallShellInitAction) Preflight(params map[string]interface{}) *Prefl
 	// Validate shells if provided
 	if shells, ok := GetStringSlice(params, "shells"); ok {
 		for _, s := range shells {
-			if !allowedShells[s] {
-				result.AddErrorf("install_shell_init: invalid shell %q (allowed: bash, zsh, fish)", s)
+			if !shellInitShells[s] {
+				result.AddError(shellInitShellError(s))
 			}
 		}
 	}
@@ -131,8 +151,8 @@ func (a *InstallShellInitAction) Execute(ctx *ExecutionContext, params map[strin
 	shells := defaultShells
 	if s, ok := GetStringSlice(params, "shells"); ok && len(s) > 0 {
 		for _, sh := range s {
-			if !allowedShells[sh] {
-				return fmt.Errorf("install_shell_init: invalid shell %q (allowed: bash, zsh, fish)", sh)
+			if !shellInitShells[sh] {
+				return errors.New(shellInitShellError(sh))
 			}
 		}
 		shells = s

--- a/internal/actions/shell_init_test.go
+++ b/internal/actions/shell_init_test.go
@@ -89,7 +89,7 @@ func TestInstallShellInitAction_Preflight(t *testing.T) {
 		result := a.Preflight(map[string]interface{}{
 			"source_command": "niwa shell-init {shell}",
 			"target":         "niwa",
-			"shells":         []interface{}{"bash", "zsh", "fish"},
+			"shells":         []interface{}{"bash", "zsh"},
 		})
 		if result.HasErrors() {
 			t.Errorf("unexpected errors: %v", result.Errors)
@@ -313,7 +313,7 @@ func TestInstallShellInitAction_Execute_SourceCommand(t *testing.T) {
 		params := map[string]interface{}{
 			"source_command": "{install_dir}/mytool {shell} {install_dir}",
 			"target":         "mytool",
-			"shells":         []interface{}{"fish"},
+			"shells":         []interface{}{"zsh"},
 		}
 
 		if err := a.Execute(ctx, params); err != nil {
@@ -321,11 +321,11 @@ func TestInstallShellInitAction_Execute_SourceCommand(t *testing.T) {
 		}
 
 		shellDDir := filepath.Join(tsukuHome, "share", "shell.d")
-		content, err := os.ReadFile(filepath.Join(shellDDir, "mytool@1.2.3.fish"))
+		content, err := os.ReadFile(filepath.Join(shellDDir, "mytool@1.2.3.zsh"))
 		if err != nil {
 			t.Fatal(err)
 		}
-		expected := "shell=fish dir=" + toolInstallDir + "\n"
+		expected := "shell=zsh dir=" + toolInstallDir + "\n"
 		if string(content) != expected {
 			t.Errorf("expected %q, got %q", expected, string(content))
 		}
@@ -681,7 +681,7 @@ func TestInstallShellInitAction_RecordsCleanupActions_SourceCommand(t *testing.T
 	params := map[string]interface{}{
 		"source_command": "{install_dir}/mytool {shell}",
 		"target":         "mytool",
-		"shells":         []interface{}{"bash", "fish"},
+		"shells":         []interface{}{"bash", "zsh"},
 	}
 
 	if err := a.Execute(ctx, params); err != nil {
@@ -694,7 +694,7 @@ func TestInstallShellInitAction_RecordsCleanupActions_SourceCommand(t *testing.T
 
 	expected := []CleanupAction{
 		{Action: "delete_file", Path: "share/shell.d/mytool@1.2.3.bash"},
-		{Action: "delete_file", Path: "share/shell.d/mytool@1.2.3.fish"},
+		{Action: "delete_file", Path: "share/shell.d/mytool@1.2.3.zsh"},
 	}
 
 	for i, ca := range ctx.CleanupActions {
@@ -1040,5 +1040,151 @@ func TestInstallShellInitAction_NoShellInit_SourceCommand(t *testing.T) {
 	// No cleanup actions should be recorded
 	if len(ctx.CleanupActions) != 0 {
 		t.Errorf("expected 0 cleanup actions when NoShellInit is set, got %d", len(ctx.CleanupActions))
+	}
+}
+
+// TestInstallShellInitAction_ShellAllowlist pins which shells the action
+// accepts. fish is rejected because a fish fragment would be written and never
+// loaded: the init cache reaches a shell only through $TSUKU_HOME/env, which is
+// POSIX shell fish cannot parse. See issue #2471.
+func TestInstallShellInitAction_ShellAllowlist(t *testing.T) {
+	a := &InstallShellInitAction{}
+
+	tests := []struct {
+		name        string
+		shell       string
+		wantErr     bool
+		wantMessage []string
+	}{
+		{name: "bash accepted", shell: "bash", wantErr: false},
+		{name: "zsh accepted", shell: "zsh", wantErr: false},
+		{
+			name:    "fish rejected with a pointer to what works",
+			shell:   "fish",
+			wantErr: true,
+			// The message has to name the alternative, not just say no.
+			wantMessage: []string{"fish", "bash, zsh", "tsuku shellenv", "install_completions"},
+		},
+		{
+			name:        "unknown shell rejected with the allowed set",
+			shell:       "powershell",
+			wantErr:     true,
+			wantMessage: []string{"powershell", "bash, zsh"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := a.Preflight(map[string]interface{}{
+				"source_file": "init.sh",
+				"target":      "mytool",
+				"shells":      []interface{}{tt.shell},
+			})
+
+			if !tt.wantErr {
+				if result.HasErrors() {
+					t.Fatalf("shell %q should be accepted, got errors: %v", tt.shell, result.Errors)
+				}
+				return
+			}
+
+			if !result.HasErrors() {
+				t.Fatalf("shell %q should be rejected, got no errors", tt.shell)
+			}
+			joined := strings.Join(result.Errors, "\n")
+			for _, want := range tt.wantMessage {
+				if !strings.Contains(joined, want) {
+					t.Errorf("error message should mention %q, got: %s", want, joined)
+				}
+			}
+		})
+	}
+}
+
+// TestInstallShellInitAction_Execute_RejectsFish drives Execute rather than
+// Preflight, and asserts the outcome a recipe author would see: no fragment on
+// disk and no cleanup action recorded. Checking only the returned error would
+// not catch a guard that rejects after already writing the file.
+func TestInstallShellInitAction_Execute_RejectsFish(t *testing.T) {
+	a := &InstallShellInitAction{}
+
+	tsukuHome := t.TempDir()
+	toolsDir := filepath.Join(tsukuHome, "tools")
+	toolInstallDir := filepath.Join(toolsDir, "mytool-1.0")
+	if err := os.MkdirAll(toolInstallDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	srcPath := filepath.Join(toolInstallDir, "init.sh")
+	if err := os.WriteFile(srcPath, []byte("# init\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := &ExecutionContext{
+		Version:        "1.2.3",
+		InstallDir:     toolInstallDir,
+		ToolInstallDir: toolInstallDir,
+		ToolsDir:       toolsDir,
+	}
+
+	err := a.Execute(ctx, map[string]interface{}{
+		"source_file": "init.sh",
+		"target":      "mytool",
+		"shells":      []interface{}{"fish"},
+	})
+	if err == nil {
+		t.Fatal("Execute should reject shells = [fish]")
+	}
+	if !strings.Contains(err.Error(), "tsuku shellenv") {
+		t.Errorf("error should point at the supported fish path, got: %v", err)
+	}
+
+	fragment := filepath.Join(tsukuHome, "share", "shell.d", "mytool@1.2.3.fish")
+	if _, statErr := os.Stat(fragment); !os.IsNotExist(statErr) {
+		t.Errorf("no fish fragment should be written, but %s exists", fragment)
+	}
+	if len(ctx.CleanupActions) != 0 {
+		t.Errorf("no cleanup action should be recorded, got %d: %v", len(ctx.CleanupActions), ctx.CleanupActions)
+	}
+}
+
+// TestInstallShellInitAction_Execute_RejectsFishAlongsideValidShell covers the
+// mixed list. A recipe asking for bash and fish must be rejected outright
+// rather than silently installing the bash half.
+func TestInstallShellInitAction_Execute_RejectsFishAlongsideValidShell(t *testing.T) {
+	a := &InstallShellInitAction{}
+
+	tsukuHome := t.TempDir()
+	toolsDir := filepath.Join(tsukuHome, "tools")
+	toolInstallDir := filepath.Join(toolsDir, "mytool-1.0")
+	if err := os.MkdirAll(toolInstallDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(toolInstallDir, "init.sh"), []byte("# init\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := &ExecutionContext{
+		Version:        "1.2.3",
+		InstallDir:     toolInstallDir,
+		ToolInstallDir: toolInstallDir,
+		ToolsDir:       toolsDir,
+	}
+
+	if err := a.Execute(ctx, map[string]interface{}{
+		"source_file": "init.sh",
+		"target":      "mytool",
+		"shells":      []interface{}{"bash", "fish"},
+	}); err == nil {
+		t.Fatal("Execute should reject a shells list containing fish")
+	}
+
+	shellDDir := filepath.Join(tsukuHome, "share", "shell.d")
+	for _, name := range []string{"mytool@1.2.3.bash", "mytool@1.2.3.fish"} {
+		if _, err := os.Stat(filepath.Join(shellDDir, name)); !os.IsNotExist(err) {
+			t.Errorf("nothing should be written when the shells list is invalid, but %s exists", name)
+		}
+	}
+	if len(ctx.CleanupActions) != 0 {
+		t.Errorf("no cleanup action should be recorded, got %d", len(ctx.CleanupActions))
 	}
 }

--- a/plugins/tsuku-recipes/skills/recipe-author/references/action-reference.md
+++ b/plugins/tsuku-recipes/skills/recipe-author/references/action-reference.md
@@ -582,12 +582,24 @@ Writes shell initialization scripts (sourced on shell startup) to
 | `source_file` | string | Mutual | Path to init script, relative to the tool's install dir |
 | `source_command` | string | Mutual | Command that outputs the init script; supports `{shell}` and `{install_dir}` |
 | `target` | string | Yes | Target name for the init file |
-| `shells` | []string | No | Shell types: `bash`, `zsh`, `fish` (default: bash, zsh) |
+| `shells` | []string | No | Shell types: `bash`, `zsh` (default: bash, zsh) |
 
 Exactly one of `source_file` and `source_command` is required. `source_command`
 needs `phase = "post-install"`: the executable has to resolve inside the tool's
 permanent directory, and the action rejects anything outside it. `source_file`
 copies out of the staging directory and works in either phase.
+
+**bash and zsh only — same limit `set_env` has.** A fragment reaches a shell only
+through the init cache, and the file that sources that cache,
+`$TSUKU_HOME/env`, is POSIX shell fish cannot parse. `shells = ["fish"]` is
+rejected at validation rather than accepted into a file nothing would load. fish
+users still get tsuku on PATH with `tsuku shellenv | source`.
+
+`install_completions` does still accept fish, because completions are written as
+standalone per-shell files and never pass through the POSIX cache that rules
+fish out here. Be aware that is a statement about what the action accepts, not a
+promise the shell will find the file — nothing currently puts
+`share/completions` on any shell's lookup path (#2520).
 
 **Output path and version keying.** Each installed version gets its own fragment.
 `nvm` at 0.40.5 and 0.40.6 write `nvm@0.40.5.bash` and `nvm@0.40.6.bash`, so a

--- a/plugins/tsuku-user/skills/tsuku-user/SKILL.md
+++ b/plugins/tsuku-user/skills/tsuku-user/SKILL.md
@@ -155,6 +155,8 @@ tsuku shellenv | source
 
 `tsuku shellenv` prints the PATH exports and sources the shell init cache for your shell.
 
+On fish this gets you PATH. Tool-specific shell init — the next section — is bash and zsh only.
+
 ### Tool-Specific Shell Init
 
 Some tools need more than PATH — nvm is a shell function, direnv installs a hook, and a recipe can export variables the tool reads at startup. Those land in `$TSUKU_HOME/share/shell.d/`, one fragment per tool version per shell, named `<target>@<version>.<shell>`:
@@ -170,6 +172,8 @@ share/shell.d/
 Your shell never sources those fragments directly. tsuku concatenates them in filename order into `.init-cache.{bash,zsh}`, and `$TSUKU_HOME/env` sources the cache. Only the active version's fragment goes in — install 0.40.6 alongside 0.40.5 and the older fragment stays on disk but drops out of the cache. Anything tsuku has no record of is included as-is, so a fragment you dropped in yourself keeps working.
 
 The cache is rebuilt whenever the active version changes: install, upgrade, `activate`, `rollback`, and removing one version among several.
+
+**bash and zsh only.** Recipes can target those two shells for init fragments, and nothing else. The cache is plain POSIX shell and it reaches you through `$TSUKU_HOME/env`, which fish can't parse — so rather than write a fish fragment nothing would load, tsuku rejects `shells = ["fish"]` when a recipe is validated. On fish you still get PATH from `tsuku shellenv | source`. What you don't get is a tool's own startup script, so something like nvm — which only exists as a shell function the fragment defines — won't be there. A recipe can still install a fish completion file, which lands in `$TSUKU_HOME/share/completions/fish/`; putting that directory somewhere your shell looks is currently up to you.
 
 ### Verifying Your Setup
 


### PR DESCRIPTION
`install_shell_init` accepted `fish` as a target shell, wrote
`share/shell.d/<target>@<version>.fish`, and recorded a cleanup action with a
content hash. Nothing on the documented delivery path ever read it.
`config.EnvFileContent` — the file the installer configures and `$TSUKU_HOME/env`
holds — is POSIX shell that fish cannot parse, and it selects only the bash and
zsh caches. A recipe author could follow the validation message, ship
`shells = ["fish"]`, watch the file appear on disk, and have it never load.

`install_shell_init` now has its own bash/zsh allowlist and rejects fish at both
`Preflight` and `Execute`. A fish value gets an error naming what does work —
`tsuku shellenv | source` for PATH, and `install_completions` for fish
completions — while any other bad value gets the plain allowed-set message.
This is the limit `set_env` has already had for the same reason, and the
recipe-author reference already documented it there while contradicting itself
two sections later.

`allowedShells` was shared between `install_shell_init` and
`install_completions`. It moves to `completions.go` as `completionShells` and
keeps fish: a completion script is read from fish's own completions directory
and never goes through the POSIX init cache, so nothing about it is broken. A
test pins that, so a future change cannot quietly re-merge the two allowlists.

No recipe in the registry changes behavior — `recipes/n/nvm.toml` is the only
`install_shell_init` user and it declares `["bash", "zsh"]`. An out-of-registry
recipe that declares fish, installed via `--recipe` or a distributed provider,
now fails its install outright rather than installing the bash and zsh halves
and silently dropping the fish one. That is deliberate, and pinned by
`TestInstallShellInitAction_Execute_RejectsFishAlongsideValidShell`.

---

Fixes #2471

## Why drop rather than finish

The issue lays out both directions and deliberately doesn't pick. Three things
decided it.

**There is already a precedent, in the same directory, for the same root
cause.** `internal/actions/set_env.go:18-20` sets
`envShells = []string{"bash", "zsh"}` with the comment "fish would need
`set -gx` and is not supported". `set_env` writes into the same `share/shell.d`
directory through the same cache. This PR doesn't invent a policy; it applies
the one already in force to the action that escaped it.

**Finishing it honestly is a feature, and a partial finish recreates the
defect.** The issue scopes "finish it" as a fish env file plus a doctor loop.
It's larger: a fish-native env file and its migration path, a per-shell cache
wrapper, a matching change in `isCacheStale` (whose comment records that a
previous mismatch made `doctor --fix` loop forever), the doctor loop, an
installer arm, fish in CI, and — the one the issue misses — fish support in
`set_env`. That last one is load-bearing. The `00-env-` sort contract exists so
a tool's init script sees the variables its recipe exported, and
`recipes/n/nvm.toml`, the only recipe using `install_shell_init` at all, depends
on it. Ship fish init scripts without fish exports and the one real consumer
breaks silently — the same class of defect this issue exists to remove, one
layer down.

**The trap closes now and the option stays open.** Dropping the value breaks no
recipe, and it's one line to reverse once the delivery path exists. The full
scope is filed as #2505 so it survives this PR's squash-merge.

The strongest argument the other way is real: fish is first-class elsewhere in
tsuku — `internal/hook` writes to `~/.config/fish/conf.d/`,
`shellenv.FormatExports` emits `set -gx`, `install.sh` registers fish hooks — so
declining it here reads as inconsistent. Those paths are all fish-native by
construction, each with an explicit fish branch emitting fish syntax. shell.d is
the one subsystem built on a POSIX concatenation contract.

## Two claims in the issue did not survive contact with a real fish

Probed against fish 4.0.2 in a container rather than reasoned about.

**"`tsuku shellenv` gives fish a partial path" — it's better than that.** Both
halves of the emitted output work. fish ships
`/usr/share/fish/functions/export.fish`, a bash-compatibility function that
special-cases `PATH`/`CDPATH`/`MANPATH` and colon-splits them into fish lists,
so `export PATH="a:b:$PATH"` yields a correct `$PATH`. And `.` is still a valid
fish builtin in 4.0.2. `tsuku shellenv | source` genuinely works.

**"fish's only working feature is a diagnostic for a file with no effect" — it's
worse than inert.** `RebuildShellCache` wraps every fragment in a POSIX brace
group, `{ # begin X ... } 2>/dev/null || true`. fish refuses it:

```
'{ ... }' is not supported for grouping commands. Please use 'begin; ...; end'
```

So a fish user on the documented `shellenv` setup would get the cache sourced,
every fragment failing, **and** a multi-line fish error dumped into shell
startup. The `2>/dev/null` is powerless because the redirection is part of the
construct fish won't parse. Worth noting `fish -n` *passes* on that content —
only execution fails, so a syntax-check diagnostic would have missed it.

**Reachability — corrected during review.** An earlier version of this
description claimed the invalid wrapper was "now unreachable". That is wrong for
an existing install, and the correction matters enough to state plainly.

`RebuildShellCache("fish")` is driven by the extension of a cleanup path already
recorded in `state.json`, not by what a recipe declares now.
`internal/install/remove.go:458-467` returns the raw extension for anything under
`share/shell.d/` (pinned for `.fish` at `remove_test.go:789`), and
`shellsRecordedFor` (`internal/install/shelld.go:69-79`), the update path, and
`finishPostInstall` all feed that value straight into the cache builder. So a
`state.json` that already holds `share/shell.d/<target>@<version>.fish` still
triggers a fish rebuild on remove, update, or a version switch.

Verified rather than reasoned about: seeding a shell.d with a leftover
`legacytool@1.0.0.fish` and calling `RebuildShellCache(home, "fish")` on this
branch produces a `.init-cache.fish` containing the POSIX brace wrapper, and
feeding that exact output to fish 4.0.2 reproduces
`'{ ... }' is not supported for grouping commands` with the fragment not loading.

Such state is producible on today's `main` through `tsuku install --recipe` or a
distributed provider, so this is not hypothetical. What this PR changes is that
no *new* install can create it. Existing installs that already have it need a
migration, which is recorded in #2505 for whoever picks up the fish work.

## Test plan

`go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l .` and
`golangci-lint run ./internal/actions/...` all clean.

New tests drive the real code path and assert what a recipe author would
observe, not just the returned error — `Execute` with `shells = ["fish"]` must
leave no fragment on disk and record no cleanup action.

Three existing tests used fish as an accepted value and were retargeted to zsh:
two in `TestInstallShellInitAction_Preflight`/`_Execute_SourceCommand`, one in
`TestInstallShellInitAction_RecordsCleanupActions_SourceCommand`. They were
exercising multi-shell behavior, not fish specifically.

### Mutation testing

Every new guard was mutation-tested by hand: inject one defect, confirm a named
test fails, revert.

| # | Injected defect | Result | Killed by |
|---|-----------------|--------|-----------|
| M1 | Re-admit fish to `shellInitShells` | KILLED | `ShellAllowlist/fish_rejected...`, `Execute_RejectsFish`, `Execute_RejectsFishAlongsideValidShell` |
| M2 | Drop the fish branch in `shellInitShellError`, so the error names no alternative | KILLED | `ShellAllowlist/fish_rejected...`, `Execute_RejectsFish` |
| M3 | `Preflight` stops validating shells entirely | KILLED | `Preflight/invalid_shell`, `ShellAllowlist/fish_rejected...` |
| M4 | `Execute`'s shell guard never fires (checks `Preflight` isn't masking it) | KILLED | `Execute_SourceFile/rejects_invalid_shell`, `Execute_RejectsFish`, `Execute_RejectsFishAlongsideValidShell` |
| M5 | `Execute` detects the invalid shell but doesn't return, writing anyway | KILLED | same three |
| M6 | Remove fish from `completionShells` (over-narrowing) | KILLED | `Preflight/accepts_source_command_with_all_shells`, `Execute_SourceCommand/skips_shell_when_command_fails` |
| M7 | Point `install_completions` back at the narrowed set | KILLED | `StillAcceptsFish`, `Execute_SourceCommand/skips_shell_when_command_fails` |
| M8 | Error message drops the `tsuku shellenv` pointer | KILLED | `ShellAllowlist/fish_rejected...`, `Execute_RejectsFish` |

M4 and M5 first died at compile rather than at test, because removing the guard
left the `errors` import unused. That's a weaker kill — it shows the mutation is
untestable in that form, not that the tests pin the behavior. Both were
re-expressed to compile (`if false`, and `_ = errors.New(...)`) and re-run; the
kills above are the compiling versions.

## Skill maintenance

`internal/actions/` is on the plugin-maintenance list, so both affected skills
were assessed and updated in this PR.

- **tsuku-recipe-author** — `action-reference.md`'s `install_shell_init` `shells`
  row said `bash`, `zsh`, `fish` while the `set_env` section 60 lines earlier
  said fish isn't supported and why. The row is corrected and a note explains
  the limit, mirroring the `set_env` wording. The `install_completions` row
  keeps fish.
- **tsuku-user** — `SKILL.md` documents `tsuku shellenv | source` for fish. It
  now states what a fish user actually gets: PATH, but not tool-specific init
  fragments, with nvm named as the concrete thing that means. It also says the
  completion file lands in `share/completions/fish/` and that putting that
  directory somewhere the shell looks is currently the user's job — see #2520.

## Collisions and CI

- **#2475** also edits `internal/shellenv/doctor.go`. This PR does not touch
  that file — the two-shell loop is left alone, since with fish unable to
  produce a fragment there's no fish cache for doctor to check. No collision.
- The golden-plan workflow is **not** armed. Its path allowlist covers
  `internal/actions/decomposable.go`, `action.go`, `composites.go` and
  `download.go`; this PR touches `shell_init.go` and `completions.go`.
- **One red CI run on this branch was the known suse flake, not this change.**
  Integration Tests run
  [30913898957](https://github.com/tsukumogami/tsuku/actions/runs/30913898957)
  failed `Homebrew Linux Tests` with
  `podman build failed: context canceled: Trying to pull docker.io/opensuse/leap@sha256:045fc29f...`.
  Established rather than assumed: this exact job passed on this branch twice
  before (runs `30853739109` and `30913568960`), and the only delta since is a
  code comment plus two markdown files — no executable change
  (`git diff 8893e624..HEAD -- '*.go'` is comment-only). `pkg-config`, the
  recipe under test, has no `install_shell_init` or `install_completions` step,
  and the failure happens while podman pulls the base image, before tsuku runs
  at all. The identical signature, same image digest, hit
  `dependabot/github_actions/github-actions-484b721a08`
  ([30870595885](https://github.com/tsukumogami/tsuku/actions/runs/30870595885))
  and `fix/2480-eval-deps-prefix-match`
  ([30853051876](https://github.com/tsukumogami/tsuku/actions/runs/30853051876));
  `debian`, `rhel` and `arch` passed in all three, only `suse` failed. Tracked
  by #1884, whose signature has since drifted from a `registry.opensuse.org`
  i/o timeout to a Docker Hub pull stalling past the `timeout 300` in
  `integration-tests.yml:80` — recorded there with evidence. Cleared by re-run.

## Review response

Two findings from review, both confirmed against the code before changing anything.

**The tsuku-user doc claimed completions that tsuku never delivers.** The line I
added said "On fish this gets you PATH and completions". `tsuku shellenv` emits a
PATH line and, conditionally, a cache source line — it never touches completions.
Worse, nothing anywhere puts `$TSUKU_HOME/share/completions/` on any shell's
lookup path, and `completionFileName` gives fish a bare `<target>` rather than the
`<target>.fish` fish autoloads. So the weaker restatement further down was
misleading in the same direction. Both lines are corrected: fish gets PATH, and
the completion file is described as installed with the wiring left to the user.
That is the same shape of false promise #2471 exists to remove, so the underlying
gap is now filed as #2520.

I found the same implication in two more places this PR had introduced and fixed
those too, since leaving them would defeat the point: the recipe-author reference
said a fish completion script "is read from fish's own completions directory",
and the `completionShells` comment said the shell "reads" it. Both now say what is
actually true — completions skip the POSIX cache, which is why the fish
constraint doesn't apply there — and both explicitly note that says nothing about
whether a shell finds the file.

The error message's "install_completions still accepts fish" is left as-is. It is
a statement about what the action accepts, which is true, and it is author-facing
guidance rather than a delivery promise — but #2520 records the gap behind it.

**"That invalid wrapper is now unreachable" was wrong for existing installs.**
Corrected in the Reachability section above, and in #2505 so the migration need
reaches whoever picks up the fish work. I verified the live path end to end rather
than accepting the report: a leftover `.fish` fragment still builds a
`.init-cache.fish` with the POSIX wrapper on this branch, and fish 4.0.2 still
refuses it.

I did not add a migration for that leftover state. The review explicitly asked for
the claim to be fixed rather than the rejection softened, and a state migration is
a separate change with its own risk — it belongs with the fish work in #2505, not
bolted onto a validation fix.

## One thing left alone

`docs/designs/current/DESIGN-shell-d-lifecycle.md` states the filename
injectivity proof over "the legal shells `{bash, zsh, fish}`". The proof still
holds — no member of a subset is a suffix of another either — so the doc is now
listing a superset rather than being wrong. Left as-is to keep this PR narrow.

