### PR TITLE
feat(doctor): warn when something earlier on PATH shadows a managed tool

### DIFF
--- a/cmd/tsuku/doctor.go
+++ b/cmd/tsuku/doctor.go
@@ -99,6 +99,9 @@ func init() {
 func runDoctorChecks(cfg *config.Config, homeDir string) (failed bool, selection shellenv.ShellDSelection) {
 	fmt.Println("Checking tsuku environment...")
 
+	// Set by check 6, which is where state is loaded, and consumed by check 9.
+	var managedBinaries []shellenv.ManagedBinaries
+
 	// Check 1: Home directory
 	fmt.Fprintf(os.Stdout, "  Home directory: %s", homeDir)
 	if info, err := os.Stat(homeDir); err != nil {
@@ -200,6 +203,7 @@ func runDoctorChecks(cfg *config.Config, homeDir string) (failed bool, selection
 	state, stateErr := stateMgr.Load()
 	if stateErr == nil {
 		selection = install.BuildShellDSelection(state)
+		managedBinaries = install.BuildManagedBinaries(state)
 	}
 
 	shellCheck := shellenv.CheckShellD(homeDir, selection)
@@ -283,6 +287,39 @@ func runDoctorChecks(cfg *config.Config, homeDir string) (failed bool, selection
 	} else {
 		fmt.Printf(" ... WARN (%d stale, >30 days old)\n", len(staleNotices))
 		fmt.Fprintf(os.Stderr, "    Run: rm %s/*.json to clear\n", noticesDir)
+	}
+
+	// Check 9: Tool precedence.
+	//
+	// Checks 2 and 3 ask whether tsuku's directories are on PATH. This one asks
+	// whether they win. A competing installer that prepends its own prefix after
+	// $TSUKU_HOME/env has been sourced leaves both checks above green while every
+	// command actually runs the other copy.
+	//
+	// It warns rather than fails. Doctor is documented as a CI gate, and which
+	// binary wins is a property of the user's PATH that they may well have
+	// arranged deliberately.
+	fmt.Fprintf(os.Stdout, "  Tool precedence")
+	shadowed := shellenv.CheckPrecedence(shellenv.PrecedenceInput{
+		TsukuHome: homeDir,
+		PathDirs:  pathDirs,
+		Tools:     managedBinaries,
+	})
+	if len(shadowed) == 0 {
+		fmt.Println(" ... ok")
+	} else {
+		fmt.Printf(" ... WARN (%d shadowed)\n", len(shadowed))
+		for _, s := range shadowed {
+			// Name the tool too when it differs from the binary, so the reader
+			// knows which `tsuku` entry to act on -- ripgrep provides rg.
+			label := s.Binary
+			if s.Tool != s.Binary {
+				label = fmt.Sprintf("%s (%s)", s.Binary, s.Tool)
+			}
+			fmt.Fprintf(os.Stderr, "    %s resolves to %s, not tsuku's %s\n", label, s.Resolved, s.Expected)
+		}
+		fmt.Fprintf(os.Stderr, "    Something earlier on PATH is shadowing a tsuku-managed tool.\n")
+		fmt.Fprintf(os.Stderr, "    Move the tsuku entries ahead of it, or remove the other copy.\n")
 	}
 
 	return failed, selection

--- a/cmd/tsuku/doctor_precedence_test.go
+++ b/cmd/tsuku/doctor_precedence_test.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/tsukumogami/tsuku/internal/config"
+	"github.com/tsukumogami/tsuku/internal/install"
+)
+
+// precedenceEnv is a $TSUKU_HOME with a competing prefix beside it, both under
+// one temp root so nothing outside t.TempDir() is written or named.
+type precedenceEnv struct {
+	home       string
+	binDir     string
+	currentDir string
+	shadowDir  string
+}
+
+func newPrecedenceEnv(t *testing.T) precedenceEnv {
+	t.Helper()
+
+	root := t.TempDir()
+	env := precedenceEnv{
+		home:       filepath.Join(root, "tsuku"),
+		binDir:     filepath.Join(root, "tsuku", "bin"),
+		currentDir: filepath.Join(root, "tsuku", "tools", "current"),
+		shadowDir:  filepath.Join(root, "other", "bin"),
+	}
+	for _, dir := range []string{env.binDir, env.currentDir, env.shadowDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(env.home, "env"), []byte(config.EnvFileContent), 0o644); err != nil {
+		t.Fatalf("writing env file: %v", err)
+	}
+	return env
+}
+
+// installVisibleTool writes a state.json recording one visible tool and puts its
+// binary in tools/current, the way a real install leaves things.
+func (e precedenceEnv) installVisibleTool(t *testing.T, tool, binary string) {
+	t.Helper()
+
+	state := install.State{Installed: map[string]install.ToolState{
+		tool: {
+			ActiveVersion: "1.0.0",
+			Versions:      map[string]install.VersionState{"1.0.0": {Binaries: []string{binary}}},
+			IsExplicit:    true,
+		},
+	}}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshaling state: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(e.home, "state.json"), data, 0o644); err != nil {
+		t.Fatalf("writing state.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(e.currentDir, binary), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("writing managed binary: %v", err)
+	}
+}
+
+func (e precedenceEnv) plantShadow(t *testing.T, binary string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(e.shadowDir, binary), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("writing shadow binary: %v", err)
+	}
+}
+
+func (e precedenceEnv) config() *config.Config {
+	return &config.Config{
+		HomeDir:  e.home,
+		ToolsDir: filepath.Join(e.home, "tools"),
+		ShareDir: filepath.Join(e.home, "share"),
+	}
+}
+
+// precedenceLine returns doctor's "Tool precedence" status line.
+func precedenceLine(t *testing.T, stdout string) string {
+	t.Helper()
+	for _, line := range strings.Split(stdout, "\n") {
+		if strings.Contains(line, "Tool precedence") {
+			return line
+		}
+	}
+	t.Fatalf("no 'Tool precedence' line in doctor output:\n%s", stdout)
+	return ""
+}
+
+// TestDoctorReportsShadowedTool is the issue's reproduction, driven through the
+// real check. A tool tsuku manages sits behind a competing copy on PATH; every
+// other check is green, and before this check doctor said "Everything looks
+// good".
+func TestDoctorReportsShadowedTool(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("execute-bit resolution differs on Windows")
+	}
+
+	env := newPrecedenceEnv(t)
+	env.installVisibleTool(t, "koto", "koto")
+	env.plantShadow(t, "koto")
+
+	t.Setenv("PATH", strings.Join([]string{env.shadowDir, env.binDir, env.currentDir}, string(os.PathListSeparator)))
+
+	var failed bool
+	stdout, stderr := captureDoctorOutput(func() {
+		failed, _ = runDoctorChecks(env.config(), env.home)
+	})
+
+	line := precedenceLine(t, stdout)
+	if !strings.Contains(line, "WARN") {
+		t.Errorf("expected a WARN on the precedence line, got %q", line)
+	}
+
+	// Reporting the shadowing path is the point: it is the thing a user cannot
+	// discover without reading `which -a` by hand.
+	shadowPath := filepath.Join(env.shadowDir, "koto")
+	if !strings.Contains(stderr, shadowPath) {
+		t.Errorf("expected the shadowing path %q in stderr, got:\n%s", shadowPath, stderr)
+	}
+	tsukuPath := filepath.Join(env.currentDir, "koto")
+	if !strings.Contains(stderr, tsukuPath) {
+		t.Errorf("expected tsuku's own path %q in stderr, got:\n%s", tsukuPath, stderr)
+	}
+
+	// WARN, not FAIL: `tsuku doctor || exit 1` must not start failing for
+	// someone who fronts a system tool deliberately.
+	if failed {
+		t.Error("a shadowed tool must not fail the environment check")
+	}
+}
+
+// TestDoctorPrecedenceQuietWhenTsukuWins is the other half: the same setup with
+// tsuku's directories ahead of the competing one has to stay silent, or the
+// warning is noise everyone learns to skip.
+func TestDoctorPrecedenceQuietWhenTsukuWins(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("execute-bit resolution differs on Windows")
+	}
+
+	env := newPrecedenceEnv(t)
+	env.installVisibleTool(t, "koto", "koto")
+	env.plantShadow(t, "koto")
+
+	t.Setenv("PATH", strings.Join([]string{env.binDir, env.currentDir, env.shadowDir}, string(os.PathListSeparator)))
+
+	stdout, _ := captureDoctorOutput(func() {
+		runDoctorChecks(env.config(), env.home)
+	})
+
+	line := precedenceLine(t, stdout)
+	if !strings.Contains(line, "ok") || strings.Contains(line, "WARN") {
+		t.Errorf("expected the precedence check to pass, got %q", line)
+	}
+}
+
+// TestDoctorPrecedenceIgnoresHiddenTools pins the exclusion that keeps this
+// check usable. Execution dependencies are installed with no symlink in
+// tools/current, so their names resolve to a system copy on every healthy
+// machine; warning about them would mean a warning per hidden dependency.
+func TestDoctorPrecedenceIgnoresHiddenTools(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("execute-bit resolution differs on Windows")
+	}
+
+	env := newPrecedenceEnv(t)
+
+	state := install.State{Installed: map[string]install.ToolState{
+		"node": {
+			ActiveVersion:         "22.0.0",
+			IsHidden:              true,
+			IsExecutionDependency: true,
+			Versions:              map[string]install.VersionState{"22.0.0": {Binaries: []string{"node"}}},
+		},
+	}}
+	data, err := json.Marshal(state)
+	if err != nil {
+		t.Fatalf("marshaling state: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(env.home, "state.json"), data, 0o644); err != nil {
+		t.Fatalf("writing state.json: %v", err)
+	}
+	// The system copy that a hidden tool always resolves to.
+	env.plantShadow(t, "node")
+
+	t.Setenv("PATH", strings.Join([]string{env.shadowDir, env.binDir, env.currentDir}, string(os.PathListSeparator)))
+
+	stdout, _ := captureDoctorOutput(func() {
+		runDoctorChecks(env.config(), env.home)
+	})
+
+	line := precedenceLine(t, stdout)
+	if strings.Contains(line, "WARN") {
+		t.Errorf("a hidden execution dependency must not be reported as shadowed, got %q", line)
+	}
+}
+
+// TestDoctorNamesTheToolBehindABinary covers the case where acting on the
+// warning means knowing which tsuku entry owns the shadowed name. "rg" alone
+// doesn't tell the reader to look at ripgrep.
+func TestDoctorNamesTheToolBehindABinary(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("execute-bit resolution differs on Windows")
+	}
+
+	env := newPrecedenceEnv(t)
+	env.installVisibleTool(t, "ripgrep", "rg")
+	env.plantShadow(t, "rg")
+
+	t.Setenv("PATH", strings.Join([]string{env.shadowDir, env.binDir, env.currentDir}, string(os.PathListSeparator)))
+
+	_, stderr := captureDoctorOutput(func() {
+		runDoctorChecks(env.config(), env.home)
+	})
+
+	if !strings.Contains(stderr, "rg (ripgrep)") {
+		t.Errorf("expected the owning tool named beside the binary, got:\n%s", stderr)
+	}
+}
+
+// TestDoctorPrecedenceAllowsShim guards the other false positive. tsuku owns
+// two PATH entries and the env file puts bin ahead of tools/current, so a shim
+// winning over the version symlink is the design working.
+func TestDoctorPrecedenceAllowsShim(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("execute-bit resolution differs on Windows")
+	}
+
+	env := newPrecedenceEnv(t)
+	env.installVisibleTool(t, "ripgrep", "rg")
+	if err := os.WriteFile(filepath.Join(env.binDir, "rg"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("writing shim: %v", err)
+	}
+
+	t.Setenv("PATH", strings.Join([]string{env.binDir, env.currentDir, env.shadowDir}, string(os.PathListSeparator)))
+
+	stdout, _ := captureDoctorOutput(func() {
+		runDoctorChecks(env.config(), env.home)
+	})
+
+	line := precedenceLine(t, stdout)
+	if strings.Contains(line, "WARN") {
+		t.Errorf("a shim in $TSUKU_HOME/bin must not be reported as shadowing, got %q", line)
+	}
+}

