### PR TITLE
fix: correct check-deps all_satisfied and stop undefined steps passing silently

### DIFF
--- a/cmd/tsuku/check_deps.go
+++ b/cmd/tsuku/check_deps.go
@@ -116,7 +116,7 @@ func runCheckDeps(cmd *cobra.Command, args []string) {
 		output := CheckDepsOutput{
 			Tool:         toolName,
 			Dependencies: statuses,
-			AllSatisfied: !hasSystemIssue,
+			AllSatisfied: allDepsSatisfied(statuses),
 		}
 		printJSON(output)
 	} else {
@@ -127,6 +127,21 @@ func runCheckDeps(cmd *cobra.Command, args []string) {
 	if hasSystemIssue {
 		exitWithCode(ExitDependencyFailed)
 	}
+}
+
+// allDepsSatisfied reports whether every dependency is installed.
+//
+// A missing provisionable dependency does not block the install -- tsuku can
+// provision it, which is why the exit code stays 0 -- but it is still not
+// satisfied. Reporting otherwise tells any script reading the JSON that there
+// is nothing left to install.
+func allDepsSatisfied(statuses []DepStatus) bool {
+	for _, s := range statuses {
+		if s.Status != "installed" {
+			return false
+		}
+	}
+	return true
 }
 
 // mergeDeps combines install-time and runtime deps into a single map

--- a/cmd/tsuku/check_deps_test.go
+++ b/cmd/tsuku/check_deps_test.go
@@ -160,6 +160,65 @@ func TestDepStatus(t *testing.T) {
 	}
 }
 