--- a/internal/install/precedence.go
+++ b/internal/install/precedence.go
@@ -1,0 +1,78 @@
+package install
+
+import (
+	"path/filepath"
+	"sort"
+
+	"github.com/tsukumogami/tsuku/internal/shellenv"
+)
+
+// BuildManagedBinaries projects state onto the set of binaries tsuku claims a
+// PATH entry for: one entry per visible tool, carrying the binary names its
+// active version provides. Pure -- it reads state and nothing else.
+//
+// Hidden tools are left out, and that exclusion is the whole reason this is a
+// projection rather than a range over state.Installed. A hidden tool is
+// installed with CreateSymlinks false, so it has no entry in tools/current at
+// all; its name resolves to a system copy on a perfectly healthy machine.
+// Including hidden tools would make doctor warn once per execution dependency
+// for everyone.
+//
+// A tool whose active version records no binaries falls back to the deprecated
+// tool-level list, then to the tool's own name. Binary names are basenames: a
+// recipe can record "bin/rg", and it is "rg" that goes on PATH.
+func BuildManagedBinaries(state *State) []shellenv.ManagedBinaries {
+	if state == nil {
+		return nil
+	}
+
+	var managed []shellenv.ManagedBinaries
+	for name, ts := range state.Installed {
+		if ts.IsHidden {
+			continue
+		}
+		if binaries := binariesForActiveVersion(name, ts); len(binaries) > 0 {
+			managed = append(managed, shellenv.ManagedBinaries{
+				Tool:     name,
+				Binaries: binaries,
+			})
+		}
+	}
+
+	// state.Installed is a map, so without this the warning order changes
+	// between runs of the same unchanged environment.
+	sort.Slice(managed, func(i, j int) bool { return managed[i].Tool < managed[j].Tool })
+
+	return managed
+}
+
+// binariesForActiveVersion returns the binary basenames the tool's active
+// version puts on PATH, deduplicated and ordered.
+func binariesForActiveVersion(name string, ts ToolState) []string {
+	activeVersion := ts.ActiveVersion
+	if activeVersion == "" {
+		activeVersion = ts.Version // legacy state files
+	}
+
+	raw := ts.Versions[activeVersion].Binaries
+	if len(raw) == 0 {
+		raw = ts.Binaries // deprecated tool-level list
+	}
+	if len(raw) == 0 {
+		raw = []string{name}
+	}
+
+	seen := make(map[string]bool, len(raw))
+	var binaries []string
+	for _, entry := range raw {
+		base := filepath.Base(entry)
+		if base == "" || base == "." || base == string(filepath.Separator) || seen[base] {
+			continue
+		}
+		seen[base] = true
+		binaries = append(binaries, base)
+	}
+	sort.Strings(binaries)
+
+	return binaries
+}

--- a/internal/install/precedence_test.go
+++ b/internal/install/precedence_test.go
@@ -1,0 +1,170 @@
+package install
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/tsukumogami/tsuku/internal/shellenv"
+)
+
+func TestBuildManagedBinaries(t *testing.T) {
+	tests := []struct {
+		name  string
+		state *State
+		want  []shellenv.ManagedBinaries
+	}{
+		{
+			name:  "nil state yields nothing",
+			state: nil,
+		},
+		{
+			name:  "empty state yields nothing",
+			state: &State{Installed: map[string]ToolState{}},
+		},
+		{
+			name: "the active version's binaries are used",
+			state: &State{Installed: map[string]ToolState{
+				"ripgrep": {
+					ActiveVersion: "14.1.0",
+					Versions: map[string]VersionState{
+						"14.1.0": {Binaries: []string{"rg"}},
+						"13.0.0": {Binaries: []string{"rg-old"}},
+					},
+				},
+			}},
+			want: []shellenv.ManagedBinaries{{Tool: "ripgrep", Binaries: []string{"rg"}}},
+		},
+		{
+			name: "a hidden tool is excluded",
+			state: &State{Installed: map[string]ToolState{
+				"node": {
+					ActiveVersion: "22.0.0",
+					IsHidden:      true,
+					Versions:      map[string]VersionState{"22.0.0": {Binaries: []string{"node", "npm"}}},
+				},
+				"koto": {
+					ActiveVersion: "0.11.3",
+					Versions:      map[string]VersionState{"0.11.3": {Binaries: []string{"koto"}}},
+				},
+			}},
+			want: []shellenv.ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}},
+		},
+		{
+			name: "a visible tool installed as a dependency is included",
+			state: &State{Installed: map[string]ToolState{
+				"jq": {
+					ActiveVersion: "1.7",
+					IsExplicit:    false,
+					RequiredBy:    []string{"somethingelse"},
+					Versions:      map[string]VersionState{"1.7": {Binaries: []string{"jq"}}},
+				},
+			}},
+			want: []shellenv.ManagedBinaries{{Tool: "jq", Binaries: []string{"jq"}}},
+		},
+		{
+			name: "the deprecated tool-level list is the first fallback",
+			state: &State{Installed: map[string]ToolState{
+				"ripgrep": {
+					ActiveVersion: "14.1.0",
+					Binaries:      []string{"rg"},
+					Versions:      map[string]VersionState{"14.1.0": {}},
+				},
+			}},
+			want: []shellenv.ManagedBinaries{{Tool: "ripgrep", Binaries: []string{"rg"}}},
+		},
+		{
+			name: "the tool's own name is the last fallback",
+			state: &State{Installed: map[string]ToolState{
+				"koto": {
+					ActiveVersion: "0.11.3",
+					Versions:      map[string]VersionState{"0.11.3": {}},
+				},
+			}},
+			want: []shellenv.ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}},
+		},
+		{
+			name: "a legacy state file's Version field names the active version",
+			state: &State{Installed: map[string]ToolState{
+				"koto": {
+					Version:  "0.10.0",
+					Versions: map[string]VersionState{"0.10.0": {Binaries: []string{"koto"}}},
+				},
+			}},
+			want: []shellenv.ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}},
+		},
+		{
+			name: "a recorded path is reduced to the basename that goes on PATH",
+			state: &State{Installed: map[string]ToolState{
+				"ripgrep": {
+					ActiveVersion: "14.1.0",
+					Versions:      map[string]VersionState{"14.1.0": {Binaries: []string{"bin/rg"}}},
+				},
+			}},
+			want: []shellenv.ManagedBinaries{{Tool: "ripgrep", Binaries: []string{"rg"}}},
+		},
+		{
+			name: "duplicate binary names collapse",
+			state: &State{Installed: map[string]ToolState{
+				"ripgrep": {
+					ActiveVersion: "14.1.0",
+					Versions:      map[string]VersionState{"14.1.0": {Binaries: []string{"rg", "bin/rg"}}},
+				},
+			}},
+			want: []shellenv.ManagedBinaries{{Tool: "ripgrep", Binaries: []string{"rg"}}},
+		},
+		{
+			name: "output is ordered by tool name",
+			state: &State{Installed: map[string]ToolState{
+				"zoxide":  {ActiveVersion: "1", Versions: map[string]VersionState{"1": {Binaries: []string{"z"}}}},
+				"atuin":   {ActiveVersion: "1", Versions: map[string]VersionState{"1": {Binaries: []string{"atuin"}}}},
+				"koto":    {ActiveVersion: "1", Versions: map[string]VersionState{"1": {Binaries: []string{"koto"}}}},
+				"shirabe": {ActiveVersion: "1", Versions: map[string]VersionState{"1": {Binaries: []string{"shirabe"}}}},
+			}},
+			want: []shellenv.ManagedBinaries{
+				{Tool: "atuin", Binaries: []string{"atuin"}},
+				{Tool: "koto", Binaries: []string{"koto"}},
+				{Tool: "shirabe", Binaries: []string{"shirabe"}},
+				{Tool: "zoxide", Binaries: []string{"z"}},
+			},
+		},
+		{
+			name: "a tool providing several binaries lists them all",
+			state: &State{Installed: map[string]ToolState{
+				"git": {
+					ActiveVersion: "2.45.0",
+					Versions:      map[string]VersionState{"2.45.0": {Binaries: []string{"git", "git-lfs"}}},
+				},
+			}},
+			want: []shellenv.ManagedBinaries{{Tool: "git", Binaries: []string{"git", "git-lfs"}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildManagedBinaries(tt.state)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BuildManagedBinaries() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestBuildManagedBinariesOrderIsStable guards against the map-iteration order
+// leaking into doctor's output, which would make two runs of an unchanged
+// environment disagree.
+func TestBuildManagedBinariesOrderIsStable(t *testing.T) {
+	state := &State{Installed: map[string]ToolState{
+		"zoxide":  {ActiveVersion: "1", Versions: map[string]VersionState{"1": {Binaries: []string{"z"}}}},
+		"atuin":   {ActiveVersion: "1", Versions: map[string]VersionState{"1": {Binaries: []string{"atuin"}}}},
+		"koto":    {ActiveVersion: "1", Versions: map[string]VersionState{"1": {Binaries: []string{"koto"}}}},
+		"shirabe": {ActiveVersion: "1", Versions: map[string]VersionState{"1": {Binaries: []string{"shirabe"}}}},
+		"jq":      {ActiveVersion: "1", Versions: map[string]VersionState{"1": {Binaries: []string{"jq"}}}},
+	}}
+
+	first := BuildManagedBinaries(state)
+	for i := 0; i < 20; i++ {
+		if got := BuildManagedBinaries(state); !reflect.DeepEqual(got, first) {
+			t.Fatalf("run %d returned %+v, want %+v", i, got, first)
+		}
+	}
+}

--- a/internal/shellenv/precedence.go
+++ b/internal/shellenv/precedence.go
@@ -1,0 +1,206 @@
+package shellenv
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// ManagedBinaries names the binaries one managed tool puts on PATH.
+type ManagedBinaries struct {
+	// Tool is the tsuku tool name, used to attribute a shadowed binary back to
+	// something the user can act on. It is not always the binary name --
+	// ripgrep provides rg.
+	Tool string
+
+	// Binaries are the binary names the tool's active version provides.
+	Binaries []string
+}
+
+// ShadowedBinary reports one binary that resolves to something other than
+// tsuku's copy.
+type ShadowedBinary struct {
+	// Tool is the managed tool that provides Binary.
+	Tool string
+
+	// Binary is the name as it appears on PATH.
+	Binary string
+
+	// Resolved is the path a shell would actually run.
+	Resolved string
+
+	// Expected is tsuku's own copy, the one Resolved is winning against.
+	Expected string
+}
+
+// PrecedenceInput carries everything CheckPrecedence needs. PathDirs is passed
+// in rather than read from the environment so the check can be exercised
+// without mutating the process's own PATH.
+type PrecedenceInput struct {
+	// TsukuHome is $TSUKU_HOME.
+	TsukuHome string
+
+	// PathDirs is PATH already split, in order. Callers pass
+	// filepath.SplitList(os.Getenv("PATH")).
+	PathDirs []string
+
+	// Tools are the visible managed tools to check. Hidden tools must not
+	// appear here: they are installed with CreateSymlinks false, so they have
+	// no entry in tools/current and every one of them would resolve to a
+	// system copy on a healthy machine. install.BuildManagedBinaries builds
+	// this list with that exclusion applied.
+	Tools []ManagedBinaries
+}
+
+// CheckPrecedence reports the managed binaries that something earlier on PATH
+// is shadowing.
+//
+// doctor's other PATH checks ask whether tsuku's directories are present. This
+// one asks whether they win, which is a different question: a directory can sit
+// on PATH behind a competing installer's prefix and never be reached. The
+// invariant is that a binary tsuku put on PATH is the one that answers.
+//
+// A binary is shadowed when the first executable of that name along PATH lies
+// outside $TSUKU_HOME entirely. The question is whether a competing installer's
+// prefix is winning, so anywhere under $TSUKU_HOME counts as tsuku's and none of
+// them is a conflict. There are more of those than the two the env file puts on
+// PATH: $TSUKU_HOME/bin holds shims and comes first, $TSUKU_HOME/tools/current
+// holds the version symlinks, and a tool's own $TSUKU_HOME/tools/<name>-<version>/bin
+// lands on PATH whenever a recipe exports it or tsuku runs the tool with its
+// runtime dependencies. Comparing against tools/current alone reports all three
+// of the others, which on a real machine means a warning per shim and per
+// exported install directory.
+//
+// A binary that resolves nowhere is not reported. That is a broken install
+// rather than a precedence problem, and the tools/current and bin checks
+// already speak to it.
+func CheckPrecedence(in PrecedenceInput) []ShadowedBinary {
+	home := absHome(in.TsukuHome)
+	if home == "" {
+		return nil
+	}
+
+	// Resolve once per binary name. Two tools that both provide a binary of the
+	// same name would otherwise walk PATH twice and report it twice.
+	seen := make(map[string]bool)
+
+	var shadowed []ShadowedBinary
+	for _, tool := range in.Tools {
+		for _, binary := range tool.Binaries {
+			if binary == "" || seen[binary] {
+				continue
+			}
+			seen[binary] = true
+
+			resolved := resolveOnPath(in.PathDirs, binary)
+			if resolved == "" {
+				continue
+			}
+			if withinHome(home, resolved) {
+				continue
+			}
+
+			expected := ownedCopy(in.TsukuHome, binary)
+			if expected == "" {
+				// tsuku records the binary but has no copy of it on disk. The
+				// name resolving elsewhere is then correct, not a shadow.
+				continue
+			}
+
+			shadowed = append(shadowed, ShadowedBinary{
+				Tool:     tool.Tool,
+				Binary:   binary,
+				Resolved: resolved,
+				Expected: expected,
+			})
+		}
+	}
+
+	return shadowed
+}
+
+// absHome cleans and absolutizes $TSUKU_HOME. Absolutizing matters: a relative
+// home compared against the absolute path a PATH walk produces matches nothing,
+// which would turn every managed binary into a reported shadow. An empty home is
+// rejected rather than absolutized, since it would otherwise resolve to whatever
+// directory doctor happened to run in.
+func absHome(tsukuHome string) string {
+	if tsukuHome == "" {
+		return ""
+	}
+	home, err := filepath.Abs(tsukuHome)
+	if err != nil {
+		return ""
+	}
+	return home
+}
+
+// withinHome reports whether path lies inside home. Both are already cleaned
+// absolute paths.
+//
+// The trailing separator is what keeps a sibling from matching: without it
+// "/home/u/.tsuku-backup/bin/rg" reads as living under "/home/u/.tsuku". Same
+// reason ValidateSymlinkTarget adds one.
+func withinHome(home, path string) bool {
+	return strings.HasPrefix(path, home+string(filepath.Separator))
+}
+
+// ownedCopy returns tsuku's own path for a binary, preferring bin/ because PATH
+// order does. An empty result means tsuku has no copy on disk.
+func ownedCopy(tsukuHome, binary string) string {
+	for _, dir := range []string{
+		filepath.Join(tsukuHome, "bin"),
+		filepath.Join(tsukuHome, "tools", "current"),
+	} {
+		candidate := filepath.Join(dir, binary)
+		if isExecutableFile(candidate) {
+			abs, err := filepath.Abs(candidate)
+			if err != nil {
+				return candidate
+			}
+			return abs
+		}
+	}
+	return ""
+}
+
+// resolveOnPath walks dirs in order and returns the first executable named
+// binary, as an absolute cleaned path. It reproduces what a shell does rather
+// than calling exec.LookPath, which consults the process's own environment.
+//
+// An empty PATH entry means the working directory to a shell. That is not a
+// place tsuku can reason about, and treating it as one would make the result
+// depend on where doctor was run, so it is skipped.
+func resolveOnPath(dirs []string, binary string) string {
+	for _, dir := range dirs {
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, binary)
+		if !isExecutableFile(candidate) {
+			continue
+		}
+		abs, err := filepath.Abs(candidate)
+		if err != nil {
+			return candidate
+		}
+		return abs
+	}
+	return ""
+}
+
+// isExecutableFile reports whether path is something a shell would run: a
+// regular file (following symlinks, since tools/current is all symlinks) with
+// an execute bit. On Windows the mode bits carry no such signal, so existence
+// is the whole test.
+func isExecutableFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		return true
+	}
+	return info.Mode().Perm()&0111 != 0
+}