+func TestAllDepsSatisfied(t *testing.T) {
+	tests := []struct {
+		name     string
+		statuses []DepStatus
+		want     bool
+	}{
+		{
+			name:     "no dependencies",
+			statuses: nil,
+			want:     true,
+		},
+		{
+			name: "everything installed",
+			statuses: []DepStatus{
+				{Name: "libyaml", Type: "provisionable", Status: "installed"},
+				{Name: "git", Type: "system-required", Status: "installed"},
+			},
+			want: true,
+		},
+		{
+			name: "missing provisionable dependency",
+			statuses: []DepStatus{
+				{Name: "libyaml", Type: "provisionable", Status: "missing"},
+				{Name: "git", Type: "system-required", Status: "installed"},
+			},
+			want: false,
+		},
+		{
+			name: "missing system dependency",
+			statuses: []DepStatus{
+				{Name: "git", Type: "system-required", Status: "missing"},
+			},
+			want: false,
+		},
+		{
+			name: "system dependency with a version mismatch",
+			statuses: []DepStatus{
+				{Name: "git", Type: "system-required", Status: "version_mismatch", Version: "2.0.0", Required: "2.30.0"},
+			},
+			want: false,
+		},
+		{
+			name: "dependency whose recipe was not found",
+			statuses: []DepStatus{
+				{Name: "mystery", Type: "unknown", Status: "missing"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := allDepsSatisfied(tt.statuses); got != tt.want {
+				t.Errorf("allDepsSatisfied() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCheckDepsOutput(t *testing.T) {
 	// Test CheckDepsOutput struct
 	output := CheckDepsOutput{

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/ProtonMail/gopenpgp/v2 v2.9.0
 	github.com/anthropics/anthropic-sdk-go v1.19.0
+	github.com/cucumber/gherkin/go/v26 v26.2.0
 	github.com/cucumber/godog v0.15.1
 	github.com/google/generative-ai-go v0.20.1
 	github.com/google/go-github/v57 v57.0.0
@@ -35,7 +36,6 @@ require (
 	github.com/ProtonMail/go-crypto v1.3.0 // indirect
 	github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f // indirect
 	github.com/cloudflare/circl v1.6.3 // indirect
-	github.com/cucumber/gherkin/go/v26 v26.2.0 // indirect
 	github.com/cucumber/messages/go/v21 v21.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/plugins/tsuku-user/skills/tsuku-user/SKILL.md
+++ b/plugins/tsuku-user/skills/tsuku-user/SKILL.md
@@ -109,6 +109,7 @@ installed already.
 | Command | Description | Common Flags |
 |---------|-------------|--------------|
 | `tsuku run <tool> [args]` | Install if missing, then execute | `--mode suggest/confirm/auto` |
+| `tsuku check-deps <tool>` | Report each dependency's type and status before installing | `--json` |
 | `tsuku verify <tool>` | Check binary integrity and deps | `--system-deps`, `--integrity` |
 | `tsuku doctor` | Environment health check | `--fix` |
 | `tsuku cache clear` | Clear download and version caches | `--downloads`, `--versions` |
@@ -117,6 +118,15 @@ installed already.
 | `tsuku plan export <tool>` | Write that plan to a file for `tsuku install --plan` | `-o` (`-` for stdout) |
 
 All commands accept `--verbose` (`-v`), `--quiet` (`-q`), and `--debug` for log control.
+
+### Reading `check-deps --json`
+
+Don't infer "ready to install" from the exit code. `check-deps` exits 0 whenever
+every system dependency is present, even if provisionable ones are missing --
+tsuku installs those for you. The `all_satisfied` field is the stricter signal:
+it's `true` only when every dependency, provisionable or system, already reports
+`"status": "installed"`. Script against `all_satisfied`, or against each
+dependency's own `status`, rather than against the exit code alone.
 
 ### Stored plans
 

--- a/test/functional/features/check-deps.feature
+++ b/test/functional/features/check-deps.feature
@@ -16,10 +16,13 @@ Feature: Check dependencies
     When I run "tsuku check-deps"
     Then the exit code is 1
 
+  @critical
   Scenario: Check deps JSON output reflects missing dependencies
-    # See #2099
+    # See #2099. ruby's provisionable deps are absent from a clean environment,
+    # so all_satisfied has to say so even though the exit code stays 0.
     When I run "tsuku check-deps ruby --json"
     Then the exit code is 0
+    And the output contains "\"all_satisfied\": false"
     And the output does not contain "\"all_satisfied\":true"
     And the output does not contain "\"all_satisfied\": true"
 

--- a/test/functional/step_binding_test.go
+++ b/test/functional/step_binding_test.go
@@ -1,0 +1,170 @@
+package functional
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	gherkin "github.com/cucumber/gherkin/go/v26"
+)
+
+// featureStep is one step of one feature file, with enough location to point a
+// reader at the offending line.
+type featureStep struct {
+	file string
+	line int64
+	text string
+}
+
+// TestEveryFeatureStepIsDefined checks that every step in every feature file
+// matches exactly one registered step definition.
+//
+// The functional suite runs only @critical scenarios on a pull request and needs
+// a built binary, so an unbound step in an untagged scenario would otherwise go
+// unnoticed until someone read a push-CI log. This test parses the feature files
+// directly -- no binary, no tsuku invocation -- so it runs in the ordinary
+// unit-test job on every pull request that touches Go code or test/functional/.
+func TestEveryFeatureStepIsDefined(t *testing.T) {
+	defs := stepDefinitions()
+	patterns := make([]*regexp.Regexp, len(defs))
+	for i, def := range defs {
+		patterns[i] = regexp.MustCompile(def.pattern)
+	}
+
+	files, err := filepath.Glob(filepath.Join("features", "*.feature"))
+	if err != nil {
+		t.Fatalf("globbing feature files: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no feature files found; this check would pass vacuously")
+	}
+
+	for _, file := range files {
+		t.Run(filepath.Base(file), func(t *testing.T) {
+			for _, step := range parseFeatureSteps(t, file) {
+				var matched []string
+				for i, pattern := range patterns {
+					if pattern.MatchString(step.text) {
+						matched = append(matched, defs[i].pattern)
+					}
+				}
+				switch len(matched) {
+				case 1:
+					// Exactly one definition claims the step. This is the
+					// only case godog can execute.
+				case 0:
+					t.Errorf("%s:%d: step `%s` matches no step definition; godog reports this as undefined and never runs it",
+						step.file, step.line, step.text)
+				default:
+					t.Errorf("%s:%d: step `%s` matches %d step definitions (%s); godog reports this as ambiguous",
+						step.file, step.line, step.text, len(matched), strings.Join(matched, ", "))
+				}
+			}
+		})
+	}
+}
+
+// TestStepPatternCarriesEscapedQuote pins the reason the check-deps assertions
+// went unbound: the quoted-argument pattern has to survive an escaped quote in
+// the step text, and the handler has to see the quote the feature author wrote.
+func TestStepPatternCarriesEscapedQuote(t *testing.T) {
+	pattern := regexp.MustCompile(`^the output does not contain ` + quotedArg + `$`)
+	step := `the output does not contain "\"all_satisfied\": true"`
+
+	match := pattern.FindStringSubmatch(step)
+	if match == nil {
+		t.Fatalf("pattern %s does not match step %s", pattern, step)
+	}
+	if got, want := unescapeArg(match[1]), `"all_satisfied": true`; got != want {
+		t.Errorf("captured argument = %q, want %q", got, want)
+	}
+}
+
+func TestUnescapeArg(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"no escapes", `all_satisfied`, `all_satisfied`},
+		{"escaped quotes", `\"all_satisfied\":true`, `"all_satisfied":true`},
+		{"escaped backslash", `a\\b`, `a\b`},
+		{"unknown escape passes through", `line\nbreak`, `line\nbreak`},
+		{"trailing backslash", `path\`, `path\`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := unescapeArg(tt.in); got != tt.want {
+				t.Errorf("unescapeArg(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// parseFeatureSteps returns every step godog would run for a feature file.
+// Pickles expand Scenario Outlines into concrete steps, and the AST supplies
+// the line numbers the pickles drop.
+func parseFeatureSteps(t *testing.T, path string) []featureStep {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+
+	n := 0
+	newID := func() string {
+		n++
+		return strconv.Itoa(n)
+	}
+
+	doc, err := gherkin.ParseGherkinDocument(bytes.NewReader(data), newID)
+	if err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	if doc.Feature == nil {
+		return nil
+	}
+
+	// Index AST step ids by line. A step under a Rule: block is not indexed
+	// here and reports line 0; it is still checked, which is what matters.
+	lines := make(map[string]int64)
+	for _, child := range doc.Feature.Children {
+		if child.Background != nil {
+			for _, step := range child.Background.Steps {
+				lines[step.Id] = step.Location.Line
+			}
+		}
+		if child.Scenario != nil {
+			for _, step := range child.Scenario.Steps {
+				lines[step.Id] = step.Location.Line
+			}
+		}
+	}
+
+	var steps []featureStep
+	seen := make(map[string]bool)
+	for _, pickle := range gherkin.Pickles(*doc, path, newID) {
+		for _, step := range pickle.Steps {
+			var line int64
+			if len(step.AstNodeIds) > 0 {
+				line = lines[step.AstNodeIds[0]]
+			}
+			// A Background step appears in every pickle of the file, and an
+			// outline step repeats per example row. Report each distinct
+			// line-and-text pair once.
+			key := strconv.FormatInt(line, 10) + "\x00" + step.Text
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			steps = append(steps, featureStep{file: path, line: line, text: step.Text})
+		}
+	}
+	return steps
+}

--- a/test/functional/steps_test.go
+++ b/test/functional/steps_test.go
@@ -18,6 +18,26 @@ func aCleanTsukuEnvironment(ctx context.Context) (context.Context, error) {
 	return ctx, nil
 }
 
+// unescapeArg resolves the backslash escapes that quotedArg lets a step
+// argument carry. Only `\"` and `\\` mean anything; every other backslash
+// passes through untouched, so a step can still assert on a literal `\n` or a
+// Windows-style path without the escape being eaten.
+func unescapeArg(s string) string {
+	if !strings.Contains(s, `\`) {
+		return s
+	}
+	var b strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' && i+1 < len(s) && (s[i+1] == '"' || s[i+1] == '\\') {
+			b.WriteByte(s[i+1])
+			i++
+			continue
+		}
+		b.WriteByte(s[i])
+	}
+	return b.String()
+}
+
 // iRun executes a command string, replacing "tsuku" with the test binary path.
 func iRun(ctx context.Context, command string) (context.Context, error) {
 	state := getState(ctx)
@@ -26,7 +46,7 @@ func iRun(ctx context.Context, command string) (context.Context, error) {
 	}
 
 	// Replace "tsuku" at the start of the command with the test binary path
-	args := strings.Fields(command)
+	args := strings.Fields(unescapeArg(command))
 	if len(args) > 0 && args[0] == "tsuku" {
 		args[0] = state.binPath
 	}
@@ -99,6 +119,7 @@ func theExitCodeIsNot(ctx context.Context, notExpected int) error {
 
 func theOutputContains(ctx context.Context, text string) error {
 	state := getState(ctx)
+	text = unescapeArg(text)
 	if !strings.Contains(state.stdout, text) {
 		return fmt.Errorf("expected stdout to contain %q, got:\n%s", text, state.stdout)
 	}
@@ -107,6 +128,7 @@ func theOutputContains(ctx context.Context, text string) error {
 
 func theOutputDoesNotContain(ctx context.Context, text string) error {
 	state := getState(ctx)
+	text = unescapeArg(text)
 	if strings.Contains(state.stdout, text) {
 		return fmt.Errorf("expected stdout not to contain %q, got:\n%s", text, state.stdout)
 	}
@@ -115,6 +137,7 @@ func theOutputDoesNotContain(ctx context.Context, text string) error {
 
 func theErrorOutputContains(ctx context.Context, text string) error {
 	state := getState(ctx)
+	text = unescapeArg(text)
 	if !strings.Contains(state.stderr, text) {
 		return fmt.Errorf("expected stderr to contain %q, got:\n%s", text, state.stderr)
 	}
@@ -123,6 +146,7 @@ func theErrorOutputContains(ctx context.Context, text string) error {
 
 func theErrorOutputDoesNotContain(ctx context.Context, text string) error {
 	state := getState(ctx)
+	text = unescapeArg(text)
 	if strings.Contains(state.stderr, text) {
 		return fmt.Errorf("expected stderr not to contain %q, got:\n%s", text, state.stderr)
 	}
@@ -131,7 +155,7 @@ func theErrorOutputDoesNotContain(ctx context.Context, text string) error {
 
 func theFileExists(ctx context.Context, path string) error {
 	state := getState(ctx)
-	fullPath := filepath.Join(state.homeDir, path)
+	fullPath := filepath.Join(state.homeDir, unescapeArg(path))
 	// Use Lstat to detect symlinks even if their target doesn't resolve
 	if _, err := os.Lstat(fullPath); os.IsNotExist(err) {
 		return fmt.Errorf("expected file %q to exist", fullPath)
@@ -141,7 +165,7 @@ func theFileExists(ctx context.Context, path string) error {
 
 func theFileDoesNotExist(ctx context.Context, path string) error {
 	state := getState(ctx)
-	fullPath := filepath.Join(state.homeDir, path)
+	fullPath := filepath.Join(state.homeDir, unescapeArg(path))
 	if _, err := os.Lstat(fullPath); err == nil {
 		return fmt.Errorf("expected file %q not to exist", fullPath)
 	}
@@ -155,7 +179,7 @@ func theFileDoesNotExist(ctx context.Context, path string) error {
 // after the foreground command (`tsuku list`, etc.) returns.
 func theFileEventuallyDoesNotExist(ctx context.Context, path string, timeoutSeconds int) error {
 	state := getState(ctx)
-	fullPath := filepath.Join(state.homeDir, path)
+	fullPath := filepath.Join(state.homeDir, unescapeArg(path))
 	deadline := time.Now().Add(time.Duration(timeoutSeconds) * time.Second)
 	for time.Now().Before(deadline) {
 		if _, err := os.Lstat(fullPath); os.IsNotExist(err) {
@@ -178,7 +202,7 @@ func iSetEnv(ctx context.Context, key, value string) (context.Context, error) {
 	if state.envOverrides == nil {
 		state.envOverrides = make(map[string]string)
 	}
-	state.envOverrides[key] = value
+	state.envOverrides[unescapeArg(key)] = unescapeArg(value)
 	return ctx, nil
 }
 
@@ -188,7 +212,7 @@ func iCreateHomeFile(ctx context.Context, path string, content *godog.DocString)
 	if state == nil {
 		return ctx, fmt.Errorf("no test state")
 	}
-	fullPath := filepath.Join(state.homeDir, path)
+	fullPath := filepath.Join(state.homeDir, unescapeArg(path))
 	if err := os.MkdirAll(filepath.Dir(fullPath), 0o755); err != nil {
 		return ctx, fmt.Errorf("creating parent dirs for %s: %w", path, err)
 	}
@@ -206,12 +230,12 @@ func iRunFromDir(ctx context.Context, dir, command string) (context.Context, err
 		return ctx, fmt.Errorf("no test state")
 	}
 
-	fullDir := filepath.Join(state.homeDir, dir)
+	fullDir := filepath.Join(state.homeDir, unescapeArg(dir))
 	if err := os.MkdirAll(fullDir, 0o755); err != nil {
 		return ctx, fmt.Errorf("creating dir %s: %w", dir, err)
 	}
 
-	args := strings.Fields(command)
+	args := strings.Fields(unescapeArg(command))
 	if len(args) > 0 && args[0] == "tsuku" {
 		args[0] = state.binPath
 	}
@@ -262,7 +286,8 @@ func iRunFromDir(ctx context.Context, dir, command string) (context.Context, err
 
 func theFileContains(ctx context.Context, path, text string) error {
 	state := getState(ctx)
-	fullPath := filepath.Join(state.homeDir, path)
+	fullPath := filepath.Join(state.homeDir, unescapeArg(path))
+	text = unescapeArg(text)
 	data, err := os.ReadFile(fullPath)
 	if err != nil {
 		return fmt.Errorf("reading %q: %w", fullPath, err)
@@ -275,7 +300,8 @@ func theFileContains(ctx context.Context, path, text string) error {
 
 func theFileDoesNotContain(ctx context.Context, path, text string) error {
 	state := getState(ctx)
-	fullPath := filepath.Join(state.homeDir, path)
+	fullPath := filepath.Join(state.homeDir, unescapeArg(path))
+	text = unescapeArg(text)
 	data, err := os.ReadFile(fullPath)
 	if err != nil {
 		return fmt.Errorf("reading %q: %w", fullPath, err)
@@ -290,9 +316,9 @@ func theFileDoesNotContain(ctx context.Context, path, text string) error {
 // runs a command in the same shell. It verifies the command succeeds.
 func iSourceHomeFileAndCanRun(ctx context.Context, sourceFile, command string) (context.Context, error) {
 	state := getState(ctx)
-	fullPath := filepath.Join(state.homeDir, sourceFile)
+	fullPath := filepath.Join(state.homeDir, unescapeArg(sourceFile))
 
-	script := fmt.Sprintf(`. "%s" && %s`, fullPath, command)
+	script := fmt.Sprintf(`. "%s" && %s`, fullPath, unescapeArg(command))
 	cmd := exec.Command("bash", "-c", script)
 	cmd.Env = append(os.Environ(),
 		"TSUKU_HOME="+state.homeDir,
@@ -330,7 +356,7 @@ func iCanRun(ctx context.Context, command string) (context.Context, error) {
 		}
 	}
 
-	cmd := exec.Command("bash", "-c", command)
+	cmd := exec.Command("bash", "-c", unescapeArg(command))
 	cmd.Env = append(os.Environ(),
 		"PATH="+toolBins+":"+os.Getenv("PATH"),
 		"TSUKU_NO_TELEMETRY=1",

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -58,8 +58,13 @@ func TestFeatures(t *testing.T) {
 	}
 
 	opts := &godog.Options{
-		Format:   "pretty",
-		Paths:    paths,
+		Format: "pretty",
+		Paths:  paths,
+		// Strict fails the run on an undefined, pending, or ambiguous step.
+		// Without it godog skips such a step, and the scenario still reports
+		// green on whatever steps did match -- so an assertion can sit in a
+		// feature file for months without ever executing.
+		Strict:   true,
 		TestingT: t,
 	}
 	if tags := os.Getenv("TSUKU_TEST_TAGS"); tags != "" {
@@ -147,29 +152,54 @@ func initializeScenario(ctx *godog.ScenarioContext, binPath string) {
 		return setState(ctx, state), nil
 	})
 
-	// Environment steps
-	ctx.Step(`^a clean tsuku environment$`, aCleanTsukuEnvironment)
+	for _, def := range stepDefinitions() {
+		ctx.Step(def.pattern, def.handler)
+	}
+}
 
-	// Command steps
-	ctx.Step(`^I run "([^"]*)"$`, iRun)
+// quotedArg matches a double-quoted step argument. Backslash escapes are
+// allowed inside the quotes so a step can carry a literal `"` -- the check-deps
+// JSON assertions need one. A plain `[^"]*` class stops at the first quote, so
+// such a step matches nothing and godog reports it as undefined. Handlers pass
+// the captured value through unescapeArg before using it.
+const quotedArg = `"((?:[^"\\]|\\.)*)"`
 
-	// Assertion steps
-	ctx.Step(`^the exit code is (\d+)$`, theExitCodeIs)
-	ctx.Step(`^the exit code is not (\d+)$`, theExitCodeIsNot)
-	ctx.Step(`^the output contains "([^"]*)"$`, theOutputContains)
-	ctx.Step(`^the output does not contain "([^"]*)"$`, theOutputDoesNotContain)
-	ctx.Step(`^the error output contains "([^"]*)"$`, theErrorOutputContains)
-	ctx.Step(`^the error output does not contain "([^"]*)"$`, theErrorOutputDoesNotContain)
-	ctx.Step(`^the file "([^"]*)" exists$`, theFileExists)
-	ctx.Step(`^the file "([^"]*)" does not exist$`, theFileDoesNotExist)
-	ctx.Step(`^the file "([^"]*)" eventually does not exist within (\d+) seconds$`, theFileEventuallyDoesNotExist)
-	ctx.Step(`^the file "([^"]*)" contains "([^"]*)"$`, theFileContains)
-	ctx.Step(`^the file "([^"]*)" does not contain "([^"]*)"$`, theFileDoesNotContain)
-	ctx.Step(`^I source home file "([^"]*)" and can run "([^"]*)"$`, iSourceHomeFileAndCanRun)
-	ctx.Step(`^I can run "([^"]*)"$`, iCanRun)
-	ctx.Step(`^I create home file "([^"]*)" with content:$`, iCreateHomeFile)
-	ctx.Step(`^I run from "([^"]*)" "([^"]*)"$`, iRunFromDir)
-	ctx.Step(`^I set env "([^"]*)" to "([^"]*)"$`, iSetEnv)
+// stepDefinition pairs a step pattern with the function implementing it.
+type stepDefinition struct {
+	pattern string
+	handler any
+}
+
+// stepDefinitions returns every step this suite understands. Registration and
+// the binding check in step_binding_test.go both read this one table, so a
+// feature step that matches nothing here fails the unit-test job rather than
+// waiting for someone to notice "undefined" in a functional run.
+func stepDefinitions() []stepDefinition {
+	return []stepDefinition{
+		// Environment steps
+		{`^a clean tsuku environment$`, aCleanTsukuEnvironment},
+
+		// Command steps
+		{`^I run ` + quotedArg + `$`, iRun},
+		{`^I run from ` + quotedArg + ` ` + quotedArg + `$`, iRunFromDir},
+		{`^I can run ` + quotedArg + `$`, iCanRun},
+		{`^I source home file ` + quotedArg + ` and can run ` + quotedArg + `$`, iSourceHomeFileAndCanRun},
+		{`^I create home file ` + quotedArg + ` with content:$`, iCreateHomeFile},
+		{`^I set env ` + quotedArg + ` to ` + quotedArg + `$`, iSetEnv},
+
+		// Assertion steps
+		{`^the exit code is (\d+)$`, theExitCodeIs},
+		{`^the exit code is not (\d+)$`, theExitCodeIsNot},
+		{`^the output contains ` + quotedArg + `$`, theOutputContains},
+		{`^the output does not contain ` + quotedArg + `$`, theOutputDoesNotContain},
+		{`^the error output contains ` + quotedArg + `$`, theErrorOutputContains},
+		{`^the error output does not contain ` + quotedArg + `$`, theErrorOutputDoesNotContain},
+		{`^the file ` + quotedArg + ` exists$`, theFileExists},
+		{`^the file ` + quotedArg + ` does not exist$`, theFileDoesNotExist},
+		{`^the file ` + quotedArg + ` eventually does not exist within (\d+) seconds$`, theFileEventuallyDoesNotExist},
+		{`^the file ` + quotedArg + ` contains ` + quotedArg + `$`, theFileContains},
+		{`^the file ` + quotedArg + ` does not contain ` + quotedArg + `$`, theFileDoesNotContain},
+	}
 }
 
 // filteredPATH returns a PATH string with directories containing any of the


### PR DESCRIPTION
Feature-step registration in `test/functional/` now goes through a
`stepDefinitions` table with one shared quoted-argument pattern. That pattern
accepts backslash escapes, so a step can carry a literal `"`, and handlers run
the captured value through `unescapeArg` before using it. `godog.Options` sets
`Strict`, so an undefined, pending, or ambiguous step fails the run instead of
being skipped while the scenario reports green on its remaining steps.

A new `step_binding_test.go` reads that same table, parses every feature file
with gherkin, and asserts each step matches exactly one registered definition.
It drives no binary, so it runs in the ordinary unit-test job rather than the
functional one.

`allDepsSatisfied` in `cmd/tsuku/check_deps.go` replaces the old
`!hasSystemIssue` expression behind the `all_satisfied` JSON field. The field
now reports `true` only when every dependency is installed; previously a
missing provisionable dependency left it `true`, telling a script reading the
JSON there was nothing left to install. Exit codes are unchanged -- a missing
provisionable dependency still exits 0, because tsuku can provision it.

The check-deps scenario gains a positive assertion on `"all_satisfied": false`
and a `@critical` tag, and the `tsuku-user` skill documents `check-deps` and
the difference between its exit code and its `all_satisfied` field.

---

Fixes #2492
Fixes #2099

## Root cause

`^the output does not contain "([^"]*)"$` -- the character class stops at the
first `"`, so a step whose argument contains an escaped quote matched nothing.
godog reported it as undefined. Without `Strict`, undefined means skipped, not
failed, so the scenario passed on its other two steps and the summary line
carried the only evidence:

```
133 scenarios (131 passed, 1 failed, 1 undefined)
617 steps (614 passed, 1 failed, 2 undefined)
```

## What the issue could not know: binding the steps turns them red

The two assertions were written as coverage for #2099, and #2099 is still open.
On a clean environment `tsuku check-deps ruby --json` prints:

```json
{
  "tool": "ruby",
  "dependencies": [
    { "name": "libyaml",  "type": "provisionable", "status": "missing" },
    { "name": "patchelf", "type": "provisionable", "status": "missing" }
  ],
  "all_satisfied": true
}
```

So binding the steps without fixing the product bug swaps a silent pass for a
red suite. The `all_satisfied` fix is in this PR for that reason, not as an
opportunistic extra. `AllSatisfied` was computed from `hasSystemIssue`, which
only ever looks at `system-required` dependencies; `ruby`'s are both
provisionable, so nothing set it. The exit-code path still keys on
`hasSystemIssue`, which is what the scenario's `Then the exit code is 0`
requires.

## Blast radius of `Strict`

None. The full suite is green with `Strict` on:

```
133 scenarios (133 passed)
618 steps (618 passed)
```

Those two steps were the only unbound ones, and they are the only steps in the
27 feature files that contain a backslash at all. The new binding test agrees:
every step in every file matches exactly one definition, and none matches two.

## Whether these assertions gate review

They didn't. `check-deps.feature` carried no tags, and the functional job runs
`make test-functional-critical` on a pull request -- only `@critical` scenarios
-- reserving the full suite for pushes to main and for PRs that touch
`test/functional/**`. So the fixed assertion would have run on push and on this
PR, and not on the next PR that changes `cmd/tsuku/check_deps.go`.

Two changes address that:

- The scenario is now `@critical`, so the #2099 regression guard runs on every
  PR that runs the functional job. It costs about 0.1s and makes no network
  call.
- `TestEveryFeatureStepIsDefined` needs no built binary and no tsuku
  invocation, so it runs in the unit-test job, which fires on any change to
  `**/*.go` or `test/functional/**`. A future undefined step fails at review
  time rather than in a push log nobody is reading. `Strict` is the backstop
  for what static matching can't see -- a step that binds but returns
  `ErrPending`, or one made ambiguous at runtime.

## Mutation testing

One defect at a time, injected and reverted. Every guard was killed.

| Defect injected | Test that failed |
|---|---|
| `quotedArg` reverted to `"([^"]*)"` | `TestEveryFeatureStepIsDefined/check-deps.feature` (both lines, by number), `TestStepPatternCarriesEscapedQuote` |
| `unescapeArg` returns its input unchanged | `TestStepPatternCarriesEscapedQuote`, `TestUnescapeArg/escaped_quotes`, `TestUnescapeArg/escaped_backslash` |
| Typo in one registered step pattern | `TestEveryFeatureStepIsDefined` across 4 feature files |
| Undefined step added to a feature file | `TestEveryFeatureStepIsDefined/check-deps.feature`, and `TestFeatures` fails the run |
| `allDepsSatisfied` counts system deps only | `TestAllDepsSatisfied/missing_provisionable_dependency`, `/dependency_whose_recipe_was_not_found` |
| `allDepsSatisfied` hardcoded `true` | `TestAllDepsSatisfied`, 4 of 6 subtests |
| `all_satisfied` regressed, driven through the real binary | `TestFeatures/Check_deps_JSON_output_reflects_missing_dependencies` |

The `Strict` change was mutation-tested in both directions on the same feature
file, with the same injected undefined step:

| Configuration | godog summary | Suite result |
|---|---|---|
| `Strict: true` (this PR) | `5 scenarios (4 passed, 1 undefined)` | FAIL |
| `Strict` removed | `5 scenarios (4 passed, 1 undefined)` | PASS |

Identical counts, opposite outcomes. That gap is the bug.

## Verification

`go test ./...`, `go vet ./...`, `gofmt`, `golangci-lint run --timeout=5m
./...`, and `go mod tidy` are all clean. The full functional suite passes
locally: 133 scenarios, 618 steps, zero undefined.

`gherkin/go/v26` moves from an indirect to a direct requirement in `go.mod`; it
was already in `go.sum` as a godog dependency, and no new module is added.

## Notes for the reviewer

- The pretty formatter now prints the same `suite_test.go` line for every step,
  because registration happens in a loop. The handler name is still printed, so
  `-> ...theOutputDoesNotContain` still identifies the definition.
- `unescapeArg` resolves only `\"` and `\\`. Any other backslash passes through
  untouched, so a step can still assert on a literal `\n`. Those two steps are
  the only place in the suite that uses an escape today.
- The `@critical` tag is a judgment call, not something #2492 asks for. Drop it
  if you'd rather this scenario stay on the push-only path; nothing else in the
  PR depends on it.
- The diff does not touch `.github/workflows/`, so it should not collide with
  #2494. If that PR changes which event runs the full suite, the "gates review"
  reasoning above may need rereading, but the code doesn't.
- No file in the diff is on the `validate-golden-code.yml` path allowlist, so
  this does not arm the golden-plan workflow.