--- a/internal/shellenv/precedence_test.go
+++ b/internal/shellenv/precedence_test.go
@@ -1,0 +1,401 @@
+package shellenv
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// precedenceFixture lays out a $TSUKU_HOME and a competing prefix under one
+// temp root, so a test can build a PATH without naming anything real.
+type precedenceFixture struct {
+	root       string
+	tsukuHome  string
+	binDir     string
+	currentDir string
+	otherDir   string
+}
+
+func newPrecedenceFixture(t *testing.T) precedenceFixture {
+	t.Helper()
+
+	root := t.TempDir()
+	f := precedenceFixture{
+		root:       root,
+		tsukuHome:  filepath.Join(root, "tsuku"),
+		binDir:     filepath.Join(root, "tsuku", "bin"),
+		currentDir: filepath.Join(root, "tsuku", "tools", "current"),
+		otherDir:   filepath.Join(root, "other", "bin"),
+	}
+	for _, dir := range []string{f.binDir, f.currentDir, f.otherDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", dir, err)
+		}
+	}
+	return f
+}
+
+// writeExecutable creates a runnable file. Windows has no execute bit, so the
+// mode is advisory there and existence is what counts.
+func writeExecutable(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+	return path
+}
+
+func writeNonExecutable(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("not runnable\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+	return path
+}
+
+func TestCheckPrecedence(t *testing.T) {
+	tests := []struct {
+		name string
+		// setup places binaries and returns the PATH dirs in order plus the
+		// tools to check.
+		setup func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries)
+		// wantShadowed lists the binary names expected in the result, in order.
+		wantShadowed []string
+		// wantResolvedIn and wantExpectedIn name the fixture directories the
+		// single expected finding should point at. Empty means unchecked.
+		wantResolvedIn func(f precedenceFixture) string
+		wantExpectedIn func(f precedenceFixture) string
+	}{
+		{
+			name: "shadow ahead of tools/current is reported",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				writeExecutable(t, f.otherDir, "koto")
+				writeExecutable(t, f.currentDir, "koto")
+				return []string{f.otherDir, f.binDir, f.currentDir},
+					[]ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}}
+			},
+			wantShadowed:   []string{"koto"},
+			wantResolvedIn: func(f precedenceFixture) string { return f.otherDir },
+			wantExpectedIn: func(f precedenceFixture) string { return f.currentDir },
+		},
+		{
+			name: "shadow ahead of bin is reported",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				writeExecutable(t, f.otherDir, "rg")
+				writeExecutable(t, f.binDir, "rg")
+				return []string{f.otherDir, f.binDir, f.currentDir},
+					[]ManagedBinaries{{Tool: "ripgrep", Binaries: []string{"rg"}}}
+			},
+			wantShadowed:   []string{"rg"},
+			wantResolvedIn: func(f precedenceFixture) string { return f.otherDir },
+			wantExpectedIn: func(f precedenceFixture) string { return f.binDir },
+		},
+		{
+			name: "tsuku's copy first is not reported",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				writeExecutable(t, f.currentDir, "koto")
+				writeExecutable(t, f.otherDir, "koto")
+				return []string{f.binDir, f.currentDir, f.otherDir},
+					[]ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}}
+			},
+		},
+		{
+			name: "a shim in bin winning over tools/current is not a conflict",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				writeExecutable(t, f.binDir, "rg")
+				writeExecutable(t, f.currentDir, "rg")
+				return []string{f.binDir, f.currentDir, f.otherDir},
+					[]ManagedBinaries{{Tool: "ripgrep", Binaries: []string{"rg"}}}
+			},
+		},
+		{
+			name: "a shim with no tools/current copy is not a conflict",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				writeExecutable(t, f.binDir, "rg")
+				return []string{f.binDir, f.currentDir, f.otherDir},
+					[]ManagedBinaries{{Tool: "ripgrep", Binaries: []string{"rg"}}}
+			},
+		},
+		{
+			// Found by running doctor against a live machine: a tool's own
+			// install directory lands on PATH ahead of tools/current whenever a
+			// recipe exports it or tsuku runs the tool with its runtime
+			// dependencies. The binary reached is tsuku's, for the active
+			// version. Reporting it was a false positive on every such tool.
+			name: "a tool's own install directory ahead of tools/current is not a shadow",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				installBin := filepath.Join(f.tsukuHome, "tools", "socat-1.8.1.3", "bin")
+				if err := os.MkdirAll(installBin, 0o755); err != nil {
+					t.Fatalf("MkdirAll: %v", err)
+				}
+				writeExecutable(t, installBin, "socat")
+				writeExecutable(t, f.currentDir, "socat")
+				return []string{installBin, f.binDir, f.currentDir, f.otherDir},
+					[]ManagedBinaries{{Tool: "socat", Binaries: []string{"socat"}}}
+			},
+		},
+		{
+			// The trailing-separator case: a directory whose name merely starts
+			// with $TSUKU_HOME is not inside it.
+			name: "a sibling directory sharing the home's prefix is a shadow",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				lookalike := f.tsukuHome + "-backup"
+				if err := os.MkdirAll(lookalike, 0o755); err != nil {
+					t.Fatalf("MkdirAll: %v", err)
+				}
+				writeExecutable(t, lookalike, "koto")
+				writeExecutable(t, f.currentDir, "koto")
+				return []string{lookalike, f.binDir, f.currentDir},
+					[]ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}}
+			},
+			wantShadowed: []string{"koto"},
+		},
+		{
+			name: "a non-executable file earlier on PATH does not shadow",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				writeNonExecutable(t, f.otherDir, "koto")
+				writeExecutable(t, f.currentDir, "koto")
+				return []string{f.otherDir, f.binDir, f.currentDir},
+					[]ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}}
+			},
+		},
+		{
+			name: "a directory earlier on PATH does not shadow",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				if err := os.MkdirAll(filepath.Join(f.otherDir, "koto"), 0o755); err != nil {
+					t.Fatalf("MkdirAll: %v", err)
+				}
+				writeExecutable(t, f.currentDir, "koto")
+				return []string{f.otherDir, f.binDir, f.currentDir},
+					[]ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}}
+			},
+		},
+		{
+			name: "a binary that resolves nowhere is not reported",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				return []string{f.binDir, f.currentDir, f.otherDir},
+					[]ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}}
+			},
+		},
+		{
+			name: "a binary tsuku has no copy of is not reported",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				writeExecutable(t, f.otherDir, "koto")
+				return []string{f.otherDir, f.binDir, f.currentDir},
+					[]ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}}
+			},
+		},
+		{
+			name: "an uncleaned PATH entry naming a tsuku directory is not a shadow",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				writeExecutable(t, f.currentDir, "koto")
+				// Built by concatenation rather than filepath.Join, which would
+				// clean the ".." away before the check ever sees it.
+				sep := string(filepath.Separator)
+				uncleaned := f.binDir + sep + ".." + sep + "tools" + sep + "current"
+				return []string{uncleaned, f.otherDir},
+					[]ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}}
+			},
+		},
+		{
+			name: "a shadow later on PATH than tsuku's copy is not reported",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				writeExecutable(t, f.currentDir, "koto")
+				writeExecutable(t, f.otherDir, "koto")
+				return []string{f.currentDir, f.otherDir},
+					[]ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}}
+			},
+		},
+		{
+			name: "a binary named differently from its tool is reported under the tool",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				writeExecutable(t, f.otherDir, "rg")
+				writeExecutable(t, f.currentDir, "rg")
+				return []string{f.otherDir, f.currentDir},
+					[]ManagedBinaries{{Tool: "ripgrep", Binaries: []string{"rg"}}}
+			},
+			wantShadowed:   []string{"rg"},
+			wantResolvedIn: func(f precedenceFixture) string { return f.otherDir },
+			wantExpectedIn: func(f precedenceFixture) string { return f.currentDir },
+		},
+		{
+			name: "an empty PATH entry is skipped rather than treated as the working directory",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				// A shell reads an empty PATH entry as the working directory.
+				// Honoring that would make the result depend on where doctor
+				// was run, so chdir somewhere holding a competing binary and
+				// assert it is not picked up.
+				cwd := filepath.Join(f.root, "cwd")
+				if err := os.MkdirAll(cwd, 0o755); err != nil {
+					t.Fatalf("MkdirAll: %v", err)
+				}
+				writeExecutable(t, cwd, "koto")
+				t.Chdir(cwd)
+
+				writeExecutable(t, f.currentDir, "koto")
+				return []string{"", f.currentDir},
+					[]ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}}
+			},
+		},
+		{
+			name: "each of a tool's binaries is checked",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				writeExecutable(t, f.currentDir, "git")
+				writeExecutable(t, f.currentDir, "git-lfs")
+				writeExecutable(t, f.otherDir, "git-lfs")
+				return []string{f.otherDir, f.currentDir},
+					[]ManagedBinaries{{Tool: "git", Binaries: []string{"git", "git-lfs"}}}
+			},
+			wantShadowed: []string{"git-lfs"},
+		},
+		{
+			name: "a binary two tools both claim is reported once",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				writeExecutable(t, f.otherDir, "node")
+				writeExecutable(t, f.currentDir, "node")
+				return []string{f.otherDir, f.currentDir}, []ManagedBinaries{
+					{Tool: "node", Binaries: []string{"node"}},
+					{Tool: "nodejs", Binaries: []string{"node"}},
+				}
+			},
+			wantShadowed: []string{"node"},
+		},
+		{
+			name: "an empty binary name is skipped",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				return []string{f.otherDir, f.currentDir},
+					[]ManagedBinaries{{Tool: "koto", Binaries: []string{""}}}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if runtime.GOOS == "windows" {
+				t.Skip("execute-bit resolution differs on Windows")
+			}
+
+			f := newPrecedenceFixture(t)
+			pathDirs, tools := tt.setup(t, f)
+
+			got := CheckPrecedence(PrecedenceInput{
+				TsukuHome: f.tsukuHome,
+				PathDirs:  pathDirs,
+				Tools:     tools,
+			})
+
+			if len(got) != len(tt.wantShadowed) {
+				t.Fatalf("CheckPrecedence returned %d findings %+v, want %d %v",
+					len(got), got, len(tt.wantShadowed), tt.wantShadowed)
+			}
+			for i, want := range tt.wantShadowed {
+				if got[i].Binary != want {
+					t.Errorf("finding %d: Binary = %q, want %q", i, got[i].Binary, want)
+				}
+			}
+			if len(got) != 1 {
+				return
+			}
+			if tt.wantResolvedIn != nil {
+				if dir := filepath.Dir(got[0].Resolved); dir != tt.wantResolvedIn(f) {
+					t.Errorf("Resolved = %q, want a path in %q", got[0].Resolved, tt.wantResolvedIn(f))
+				}
+			}
+			if tt.wantExpectedIn != nil {
+				if dir := filepath.Dir(got[0].Expected); dir != tt.wantExpectedIn(f) {
+					t.Errorf("Expected = %q, want a path in %q", got[0].Expected, tt.wantExpectedIn(f))
+				}
+			}
+		})
+	}
+}
+
+// TestCheckPrecedenceAttributesToolAndPaths pins the content of a finding. The
+// resolved path is the thing a user cannot easily discover on their own, so an
+// assertion that merely counts findings would not be pinning what matters.
+func TestCheckPrecedenceAttributesToolAndPaths(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("execute-bit resolution differs on Windows")
+	}
+
+	f := newPrecedenceFixture(t)
+	shadowPath := writeExecutable(t, f.otherDir, "koto")
+	tsukuPath := writeExecutable(t, f.currentDir, "koto")
+
+	got := CheckPrecedence(PrecedenceInput{
+		TsukuHome: f.tsukuHome,
+		PathDirs:  []string{f.otherDir, f.binDir, f.currentDir},
+		Tools:     []ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}},
+	})
+
+	if len(got) != 1 {
+		t.Fatalf("CheckPrecedence returned %d findings, want 1: %+v", len(got), got)
+	}
+	if got[0].Tool != "koto" {
+		t.Errorf("Tool = %q, want %q", got[0].Tool, "koto")
+	}
+	if got[0].Resolved != shadowPath {
+		t.Errorf("Resolved = %q, want %q", got[0].Resolved, shadowPath)
+	}
+	if got[0].Expected != tsukuPath {
+		t.Errorf("Expected = %q, want %q", got[0].Expected, tsukuPath)
+	}
+}
+
+// TestCheckPrecedenceRelativeTsukuHome pins the absolutization of the owned
+// directories. A relative home compared against the absolute path a PATH walk
+// produces matches nothing, which would turn every managed binary into a
+// reported shadow -- the loudest possible false positive.
+func TestCheckPrecedenceRelativeTsukuHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("execute-bit resolution differs on Windows")
+	}
+
+	f := newPrecedenceFixture(t)
+	writeExecutable(t, f.currentDir, "koto")
+	t.Chdir(f.root)
+
+	got := CheckPrecedence(PrecedenceInput{
+		TsukuHome: "tsuku", // relative to the working directory
+		PathDirs:  []string{f.currentDir},
+		Tools:     []ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}},
+	})
+
+	if len(got) != 0 {
+		t.Errorf("a relative TsukuHome must still recognize its own directories, got %+v", got)
+	}
+}
+
+// TestCheckPrecedenceWithoutTsukuHome guards the zero value. An empty home
+// would otherwise absolutize to the working directory, so doctor would compare
+// managed binaries against a "bin" and "tools/current" that happen to sit
+// wherever it was run from.
+func TestCheckPrecedenceWithoutTsukuHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("execute-bit resolution differs on Windows")
+	}
+
+	f := newPrecedenceFixture(t)
+	writeExecutable(t, f.otherDir, "koto")
+
+	// A working directory that looks like a tsuku home, so the guard is what
+	// stops the check rather than the absence of a copy to compare against.
+	decoy := filepath.Join(f.root, "decoy")
+	if err := os.MkdirAll(filepath.Join(decoy, "bin"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeExecutable(t, filepath.Join(decoy, "bin"), "koto")
+	t.Chdir(decoy)
+
+	got := CheckPrecedence(PrecedenceInput{
+		PathDirs: []string{f.otherDir},
+		Tools:    []ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}},
+	})
+
+	if got != nil {
+		t.Errorf("CheckPrecedence with no TsukuHome returned %+v, want nil", got)
+	}
+}

--- a/plugins/tsuku-user/skills/tsuku-user/SKILL.md
+++ b/plugins/tsuku-user/skills/tsuku-user/SKILL.md
@@ -177,7 +177,7 @@ The cache is rebuilt whenever the active version changes: install, upgrade, `act
 tsuku doctor
 ```
 
-Doctor checks that `$TSUKU_HOME` exists, both directories are on PATH, the state file is accessible, shell init caches are current, and no orphaned staging directories remain. If something's wrong, it tells you what to fix.
+Doctor checks that `$TSUKU_HOME` exists, both directories are on PATH, the state file is accessible, shell init caches are current, no orphaned staging directories remain, and every tool tsuku manages is the one your shell actually reaches. If something's wrong, it tells you what to fix.
 
 Three shell.d diagnostics are worth knowing:
 
@@ -192,6 +192,25 @@ tsuku doctor --fix
 ```
 
 `--fix` repairs the two things it can generate from scratch: a stale `$TSUKU_HOME/env`, and stale shell caches. It won't touch a hash mismatch or a symlink, because both mean something outside tsuku wrote into `share/shell.d/` and tsuku can't reproduce the original bytes. Recover with `tsuku remove <tool>@<version> && tsuku install <tool>@<version>`, or delete the offending file if you put it there.
+
+### When Another Copy Wins
+
+The `Tool precedence` check is the one that catches a problem nothing else reports:
+
+```
+  Tool precedence ... WARN (1 shadowed)
+    koto resolves to /home/you/.koto/bin/koto, not tsuku's $TSUKU_HOME/tools/current/koto
+```
+
+tsuku is fine here. It resolved the pin, installed the right version, and pointed `tools/current` at it. What's wrong is your PATH: something earlier on it provides a binary of the same name, so that's what runs. It happens when another installer prepends its own prefix — `~/.koto/env`, `~/.cargo/env`, a language version manager — and your shell profile sources it *after* `$TSUKU_HOME/env`. Whichever prepend runs last wins.
+
+This is easy to miss, because every other signal looks healthy. `tsuku list` shows the version you expect, `tsuku outdated` finds nothing, and the tool keeps working — it just keeps working at whatever version the other copy is pinned to, forever.
+
+Two ways out: move the tsuku entries ahead of the competing prefix in your profile (source `$TSUKU_HOME/env` last), or remove the other copy. If you put the other one first on purpose, ignore the warning — it's a `WARN`, it doesn't change the exit code, and `tsuku doctor || exit 1` keeps passing.
+
+`--fix` won't touch this. Which directory wins is a property of your shell profile, and tsuku doesn't edit that.
+
+Only tools that are visible on PATH are checked. Execution dependencies tsuku installed for its own use — the npm or Python behind a recipe — are deliberately kept off PATH, so a system copy answering for them isn't a conflict.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Doctor checked that `$TSUKU_HOME/bin` and `$TSUKU_HOME/tools/current` are present on PATH. It never checked that they win. A competing installer that prepends its own prefix after `$TSUKU_HOME/env` has been sourced leaves both checks green while every command runs the other copy, so a tool can sit several releases stale indefinitely with tsuku reporting a clean bill of health. `tsuku list` shows the version tsuku installed, `tsuku outdated` finds nothing, and neither consults PATH. `tsuku verify <tool>` does resolve along PATH, but it takes exactly one tool by name, so nothing has ever swept the managed set.

Add a ninth check. `shellenv.CheckPrecedence` walks PATH the way a shell does, takes the first executable of each managed binary's name, and reports the ones that land outside `$TSUKU_HOME` entirely, naming both the path that won and tsuku's own. The resolved path is the part a user cannot easily discover -- finding it today means reading `which -a` by hand.

Two exclusions decide whether this is usable or noise.

Anywhere under `$TSUKU_HOME` counts as tsuku's, not just the two directories the env file puts on PATH. There are more than two: `bin` holds shims and comes first, `tools/current` holds the version symlinks, and a tool's own `tools/<name>-<version>/bin` lands on PATH whenever a recipe exports it or tsuku runs the tool with its runtime dependencies. Comparing against `tools/current` alone reported all of the others -- on a live machine that was eight warnings, every one of them naming a binary tsuku had installed and the user was correctly running. The question the check asks is whether a foreign prefix is winning, so the boundary is `$TSUKU_HOME` itself.

Hidden tools are left out. `install.BuildManagedBinaries` projects state onto the binaries tsuku actually claims a PATH entry for, and an execution dependency is installed with `CreateSymlinks: false` -- it has no entry in `tools/current` at all, so its name resolves to a system copy on every healthy machine. Checking those would mean one warning per hidden dependency for everyone.

Resolution walks a caller-supplied PATH rather than calling `exec.LookPath`, which consults the process's own environment and cannot be varied under test. An empty PATH entry, which a shell reads as the working directory, is skipped -- honoring it would make the result depend on where doctor was run.

It warns rather than fails. Doctor is documented as a CI gate, and which copy wins is a property of the user's shell profile that they may have arranged on purpose. `--fix` doesn't touch it, because tsuku doesn't edit shell profiles.

Document the check and the shadowing case it catches in the tsuku-user skill.

---

## What the user sees

```
  Tool precedence ... WARN (1 shadowed)
    koto resolves to /home/you/.koto/bin/koto, not tsuku's $TSUKU_HOME/tools/current/koto
    Something earlier on PATH is shadowing a tsuku-managed tool.
    Move the tsuku entries ahead of it, or remove the other copy.
```

The owning tool is named beside the binary when the two differ, so a warning about `rg` reads `rg (ripgrep)` and points at the entry to act on.

## The two refinements the issue raised

Both were evaluated and declined rather than deferred.

Version comparison would mean executing an arbitrary program found on PATH to ask its version, with no knowable flag (`--version` / `version` / `-V`) and output that has to be guessed at. And a same-version shadow isn't benign: the next `tsuku update` moves tsuku's copy and the shadow goes stale again, which is the exact failure that produced this issue.

An acknowledgment mechanism is new `config.toml` surface plus a second code path for a complaint nobody has filed. WARN already keeps a deliberate shadow non-fatal and off the exit code. If warning fatigue shows up, an acknowledge list is a small follow-up on this shape.

## Issue claims checked

The issue's stated consequence holds. `tsuku list` reads state and `tsuku outdated` compares state against upstream; neither consults PATH. Nothing resolved a managed binary along PATH except `tsuku verify <tool>`, which is `cobra.ExactArgs(1)` -- it has always been able to see this, one named tool at a time, and has never swept the managed set.

## A false positive that only a real machine exposed

Running doctor against a live `$TSUKU_HOME` produced eight warnings on a healthy install. bubblewrap and socat both resolved to their own `tools/<name>-<version>/bin`, which sits ahead of `tools/current` on that machine's PATH -- the active version's binary, exactly what the user should be running, reported as shadowed.

The unit fixture had only ever modeled three directories (`bin`, `tools/current`, and a foreign one), because the env file names only two tsuku entries. That is what moved the ownership test from "equals one of two directories" to "is inside `$TSUKU_HOME`". Two regression tests cover it, including the sibling-prefix case where `$TSUKU_HOME-backup` must not read as inside `$TSUKU_HOME`.

## Mutation testing

15 defects injected one at a time, each reverted after the run.

| # | Injected defect | Killed by |
|---|---|---|
| 1 | containment test drops the trailing separator | `TestCheckPrecedence/a_sibling_directory_sharing_the_home's_prefix_is_a_shadow` |
| 2 | hidden tools are checked too | `TestBuildManagedBinaries/a_hidden_tool_is_excluded` |
| 3 | `$TSUKU_HOME` is not absolutized | `TestCheckPrecedenceRelativeTsukuHome` |
| 4 | a non-executable entry counts as resolvable | `TestCheckPrecedence/a_non-executable_file_earlier_on_PATH_does_not_shadow` |
| 5 | containment test inverted | `TestCheckPrecedence/shadow_ahead_of_tools/current_is_reported` + 10 more |
| 6 | the tool name stands in for its binaries | `TestBuildManagedBinaries/the_active_version's_binaries_are_used` + 5 more |
| 7 | a binary two tools claim is resolved twice | `TestCheckPrecedence/a_binary_two_tools_both_claim_is_reported_once` |
| 8 | tool order follows map iteration | `TestBuildManagedBinariesOrderIsStable` |
| 9 | a binary tsuku has no copy of is still reported | `TestCheckPrecedence/a_binary_tsuku_has_no_copy_of_is_not_reported` |
| 10 | an empty PATH entry means the working directory | `TestCheckPrecedence/an_empty_PATH_entry_is_skipped...` |
| 11 | a recorded path is not reduced to its basename | `TestBuildManagedBinaries/a_recorded_path_is_reduced_to_the_basename...` |
| 12 | an empty `TsukuHome` is not guarded | `TestCheckPrecedenceWithoutTsukuHome` |
| 13 | only `tools/current` counts as tsuku's | `TestCheckPrecedence/a_tool's_own_install_directory_ahead_of_tools/current_is_not_a_shadow` + 2 more |
| 14 | the owning tool is not named beside the binary | `TestDoctorNamesTheToolBehindABinary` |
| 15 | a shadowed tool fails the environment check | `TestDoctorReportsShadowedTool` |

Two mutations initially survived, and in both cases the test was at fault rather than the code. The uncleaned-PATH case built its path with `filepath.Join`, which cleans, so it never passed an uncleaned entry. The empty-`TsukuHome` case was masked by the no-copy-on-disk guard downstream. Both were rewritten to discriminate.

## Testing

`go build`, `go vet ./...`, `gofmt -l`, and `go test ./...` all pass locally; the test run includes `TestGolangCILint`, which is the lint gate CI runs. Nothing is gated behind `testing.Short()`. Tests write only under `t.TempDir()`, including the "outside" shadowing directory.

QA scenarios driven through the built binary: the issue's reproduction, two tools shadowed at once, a hidden dependency with a system copy ahead of tsuku, a user reordering PATH to fix it, a shim in `bin` ahead of `tools/current`, `--fix`, an empty install, and a live `$TSUKU_HOME` read-only.

## Scope

`internal/shellenv/doctor.go` is untouched, so there's no collision with the fish-fragment work in #2471. The golden-plan workflow is not armed -- none of its allowlisted paths is in this diff.

Per the plugin-maintenance table, `plugins/tsuku-user` is updated here: the doctor section now lists the ninth check and a new subsection explains the shadowing case, why every other signal looks healthy while it happens, and why `--fix` can't repair it. `plugins/tsuku-recipes` needs no change -- no action name, recipe field, plan-generation rule, or validation exit code moved.

## Two defects found while working, filed separately

- #2506 -- `tsuku verify <tool>` reports a spurious PATH conflict for a tool the user shimmed, because it compares against `tools/current` alone. Same root-cause class as the QA false positive above, in a command this PR doesn't touch.
- #2507 -- doctor prints "Everything looks good!" underneath its own WARN lines. Pre-existing; fixing it changes the two older warning checks too.

## CI note

The Checksum Pinning Tests failure on the first run was the suse family's Docker image build timing out while retrieving `download.opensuse.org` repository metadata, and it was cancelled during image provisioning before any tsuku code ran. Unrelated to this diff, which touches no recipe, action, or verification path.

Fixes #2475
