### PR TITLE
fix(update): run the stale-cleanup pass on every update path

### DIFF
--- a/cmd/tsuku/cmd_apply_updates.go
+++ b/cmd/tsuku/cmd_apply_updates.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/tsukumogami/tsuku/internal/config"
+	"github.com/tsukumogami/tsuku/internal/install"
 	"github.com/tsukumogami/tsuku/internal/installevents"
 	"github.com/tsukumogami/tsuku/internal/notices"
 	"github.com/tsukumogami/tsuku/internal/progress"
@@ -36,36 +37,72 @@ var applyUpdatesCmd = &cobra.Command{
 			return nil
 		}
 
-		noticesDir := notices.NoticesDir(cfg.HomeDir)
-		var reporters []*progress.InboxReporter
-
 		// Background auto-apply: tag every event with SourceAuto on the
 		// context once so all downstream callsites read it via
 		// installevents.SourceFromContext.
 		ctx := installevents.WithSource(globalCtx, installevents.SourceAuto)
-		installFn := func(toolName, version, constraint string) error {
-			reporter := progress.NewInboxReporter(toolName, noticesDir)
-			reporters = append(reporters, reporter)
-			return runInstallWithReporter(ctx, installArgs{
+
+		installFn, flushNotices := autoApplyInstaller(
+			install.New(cfg),
+			notices.NoticesDir(cfg.HomeDir),
+			func(args installArgs) error { return runInstallWithReporter(ctx, args) },
+		)
+
+		updates.MaybeAutoApply(cfg, userCfg, nil, installFn, nil)
+		flushNotices()
+
+		return nil
+	},
+}
+
+// autoApplyInstaller builds the install callback the background apply path hands
+// to MaybeAutoApply, plus the function that flushes what those installs had to
+// say into $TSUKU_HOME/notices/.
+//
+// It takes the install itself as a parameter, rather than calling
+// runInstallWithReporter directly, so the wiring below can be driven by a test
+// that has no network.
+//
+// The stale-cleanup pass belongs here rather than inside MaybeAutoApply: that
+// function decides which tools to update, and this callback decides how one gets
+// installed. Bracketing it here gives the background path the same pass the two
+// foreground ones run, through the same helper.
+//
+// Warnings do reach the user even though apply-updates sends stdout and stderr
+// to /dev/null, because an InboxReporter accumulates them in memory and writes
+// them as a notice on Stop(). That is what makes the ordering load-bearing: the
+// reconcile has to happen inside the callback, before flushNotices runs, or the
+// warning is composed after the only thing that would have persisted it.
+func autoApplyInstaller(
+	mgr *install.Manager,
+	noticesDir string,
+	runInstall func(installArgs) error,
+) (updates.InstallFunc, func()) {
+	var reporters []*progress.InboxReporter
+
+	installFn := func(toolName, version, constraint string) error {
+		reporter := progress.NewInboxReporter(toolName, noticesDir)
+		reporters = append(reporters, reporter)
+
+		return updateWithCleanup(mgr, toolName, reporter.Warn, func() error {
+			return runInstall(installArgs{
 				Tool:              toolName,
 				ReqVersion:        version,
 				VersionConstraint: constraint,
 				Reporter:          reporter,
 			})
-		}
+		})
+	}
 
-		updates.MaybeAutoApply(cfg, userCfg, nil, installFn, nil)
-
-		// Stop reporters after MaybeAutoApply has written success notices.
-		// Reporters with no accumulated messages return early, leaving the
-		// success notice intact. Reporters with warnings (e.g., version_fallback)
-		// overwrite the success notice with a richer notice.
+	// Stopping the reporters is deferred until MaybeAutoApply has written its
+	// success notices. A reporter with nothing accumulated returns early and
+	// leaves that notice intact; one with warnings overwrites it with a richer
+	// notice.
+	return installFn, func() {
 		for _, r := range reporters {
 			r.Stop()
 		}
-
-		return nil
-	},
+	}
 }
 
 func init() {

--- a/cmd/tsuku/cmd_apply_updates_test.go
+++ b/cmd/tsuku/cmd_apply_updates_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tsukumogami/tsuku/internal/install"
+	"github.com/tsukumogami/tsuku/internal/notices"
+	"github.com/tsukumogami/tsuku/internal/testutil"
+)
+
+// TestAutoApplyInstaller_ShellInitChangeReachesTheNoticeInbox is the auto-apply
+// half of issue #2470, and the reason the warning is worth emitting on a path
+// that writes to /dev/null.
+//
+// apply-updates redirects stdout and stderr before it does anything, so nothing
+// printed there can reach a user. The InboxReporter is the channel that does:
+// warnings accumulate in memory and land as a notice the next foreground command
+// displays. This drives the real callback with the install substituted and reads
+// the notice back off disk.
+func TestAutoApplyInstaller_ShellInitChangeReachesTheNoticeInbox(t *testing.T) {
+	cfg, cleanup := testutil.NewTestConfig(t)
+	defer cleanup()
+
+	mgr := install.New(cfg)
+	noticesDir := notices.NoticesDir(cfg.HomeDir)
+
+	recordUpdateVersion(t, mgr, "mytool", "1.0.0", []install.CleanupAction{
+		updateFragment("mytool", "1.0.0", "bash", "before"),
+	})
+
+	installFn, flushNotices := autoApplyInstaller(mgr, noticesDir, func(installArgs) error {
+		// What the install would leave behind: a new active version whose bash
+		// init has different content.
+		recordUpdateVersion(t, mgr, "mytool", "2.0.0", []install.CleanupAction{
+			updateFragment("mytool", "2.0.0", "bash", "after"),
+		})
+		return nil
+	})
+
+	if err := installFn("mytool", "2.0.0", ""); err != nil {
+		t.Fatalf("the auto-apply install callback failed: %v", err)
+	}
+	flushNotices()
+
+	all, err := notices.ReadAllNotices(noticesDir)
+	if err != nil {
+		t.Fatalf("ReadAllNotices() error = %v", err)
+	}
+
+	var found bool
+	for _, n := range all {
+		for _, msg := range n.Messages {
+			if strings.Contains(msg, "shell init changed for mytool (bash)") {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("the shell init change never reached the notice inbox; notices = %+v", all)
+	}
+}
+
+// A background update that changed nothing about the tool's shell init must not
+// manufacture a notice. An inbox that fills up on every routine update is one
+// the user stops reading.
+func TestAutoApplyInstaller_UnchangedShellInitWritesNoNotice(t *testing.T) {
+	cfg, cleanup := testutil.NewTestConfig(t)
+	defer cleanup()
+
+	mgr := install.New(cfg)
+	noticesDir := notices.NoticesDir(cfg.HomeDir)
+
+	recordUpdateVersion(t, mgr, "mytool", "1.0.0", []install.CleanupAction{
+		updateFragment("mytool", "1.0.0", "bash", "same"),
+	})
+
+	installFn, flushNotices := autoApplyInstaller(mgr, noticesDir, func(installArgs) error {
+		recordUpdateVersion(t, mgr, "mytool", "2.0.0", []install.CleanupAction{
+			updateFragment("mytool", "2.0.0", "bash", "same"),
+		})
+		return nil
+	})
+
+	if err := installFn("mytool", "2.0.0", ""); err != nil {
+		t.Fatalf("the auto-apply install callback failed: %v", err)
+	}
+	flushNotices()
+
+	all, err := notices.ReadAllNotices(noticesDir)
+	if err != nil {
+		t.Fatalf("ReadAllNotices() error = %v", err)
+	}
+	for _, n := range all {
+		for _, msg := range n.Messages {
+			if strings.Contains(msg, "shell init changed") {
+				t.Errorf("an unchanged shell init produced a notice: %q", msg)
+			}
+		}
+	}
+}

--- a/cmd/tsuku/cmd_apply_updates_test.go
+++ b/cmd/tsuku/cmd_apply_updates_test.go
@@ -25,14 +25,14 @@ func TestAutoApplyInstaller_ShellInitChangeReachesTheNoticeInbox(t *testing.T) {
 	mgr := install.New(cfg)
 	noticesDir := notices.NoticesDir(cfg.HomeDir)
 
-	recordUpdateVersion(t, mgr, "mytool", "1.0.0", []install.CleanupAction{
+	recordUpdateVersion(t, cfg, mgr, "mytool", "1.0.0", []install.CleanupAction{
 		updateFragment("mytool", "1.0.0", "bash", "before"),
 	})
 
 	installFn, flushNotices := autoApplyInstaller(mgr, noticesDir, func(installArgs) error {
 		// What the install would leave behind: a new active version whose bash
 		// init has different content.
-		recordUpdateVersion(t, mgr, "mytool", "2.0.0", []install.CleanupAction{
+		recordUpdateVersion(t, cfg, mgr, "mytool", "2.0.0", []install.CleanupAction{
 			updateFragment("mytool", "2.0.0", "bash", "after"),
 		})
 		return nil
@@ -71,12 +71,12 @@ func TestAutoApplyInstaller_UnchangedShellInitWritesNoNotice(t *testing.T) {
 	mgr := install.New(cfg)
 	noticesDir := notices.NoticesDir(cfg.HomeDir)
 
-	recordUpdateVersion(t, mgr, "mytool", "1.0.0", []install.CleanupAction{
+	recordUpdateVersion(t, cfg, mgr, "mytool", "1.0.0", []install.CleanupAction{
 		updateFragment("mytool", "1.0.0", "bash", "same"),
 	})
 
 	installFn, flushNotices := autoApplyInstaller(mgr, noticesDir, func(installArgs) error {
-		recordUpdateVersion(t, mgr, "mytool", "2.0.0", []install.CleanupAction{
+		recordUpdateVersion(t, cfg, mgr, "mytool", "2.0.0", []install.CleanupAction{
 			updateFragment("mytool", "2.0.0", "bash", "same"),
 		})
 		return nil

--- a/cmd/tsuku/shelld_lifecycle_test.go
+++ b/cmd/tsuku/shelld_lifecycle_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -578,16 +577,18 @@ func TestShellDLifecycle_UpdateAllDropsAShell(t *testing.T) {
 		t.Fatalf("the scenario needs %s's init script in the zsh cache to start with", lifecycleV1)
 	}
 
-	var warns []string
-	err := updateWithCleanup(h.mgr, h.tool, func(format string, args ...any) {
-		warns = append(warns, fmt.Sprintf(format, args...))
-	}, func() error {
+	reporter := &recordingReporter{}
+	newVersion, err := updateInstalledTool(h.mgr, h.tool, reporter, func() error {
 		h.installVersionShells(lifecycleV2, []string{"bash"})
 		return nil
 	})
 	if err != nil {
-		t.Fatalf("updateWithCleanup() error = %v", err)
+		t.Fatalf("updateInstalledTool() error = %v", err)
 	}
+	if newVersion != lifecycleV2 {
+		t.Fatalf("updateInstalledTool() reported version %q active, want %q", newVersion, lifecycleV2)
+	}
+	warns := reporter.warns
 
 	// The tool rewrote its bash init between versions, which is the whole point
 	// of the warning: it is the only notice a user gets that the script their

--- a/cmd/tsuku/shelld_lifecycle_test.go
+++ b/cmd/tsuku/shelld_lifecycle_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -139,6 +140,21 @@ func (h *shellDHarness) installVersion(version string) {
 // the stable {data_dir}.
 func (h *shellDHarness) installVersionExporting(version, envValue string) {
 	h.t.Helper()
+	h.installVersionWith(version, envValue, []string{"bash"})
+}
+
+// installVersionShells installs a version whose install_shell_init step targets the
+// given shells, so a scenario can drop one between versions. set_env is not
+// configurable this way -- it always writes both bash and zsh -- which is why the
+// dropped shell shows up as an orphaned init fragment and not as an orphaned
+// export.
+func (h *shellDHarness) installVersionShells(version string, shells []string) {
+	h.t.Helper()
+	h.installVersionWith(version, "{install_dir}", shells)
+}
+
+func (h *shellDHarness) installVersionWith(version, envValue string, shells []string) {
+	h.t.Helper()
 
 	workDir := h.t.TempDir()
 	installDir := filepath.Join(workDir, ".install")
@@ -182,10 +198,14 @@ func (h *shellDHarness) installVersionExporting(version, envValue string) {
 	}
 
 	shellInit := &actions.InstallShellInitAction{}
+	shellParam := make([]interface{}, len(shells))
+	for i, s := range shells {
+		shellParam[i] = s
+	}
 	if err := shellInit.Execute(execCtx, map[string]interface{}{
 		"source_file": "init.sh",
 		"target":      h.tool,
-		"shells":      []interface{}{"bash"},
+		"shells":      shellParam,
 	}); err != nil {
 		h.t.Fatalf("install_shell_init Execute(%s) error = %v", version, err)
 	}
@@ -513,4 +533,94 @@ func TestShellDLifecycle_DataRootSurvivesUpgradeAndReclaim(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(afterReclaim, "versions", "node", "v22.0.0", "bin", "node")); err != nil {
 		t.Errorf("reclaiming the superseded version deleted the user's data: %v", err)
 	}
+}
+
+// initCacheFor reads the init cache a shell of the given name would source. An
+// absent cache reads as empty, which is what a shell with no fragments gets.
+func (h *shellDHarness) initCacheFor(shell string) string {
+	h.t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(h.home, "share", "shell.d", ".init-cache."+shell))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return ""
+		}
+		h.t.Fatalf("reading the %s init cache: %v", shell, err)
+	}
+	return string(data)
+}
+
+// TestShellDLifecycle_UpdateAllDropsAShell is issue #2470's scenario, run
+// through the sequence `tsuku update --all` performs per tool. Only recipe
+// resolution and download are substituted; everything the update does to
+// $TSUKU_HOME is the production path.
+//
+// Before this change `runUpdateAll` ran no part of the pass, so none of the
+// warnings below were emitted on that path.
+//
+// The two disk assertions are the reachability finding the issue predates. Its
+// acceptance criterion asks for the dropped shell's fragment to be gone right
+// after the update. It cannot be: the replaced version is still installed as the
+// rollback target and still records that path, so ExecuteStaleCleanup's
+// retained-path guard exempts it. What the user actually gets is that the
+// fragment stops being sourced immediately and goes when the version is
+// reclaimed -- which is what a rollback needs and what this asserts.
+func TestShellDLifecycle_UpdateAllDropsAShell(t *testing.T) {
+	h := newShellDHarness(t)
+
+	h.installVersionShells(lifecycleV1, []string{"bash", "zsh"})
+
+	droppedFragment := filepath.Join(h.home, "share", "shell.d", h.tool+"@"+lifecycleV1+".zsh")
+	if _, err := os.Stat(droppedFragment); err != nil {
+		t.Fatalf("the scenario needs %s's zsh fragment on disk to start with: %v", lifecycleV1, err)
+	}
+	if !strings.Contains(h.initCacheFor("zsh"), initVar(lifecycleV1)) {
+		t.Fatalf("the scenario needs %s's init script in the zsh cache to start with", lifecycleV1)
+	}
+
+	var warns []string
+	err := updateWithCleanup(h.mgr, h.tool, func(format string, args ...any) {
+		warns = append(warns, fmt.Sprintf(format, args...))
+	}, func() error {
+		h.installVersionShells(lifecycleV2, []string{"bash"})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("updateWithCleanup() error = %v", err)
+	}
+
+	// The tool rewrote its bash init between versions, which is the whole point
+	// of the warning: it is the only notice a user gets that the script their
+	// shell runs at every start is not the one it ran yesterday.
+	if len(warns) == 0 {
+		t.Error("updating through the --all path announced no shell init change")
+	}
+	for _, w := range warns {
+		if !strings.Contains(w, "shell init changed for "+h.tool) {
+			t.Errorf("unexpected warning %q", w)
+		}
+	}
+
+	// A real bash shell gets the new version and nothing of the old one.
+	h.assertShellSees(lifecycleV2, lifecycleV1)
+
+	// zsh has no fragment from the new version, and must not still be sourcing
+	// the old one. This is the "orphan keeps being sourced" half of the issue.
+	if cache := h.initCacheFor("zsh"); strings.Contains(cache, initVar(lifecycleV1)) {
+		t.Errorf("the dropped shell's cache still sources %s's init script:\n%s", lifecycleV1, cache)
+	}
+
+	// The file itself stays while the version that wrote it is the rollback
+	// target. Deleting it here is what PR #2465's guard exists to prevent.
+	if _, err := os.Stat(droppedFragment); err != nil {
+		t.Errorf("the rollback target's zsh fragment was deleted: %v", err)
+	}
+
+	// Reclaiming the superseded version is what finally takes it.
+	if err := h.mgr.RemoveVersion(lifecycleCtx(), h.tool, lifecycleV1); err != nil {
+		t.Fatalf("RemoveVersion(%s) error = %v", lifecycleV1, err)
+	}
+	h.assertNoFragmentFor(lifecycleV1)
+	h.assertShellSees(lifecycleV2)
+	h.assertDoctorClean()
 }

--- a/cmd/tsuku/shelld_lifecycle_test.go
+++ b/cmd/tsuku/shelld_lifecycle_test.go
@@ -577,8 +577,8 @@ func TestShellDLifecycle_UpdateAllDropsAShell(t *testing.T) {
 		t.Fatalf("the scenario needs %s's init script in the zsh cache to start with", lifecycleV1)
 	}
 
-	reporter := &recordingReporter{}
-	newVersion, err := updateInstalledTool(h.mgr, h.tool, reporter, func() error {
+	var warns []string
+	newVersion, err := updateInstalledTool(h.mgr, h.tool, collectWarns(&warns), func() error {
 		h.installVersionShells(lifecycleV2, []string{"bash"})
 		return nil
 	})
@@ -588,7 +588,6 @@ func TestShellDLifecycle_UpdateAllDropsAShell(t *testing.T) {
 	if newVersion != lifecycleV2 {
 		t.Fatalf("updateInstalledTool() reported version %q active, want %q", newVersion, lifecycleV2)
 	}
-	warns := reporter.warns
 
 	// The tool rewrote its bash init between versions, which is the whole point
 	// of the warning: it is the only notice a user gets that the script their

--- a/cmd/tsuku/update.go
+++ b/cmd/tsuku/update.go
@@ -121,10 +121,7 @@ Examples:
 		// the outcome appearing on a separate stdout line. See #2280/#2359.
 		reporter := progress.NewTTYReporter(os.Stderr)
 
-		// The install is bracketed by the stale-cleanup pass: files the old
-		// version created that the new one no longer needs go, and a shell init
-		// script that changed content across the upgrade is announced.
-		if err := updateWithCleanup(mgr, toolName, reporter.Warn, func() error {
+		newVersion, err := updateInstalledTool(mgr, toolName, reporter, func() error {
 			return runInstallWithReporter(installevents.WithSource(globalCtx, installevents.SourceManual), installArgs{
 				Tool:            toolName,
 				ReqVersion:      reqVersion,
@@ -132,25 +129,13 @@ Examples:
 				TelemetryClient: telemetryClient,
 				Reporter:        reporter,
 			})
-		}); err != nil {
+		})
+		if err != nil {
 			reporter.Stop()
 			// UpdateFailed event was already published from Manager.Install
 			// via the bus; the telemetry subscriber emitted the
 			// UpdateOutcomeFailure event. No direct telemetry call needed.
 			exitWithCode(ExitInstallFailed)
-		}
-
-		// Get the active version after update. List returns one entry
-		// per retained version, so we must pick the entry where
-		// IsActive is true — otherwise an older retained version
-		// could shadow the just-installed one in the loop below.
-		tools, _ = mgr.List()
-		var newVersion string
-		for _, tool := range tools {
-			if tool.Name == toolName && tool.IsActive {
-				newVersion = tool.Version
-				break
-			}
 		}
 
 		// Emit the no-op outcome via the reporter so the TTY spinner is
@@ -215,6 +200,42 @@ func updateWithCleanup(mgr *install.Manager, toolName string, warn install.WarnF
 	}
 	mgr.ReconcileUpdate(snapshot, warn)
 	return nil
+}
+
+// updateInstalledTool is one foreground tool update end to end: the
+// cleanup-bracketed install, then the version that ended up active. Both
+// `tsuku update <tool>` and `tsuku update --all` go through it, so neither the
+// pass nor the version readback can be right on one and wrong on the other.
+//
+// The returned version is empty when the install failed, and when state cannot
+// say which version is active afterwards. Callers that treat "no version" as
+// "unchanged" have to say so themselves -- the two commands differ on that.
+//
+// doInstall is a parameter rather than a direct call so a test can drive the
+// sequence without resolving a recipe or downloading anything.
+func updateInstalledTool(mgr *install.Manager, toolName string, reporter progress.Reporter, doInstall func() error) (string, error) {
+	if err := updateWithCleanup(mgr, toolName, reporter.Warn, doInstall); err != nil {
+		return "", err
+	}
+	return activeVersionAfterUpdate(mgr, toolName), nil
+}
+
+// activeVersionAfterUpdate reports which version of the tool is active now.
+//
+// List returns one entry per retained version, so the entry flagged IsActive is
+// the one to read: an older retained version would otherwise shadow the version
+// that was just installed.
+func activeVersionAfterUpdate(mgr *install.Manager, toolName string) string {
+	tools, err := mgr.List()
+	if err != nil {
+		return ""
+	}
+	for _, tool := range tools {
+		if tool.Name == toolName && tool.IsActive {
+			return tool.Version
+		}
+	}
+	return ""
 }
 
 // isDistributedSource returns true if the source string is a distributed
@@ -292,7 +313,7 @@ func runUpdateAll(cmd *cobra.Command) {
 		// outcome line, consistent with the single-tool path.
 		toolReporter := progress.NewTTYReporter(os.Stderr)
 
-		if err := updateWithCleanup(mgr, tool.Name, toolReporter.Warn, func() error {
+		newVersion, err := updateInstalledTool(mgr, tool.Name, toolReporter, func() error {
 			return runInstallWithReporter(installevents.WithSource(globalCtx, installevents.SourceManual), installArgs{
 				Tool:            tool.Name,
 				ReqVersion:      requested,
@@ -300,7 +321,8 @@ func runUpdateAll(cmd *cobra.Command) {
 				TelemetryClient: telemetryClient,
 				Reporter:        toolReporter,
 			})
-		}); err != nil {
+		})
+		if err != nil {
 			toolReporter.Log("failed to update %s: %v", tool.Name, err)
 			toolReporter.Stop()
 			// UpdateFailed was published from Manager.Install; the
@@ -309,24 +331,16 @@ func runUpdateAll(cmd *cobra.Command) {
 			continue
 		}
 
-		// Detect whether the install actually changed the active version
-		// or whether the tool was already at latest. The install
+		// Whether the install changed the active version or the tool was
+		// already at latest decides which counter moves. The install
 		// machinery's "is already installed" status is a transient TTY
-		// message; we need to count up-to-date separately so the summary
-		// at the end is accurate.
-		//
-		// List returns one entry per retained version; pick the one
-		// flagged IsActive so we don't shadow the just-installed
-		// version with an older retained one.
-		newVersion := previousVersion
-		if afterTools, listErr := mgr.List(); listErr == nil {
-			for _, t := range afterTools {
-				if t.Name == tool.Name && t.IsActive {
-					newVersion = t.Version
-					break
-				}
-			}
+		// message, so up-to-date has to be counted separately for the summary
+		// to be accurate. A version state cannot vouch for reads as unchanged
+		// here rather than as an update, which is the conservative count.
+		if newVersion == "" {
+			newVersion = previousVersion
 		}
+
 		// Emit the no-op outcome via the reporter so the TTY spinner is
 		// replaced in-place. Real updates already get a permanent
 		// "✅ <name>@<version>" line from the install reporter (#2280).

--- a/cmd/tsuku/update.go
+++ b/cmd/tsuku/update.go
@@ -121,7 +121,7 @@ Examples:
 		// the outcome appearing on a separate stdout line. See #2280/#2359.
 		reporter := progress.NewTTYReporter(os.Stderr)
 
-		newVersion, err := updateInstalledTool(mgr, toolName, reporter, func() error {
+		newVersion, err := updateInstalledTool(mgr, toolName, reporter.Warn, func() error {
 			return runInstallWithReporter(installevents.WithSource(globalCtx, installevents.SourceManual), installArgs{
 				Tool:            toolName,
 				ReqVersion:      reqVersion,
@@ -213,8 +213,8 @@ func updateWithCleanup(mgr *install.Manager, toolName string, warn install.WarnF
 //
 // doInstall is a parameter rather than a direct call so a test can drive the
 // sequence without resolving a recipe or downloading anything.
-func updateInstalledTool(mgr *install.Manager, toolName string, reporter progress.Reporter, doInstall func() error) (string, error) {
-	if err := updateWithCleanup(mgr, toolName, reporter.Warn, doInstall); err != nil {
+func updateInstalledTool(mgr *install.Manager, toolName string, warn install.WarnFunc, doInstall func() error) (string, error) {
+	if err := updateWithCleanup(mgr, toolName, warn, doInstall); err != nil {
 		return "", err
 	}
 	return activeVersionAfterUpdate(mgr, toolName), nil
@@ -313,7 +313,7 @@ func runUpdateAll(cmd *cobra.Command) {
 		// outcome line, consistent with the single-tool path.
 		toolReporter := progress.NewTTYReporter(os.Stderr)
 
-		newVersion, err := updateInstalledTool(mgr, tool.Name, toolReporter, func() error {
+		newVersion, err := updateInstalledTool(mgr, tool.Name, toolReporter.Warn, func() error {
 			return runInstallWithReporter(installevents.WithSource(globalCtx, installevents.SourceManual), installArgs{
 				Tool:            tool.Name,
 				ReqVersion:      requested,
@@ -335,8 +335,11 @@ func runUpdateAll(cmd *cobra.Command) {
 		// already at latest decides which counter moves. The install
 		// machinery's "is already installed" status is a transient TTY
 		// message, so up-to-date has to be counted separately for the summary
-		// to be accurate. A version state cannot vouch for reads as unchanged
-		// here rather than as an update, which is the conservative count.
+		// to be accurate.
+		//
+		// When state cannot say which version is active, count the tool as
+		// unchanged rather than as an update. Reporting an update that may not
+		// have happened is the worse of the two errors here.
 		if newVersion == "" {
 			newVersion = previousVersion
 		}

--- a/cmd/tsuku/update.go
+++ b/cmd/tsuku/update.go
@@ -114,18 +114,6 @@ Examples:
 			}
 		}
 
-		// Snapshot old version's cleanup actions before installing new version.
-		// These are needed to compute stale cleanup (files the old version
-		// created that the new version no longer needs).
-		var oldCleanupActions []install.CleanupAction
-		if state != nil {
-			if ts, ok := state.Installed[toolName]; ok {
-				if vs, ok := ts.Versions[previousVersion]; ok {
-					oldCleanupActions = vs.CleanupActions
-				}
-			}
-		}
-
 		// Create a reporter here so that both the install progress and the
 		// outcome line share the same stream (stderr). This lets the TTY
 		// spinner be replaced in-place by the permanent outcome line via
@@ -133,12 +121,17 @@ Examples:
 		// the outcome appearing on a separate stdout line. See #2280/#2359.
 		reporter := progress.NewTTYReporter(os.Stderr)
 
-		if err := runInstallWithReporter(installevents.WithSource(globalCtx, installevents.SourceManual), installArgs{
-			Tool:            toolName,
-			ReqVersion:      reqVersion,
-			IsExplicit:      true,
-			TelemetryClient: telemetryClient,
-			Reporter:        reporter,
+		// The install is bracketed by the stale-cleanup pass: files the old
+		// version created that the new one no longer needs go, and a shell init
+		// script that changed content across the upgrade is announced.
+		if err := updateWithCleanup(mgr, toolName, reporter.Warn, func() error {
+			return runInstallWithReporter(installevents.WithSource(globalCtx, installevents.SourceManual), installArgs{
+				Tool:            toolName,
+				ReqVersion:      reqVersion,
+				IsExplicit:      true,
+				TelemetryClient: telemetryClient,
+				Reporter:        reporter,
+			})
 		}); err != nil {
 			reporter.Stop()
 			// UpdateFailed event was already published from Manager.Install
@@ -168,28 +161,6 @@ Examples:
 		}
 		reporter.Stop()
 		reporter.FlushDeferred()
-
-		// Lifecycle-aware stale cleanup: delete files the old version created
-		// that the new version no longer needs (e.g., shell.d scripts for a
-		// shell the new version dropped). Only runs when the version changed
-		// and the old version had cleanup actions recorded.
-		if newVersion != "" && newVersion != previousVersion && len(oldCleanupActions) > 0 {
-			// Reload state to get the new version's cleanup actions
-			newState, _ := mgr.GetState().Load()
-			if newState != nil {
-				if ts, ok := newState.Installed[toolName]; ok {
-					if vs, ok := ts.Versions[newVersion]; ok {
-						stale := install.StaleCleanupActions(oldCleanupActions, vs.CleanupActions)
-						mgr.ExecuteStaleCleanup(stale)
-
-						// Update diff visibility: warn when shell init content
-						// changed between versions. This surfaces silent supply-chain
-						// changes where an upstream binary alters its init output.
-						warnShellInitChanges(toolName, oldCleanupActions, vs.CleanupActions, reporter)
-					}
-				}
-			}
-		}
 
 		// Send action telemetry for update. The UpdateOutcomeSuccess
 		// event is emitted automatically by the telemetry subscriber when
@@ -225,41 +196,25 @@ func updateOutcomeMessage(toolName, previousVersion, newVersion string) string {
 	return fmt.Sprintf("%s is already at the latest version (%s).", toolName, newVersion)
 }
 
-// warnShellInitChanges compares content hashes between old and new cleanup
-// actions for shell.d fragments. When the same (target, shell) has different
-// hashes across versions, the tool's shell init output changed during the
-// update -- a signal worth surfacing to the user.
+// updateWithCleanup runs an install that replaces one version of a tool with
+// another, bracketed by the lifecycle-aware cleanup pass every such install
+// needs: snapshot what the outgoing version wrote outside its own directory,
+// install, then reconcile against what the incoming version writes.
 //
-// The comparison is keyed on (target, shell) rather than on the raw path
-// because shell.d filenames carry a version key, so every fragment has a new
-// path in every version and a path-keyed comparison would never match.
-func warnShellInitChanges(toolName string, old, new []install.CleanupAction, reporter progress.Reporter) {
-	type fragment struct{ target, shell string }
-
-	// Build a map of (target, shell) -> content hash from old actions
-	oldHashes := make(map[fragment]string)
-	for _, ca := range old {
-		shell := install.ShellFromCleanupPath(ca.Path)
-		if shell == "" || ca.ContentHash == "" {
-			continue
-		}
-		oldHashes[fragment{install.TargetFromCleanupPath(ca.Path), shell}] = ca.ContentHash
+// It exists so the three paths that update a tool -- `tsuku update <tool>`,
+// `tsuku update --all`, and background auto-apply -- cannot each hold a
+// different two thirds of that sequence. They already had: only the single-tool
+// path ran the pass at all, which is issue #2470.
+//
+// The install error is returned unchanged, and nothing is reconciled when the
+// install fails.
+func updateWithCleanup(mgr *install.Manager, toolName string, warn install.WarnFunc, doInstall func() error) error {
+	snapshot := mgr.SnapshotCleanup(toolName)
+	if err := doInstall(); err != nil {
+		return err
 	}
-
-	for _, ca := range new {
-		shell := install.ShellFromCleanupPath(ca.Path)
-		if shell == "" || ca.ContentHash == "" {
-			continue
-		}
-		oldHash, exists := oldHashes[fragment{install.TargetFromCleanupPath(ca.Path), shell}]
-		if !exists {
-			// New fragment not in old -- new shell init file, not a change
-			continue
-		}
-		if oldHash != ca.ContentHash {
-			reporter.Warn("shell init changed for %s (%s)", toolName, shell)
-		}
-	}
+	mgr.ReconcileUpdate(snapshot, warn)
+	return nil
 }
 
 // isDistributedSource returns true if the source string is a distributed
@@ -337,12 +292,14 @@ func runUpdateAll(cmd *cobra.Command) {
 		// outcome line, consistent with the single-tool path.
 		toolReporter := progress.NewTTYReporter(os.Stderr)
 
-		if err := runInstallWithReporter(installevents.WithSource(globalCtx, installevents.SourceManual), installArgs{
-			Tool:            tool.Name,
-			ReqVersion:      requested,
-			IsExplicit:      true,
-			TelemetryClient: telemetryClient,
-			Reporter:        toolReporter,
+		if err := updateWithCleanup(mgr, tool.Name, toolReporter.Warn, func() error {
+			return runInstallWithReporter(installevents.WithSource(globalCtx, installevents.SourceManual), installArgs{
+				Tool:            tool.Name,
+				ReqVersion:      requested,
+				IsExplicit:      true,
+				TelemetryClient: telemetryClient,
+				Reporter:        toolReporter,
+			})
 		}); err != nil {
 			toolReporter.Log("failed to update %s: %v", tool.Name, err)
 			toolReporter.Stop()

--- a/cmd/tsuku/update_test.go
+++ b/cmd/tsuku/update_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/tsukumogami/tsuku/internal/config"
 	"github.com/tsukumogami/tsuku/internal/install"
-	"github.com/tsukumogami/tsuku/internal/progress"
 	"github.com/tsukumogami/tsuku/internal/testutil"
 )
 
@@ -99,15 +98,12 @@ func updateFragment(target, version, shell, hash string) install.CleanupAction {
 	}
 }
 
-// recordingReporter captures what an update wanted to tell the user, so a test
-// can assert on the message rather than on stderr.
-type recordingReporter struct {
-	progress.NoopReporter
-	warns []string
-}
-
-func (r *recordingReporter) Warn(format string, args ...any) {
-	r.warns = append(r.warns, fmt.Sprintf(format, args...))
+// collectWarns returns a WarnFunc that appends formatted messages to into, so a
+// test can assert on the message a user would see rather than on stderr.
+func collectWarns(into *[]string) install.WarnFunc {
+	return func(format string, args ...any) {
+		*into = append(*into, fmt.Sprintf(format, args...))
+	}
 }
 
 // TestUpdateInstalledTool pins the ordering contract both foreground update
@@ -180,9 +176,9 @@ func TestUpdateInstalledTool(t *testing.T) {
 				updateFragment("tool", "1.0.0", "bash", "before"),
 			})
 
-			reporter := &recordingReporter{}
+			var warns []string
 			installed := false
-			gotVersion, err := updateInstalledTool(mgr, "tool", reporter, func() error {
+			gotVersion, err := updateInstalledTool(mgr, "tool", collectWarns(&warns), func() error {
 				installed = true
 				tt.install(t, cfg, mgr)
 				return tt.installErr
@@ -197,12 +193,12 @@ func TestUpdateInstalledTool(t *testing.T) {
 			if gotVersion != tt.wantVersion {
 				t.Errorf("updateInstalledTool() version = %q, want %q", gotVersion, tt.wantVersion)
 			}
-			if len(reporter.warns) != len(tt.wantWarns) {
-				t.Fatalf("warnings = %q, want %q", reporter.warns, tt.wantWarns)
+			if len(warns) != len(tt.wantWarns) {
+				t.Fatalf("warnings = %q, want %q", warns, tt.wantWarns)
 			}
 			for i, want := range tt.wantWarns {
-				if reporter.warns[i] != want {
-					t.Errorf("warning %d = %q, want %q", i, reporter.warns[i], want)
+				if warns[i] != want {
+					t.Errorf("warning %d = %q, want %q", i, warns[i], want)
 				}
 			}
 		})

--- a/cmd/tsuku/update_test.go
+++ b/cmd/tsuku/update_test.go
@@ -3,9 +3,12 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
 	"testing"
 
+	"github.com/tsukumogami/tsuku/internal/config"
 	"github.com/tsukumogami/tsuku/internal/install"
+	"github.com/tsukumogami/tsuku/internal/progress"
 	"github.com/tsukumogami/tsuku/internal/testutil"
 )
 
@@ -64,8 +67,16 @@ func TestUpdateOutcomeMessage(t *testing.T) {
 
 // recordUpdateVersion writes a version's state directly and makes it active,
 // standing in for the install that would normally do so.
-func recordUpdateVersion(t *testing.T, mgr *install.Manager, tool, version string, actions []install.CleanupAction) {
+//
+// The version directory has to exist alongside the state entry: Manager.List
+// skips a version state records but disk does not have, so a state-only entry
+// would be invisible to the version readback.
+func recordUpdateVersion(t *testing.T, cfg *config.Config, mgr *install.Manager, tool, version string, actions []install.CleanupAction) {
 	t.Helper()
+
+	if err := os.MkdirAll(cfg.ToolDir(tool, version), 0755); err != nil {
+		t.Fatalf("creating the version directory for %s@%s: %v", tool, version, err)
+	}
 
 	if err := mgr.GetState().UpdateTool(tool, func(ts *install.ToolState) {
 		if ts.Versions == nil {
@@ -88,47 +99,70 @@ func updateFragment(target, version, shell, hash string) install.CleanupAction {
 	}
 }
 
-// TestUpdateWithCleanup pins the ordering contract the three update paths share:
-// the snapshot is taken before the install, the reconcile runs after it, and a
-// failed install reconciles nothing.
+// recordingReporter captures what an update wanted to tell the user, so a test
+// can assert on the message rather than on stderr.
+type recordingReporter struct {
+	progress.NoopReporter
+	warns []string
+}
+
+func (r *recordingReporter) Warn(format string, args ...any) {
+	r.warns = append(r.warns, fmt.Sprintf(format, args...))
+}
+
+// TestUpdateInstalledTool pins the ordering contract both foreground update
+// commands share: the snapshot is taken before the install, the reconcile runs
+// after it, a failed install reconciles nothing, and the version reported back
+// is the one that ended up active.
 //
 // Ordering is the whole point of the helper. A reconcile run against a snapshot
 // taken after the install would compare the new version with itself, find no
 // change, and stay silent -- indistinguishable from a clean update.
-func TestUpdateWithCleanup(t *testing.T) {
+func TestUpdateInstalledTool(t *testing.T) {
 	tests := []struct {
-		name       string
-		installErr error
-		install    func(t *testing.T, mgr *install.Manager)
-		wantWarns  []string
-		wantErr    bool
+		name        string
+		installErr  error
+		install     func(t *testing.T, cfg *config.Config, mgr *install.Manager)
+		wantWarns   []string
+		wantVersion string
+		wantErr     bool
 	}{
 		{
 			name: "a shell init rewrite during the install is announced",
-			install: func(t *testing.T, mgr *install.Manager) {
-				recordUpdateVersion(t, mgr, "tool", "2.0.0", []install.CleanupAction{
+			install: func(t *testing.T, cfg *config.Config, mgr *install.Manager) {
+				recordUpdateVersion(t, cfg, mgr, "tool", "2.0.0", []install.CleanupAction{
 					updateFragment("tool", "2.0.0", "bash", "after"),
 				})
 			},
-			wantWarns: []string{"shell init changed for tool (bash)"},
+			wantWarns:   []string{"shell init changed for tool (bash)"},
+			wantVersion: "2.0.0",
 		},
 		{
 			name: "an unchanged shell init says nothing",
-			install: func(t *testing.T, mgr *install.Manager) {
-				recordUpdateVersion(t, mgr, "tool", "2.0.0", []install.CleanupAction{
+			install: func(t *testing.T, cfg *config.Config, mgr *install.Manager) {
+				recordUpdateVersion(t, cfg, mgr, "tool", "2.0.0", []install.CleanupAction{
 					updateFragment("tool", "2.0.0", "bash", "before"),
 				})
 			},
+			wantVersion: "2.0.0",
+		},
+		{
+			name:    "an install that changed nothing reports the version already active",
+			install: func(*testing.T, *config.Config, *install.Manager) {},
+			// The tool was already at latest: no warning, and the version the
+			// caller reads back is the one it started on, which is how
+			// `--all` tells "up to date" from "updated".
+			wantVersion: "1.0.0",
 		},
 		{
 			name:       "a failed install reconciles nothing",
 			installErr: errors.New("download failed"),
-			install: func(t *testing.T, mgr *install.Manager) {
+			install: func(t *testing.T, cfg *config.Config, mgr *install.Manager) {
 				// A partial install that got as far as recording state is the
 				// case worth pinning: the error still has to suppress the
 				// reconcile, or an update that did not land warns about a
 				// change the user never received.
-				recordUpdateVersion(t, mgr, "tool", "2.0.0", []install.CleanupAction{
+				recordUpdateVersion(t, cfg, mgr, "tool", "2.0.0", []install.CleanupAction{
 					updateFragment("tool", "2.0.0", "bash", "after"),
 				})
 			},
@@ -142,32 +176,33 @@ func TestUpdateWithCleanup(t *testing.T) {
 			defer cleanup()
 
 			mgr := install.New(cfg)
-			recordUpdateVersion(t, mgr, "tool", "1.0.0", []install.CleanupAction{
+			recordUpdateVersion(t, cfg, mgr, "tool", "1.0.0", []install.CleanupAction{
 				updateFragment("tool", "1.0.0", "bash", "before"),
 			})
 
-			var warns []string
+			reporter := &recordingReporter{}
 			installed := false
-			err := updateWithCleanup(mgr, "tool", func(format string, args ...any) {
-				warns = append(warns, fmt.Sprintf(format, args...))
-			}, func() error {
+			gotVersion, err := updateInstalledTool(mgr, "tool", reporter, func() error {
 				installed = true
-				tt.install(t, mgr)
+				tt.install(t, cfg, mgr)
 				return tt.installErr
 			})
 
 			if (err != nil) != tt.wantErr {
-				t.Fatalf("updateWithCleanup() error = %v, wantErr %v", err, tt.wantErr)
+				t.Fatalf("updateInstalledTool() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !installed {
-				t.Fatal("updateWithCleanup() never ran the install")
+				t.Fatal("updateInstalledTool() never ran the install")
 			}
-			if len(warns) != len(tt.wantWarns) {
-				t.Fatalf("warnings = %q, want %q", warns, tt.wantWarns)
+			if gotVersion != tt.wantVersion {
+				t.Errorf("updateInstalledTool() version = %q, want %q", gotVersion, tt.wantVersion)
+			}
+			if len(reporter.warns) != len(tt.wantWarns) {
+				t.Fatalf("warnings = %q, want %q", reporter.warns, tt.wantWarns)
 			}
 			for i, want := range tt.wantWarns {
-				if warns[i] != want {
-					t.Errorf("warning %d = %q, want %q", i, warns[i], want)
+				if reporter.warns[i] != want {
+					t.Errorf("warning %d = %q, want %q", i, reporter.warns[i], want)
 				}
 			}
 		})

--- a/cmd/tsuku/update_test.go
+++ b/cmd/tsuku/update_test.go
@@ -1,164 +1,13 @@
 package main
 
 import (
-	"bytes"
-	"os"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/tsukumogami/tsuku/internal/install"
-	"github.com/tsukumogami/tsuku/internal/progress"
+	"github.com/tsukumogami/tsuku/internal/testutil"
 )
-
-func TestWarnShellInitChanges_NoWarningWhenHashesMatch(t *testing.T) {
-	old := []install.CleanupAction{
-		{Action: "delete_file", Path: "share/shell.d/tool.bash", ContentHash: "abc123"},
-		{Action: "delete_file", Path: "share/shell.d/tool.zsh", ContentHash: "def456"},
-	}
-	new := []install.CleanupAction{
-		{Action: "delete_file", Path: "share/shell.d/tool.bash", ContentHash: "abc123"},
-		{Action: "delete_file", Path: "share/shell.d/tool.zsh", ContentHash: "def456"},
-	}
-
-	// Capture stderr
-	oldStderr := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	reporter := progress.NewTTYReporter(os.Stderr)
-
-	warnShellInitChanges("tool", old, new, reporter)
-
-	w.Close()
-	os.Stderr = oldStderr
-
-	var buf bytes.Buffer
-	_, _ = buf.ReadFrom(r)
-	if buf.Len() != 0 {
-		t.Errorf("expected no output when hashes match, got: %s", buf.String())
-	}
-}
-
-func TestWarnShellInitChanges_WarnsWhenHashChanges(t *testing.T) {
-	old := []install.CleanupAction{
-		{Action: "delete_file", Path: "share/shell.d/tool.bash", ContentHash: "abc123"},
-		{Action: "delete_file", Path: "share/shell.d/tool.zsh", ContentHash: "def456"},
-	}
-	new := []install.CleanupAction{
-		{Action: "delete_file", Path: "share/shell.d/tool.bash", ContentHash: "changed"},
-		{Action: "delete_file", Path: "share/shell.d/tool.zsh", ContentHash: "def456"},
-	}
-
-	oldStderr := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	reporter := progress.NewTTYReporter(os.Stderr)
-
-	warnShellInitChanges("tool", old, new, reporter)
-
-	w.Close()
-	os.Stderr = oldStderr
-
-	var buf bytes.Buffer
-	_, _ = buf.ReadFrom(r)
-	output := buf.String()
-
-	if output == "" {
-		t.Fatal("expected warning output when hash changes")
-	}
-	if !bytes.Contains([]byte(output), []byte("shell init changed for tool (bash)")) {
-		t.Errorf("expected warning about bash, got: %s", output)
-	}
-	// zsh hash didn't change, so no warning for it
-	if bytes.Contains([]byte(output), []byte("(zsh)")) {
-		t.Errorf("did not expect warning about zsh, got: %s", output)
-	}
-}
-
-func TestWarnShellInitChanges_NoWarningForNewPaths(t *testing.T) {
-	// Old version had no shell.d files, new version adds them
-	old := []install.CleanupAction{}
-	new := []install.CleanupAction{
-		{Action: "delete_file", Path: "share/shell.d/tool.bash", ContentHash: "abc123"},
-	}
-
-	oldStderr := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	reporter := progress.NewTTYReporter(os.Stderr)
-
-	warnShellInitChanges("tool", old, new, reporter)
-
-	w.Close()
-	os.Stderr = oldStderr
-
-	var buf bytes.Buffer
-	_, _ = buf.ReadFrom(r)
-	if buf.Len() != 0 {
-		t.Errorf("expected no output for new paths, got: %s", buf.String())
-	}
-}
-
-func TestWarnShellInitChanges_SkipsActionsWithoutHash(t *testing.T) {
-	old := []install.CleanupAction{
-		{Action: "delete_file", Path: "share/shell.d/tool.bash"},
-	}
-	new := []install.CleanupAction{
-		{Action: "delete_file", Path: "share/shell.d/tool.bash"},
-	}
-
-	oldStderr := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	reporter := progress.NewTTYReporter(os.Stderr)
-
-	warnShellInitChanges("tool", old, new, reporter)
-
-	w.Close()
-	os.Stderr = oldStderr
-
-	var buf bytes.Buffer
-	_, _ = buf.ReadFrom(r)
-	if buf.Len() != 0 {
-		t.Errorf("expected no output for actions without hash, got: %s", buf.String())
-	}
-}
-
-func TestWarnShellInitChanges_MultipleShellChanges(t *testing.T) {
-	old := []install.CleanupAction{
-		{Action: "delete_file", Path: "share/shell.d/tool.bash", ContentHash: "hash1"},
-		{Action: "delete_file", Path: "share/shell.d/tool.zsh", ContentHash: "hash2"},
-		{Action: "delete_file", Path: "share/shell.d/tool.fish", ContentHash: "hash3"},
-	}
-	new := []install.CleanupAction{
-		{Action: "delete_file", Path: "share/shell.d/tool.bash", ContentHash: "changed1"},
-		{Action: "delete_file", Path: "share/shell.d/tool.zsh", ContentHash: "changed2"},
-		{Action: "delete_file", Path: "share/shell.d/tool.fish", ContentHash: "hash3"},
-	}
-
-	oldStderr := os.Stderr
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-	reporter := progress.NewTTYReporter(os.Stderr)
-
-	warnShellInitChanges("tool", old, new, reporter)
-
-	w.Close()
-	os.Stderr = oldStderr
-
-	var buf bytes.Buffer
-	_, _ = buf.ReadFrom(r)
-	output := buf.String()
-
-	if !bytes.Contains([]byte(output), []byte("(bash)")) {
-		t.Errorf("expected warning about bash, got: %s", output)
-	}
-	if !bytes.Contains([]byte(output), []byte("(zsh)")) {
-		t.Errorf("expected warning about zsh, got: %s", output)
-	}
-	// fish hash didn't change
-	if bytes.Contains([]byte(output), []byte("(fish)")) {
-		t.Errorf("did not expect warning about fish, got: %s", output)
-	}
-}
 
 func TestUpdateOutcomeMessage(t *testing.T) {
 	cases := []struct {
@@ -213,58 +62,113 @@ func TestUpdateOutcomeMessage(t *testing.T) {
 	}
 }
 
-// Version-keyed filenames mean the same fragment has a different path in every
-// version, so a comparison keyed on the raw path would never find a match and
-// this warning would silently stop firing.
-func TestWarnShellInitChanges_ComparesByTargetAndShell(t *testing.T) {
+// recordUpdateVersion writes a version's state directly and makes it active,
+// standing in for the install that would normally do so.
+func recordUpdateVersion(t *testing.T, mgr *install.Manager, tool, version string, actions []install.CleanupAction) {
+	t.Helper()
+
+	if err := mgr.GetState().UpdateTool(tool, func(ts *install.ToolState) {
+		if ts.Versions == nil {
+			ts.Versions = map[string]install.VersionState{}
+		}
+		ts.Versions[version] = install.VersionState{CleanupActions: actions}
+		ts.ActiveVersion = version
+	}); err != nil {
+		t.Fatalf("UpdateTool(%s@%s) error = %v", tool, version, err)
+	}
+}
+
+// updateFragment builds the cleanup action a version-keyed shell.d fragment
+// records, the same shape install_shell_init produces.
+func updateFragment(target, version, shell, hash string) install.CleanupAction {
+	return install.CleanupAction{
+		Action:      "delete_file",
+		Path:        "share/shell.d/" + target + "@" + version + "." + shell,
+		ContentHash: hash,
+	}
+}
+
+// TestUpdateWithCleanup pins the ordering contract the three update paths share:
+// the snapshot is taken before the install, the reconcile runs after it, and a
+// failed install reconciles nothing.
+//
+// Ordering is the whole point of the helper. A reconcile run against a snapshot
+// taken after the install would compare the new version with itself, find no
+// change, and stay silent -- indistinguishable from a clean update.
+func TestUpdateWithCleanup(t *testing.T) {
 	tests := []struct {
-		name     string
-		old      []install.CleanupAction
-		new      []install.CleanupAction
-		wantWarn bool
+		name       string
+		installErr error
+		install    func(t *testing.T, mgr *install.Manager)
+		wantWarns  []string
+		wantErr    bool
 	}{
 		{
-			name:     "same target and shell across versions, content changed",
-			old:      []install.CleanupAction{{Action: "delete_file", Path: "share/shell.d/nvm@0.40.5.bash", ContentHash: "old"}},
-			new:      []install.CleanupAction{{Action: "delete_file", Path: "share/shell.d/nvm@0.40.6.bash", ContentHash: "new"}},
-			wantWarn: true,
+			name: "a shell init rewrite during the install is announced",
+			install: func(t *testing.T, mgr *install.Manager) {
+				recordUpdateVersion(t, mgr, "tool", "2.0.0", []install.CleanupAction{
+					updateFragment("tool", "2.0.0", "bash", "after"),
+				})
+			},
+			wantWarns: []string{"shell init changed for tool (bash)"},
 		},
 		{
-			name:     "same target and shell across versions, content unchanged",
-			old:      []install.CleanupAction{{Action: "delete_file", Path: "share/shell.d/nvm@0.40.5.bash", ContentHash: "same"}},
-			new:      []install.CleanupAction{{Action: "delete_file", Path: "share/shell.d/nvm@0.40.6.bash", ContentHash: "same"}},
-			wantWarn: false,
+			name: "an unchanged shell init says nothing",
+			install: func(t *testing.T, mgr *install.Manager) {
+				recordUpdateVersion(t, mgr, "tool", "2.0.0", []install.CleanupAction{
+					updateFragment("tool", "2.0.0", "bash", "before"),
+				})
+			},
 		},
 		{
-			name:     "a different target is a new fragment, not a change",
-			old:      []install.CleanupAction{{Action: "delete_file", Path: "share/shell.d/nvm@0.40.5.bash", ContentHash: "old"}},
-			new:      []install.CleanupAction{{Action: "delete_file", Path: "share/shell.d/00-env-nvm@0.40.6.bash", ContentHash: "new"}},
-			wantWarn: false,
-		},
-		{
-			name:     "a different shell is a new fragment, not a change",
-			old:      []install.CleanupAction{{Action: "delete_file", Path: "share/shell.d/nvm@0.40.5.bash", ContentHash: "old"}},
-			new:      []install.CleanupAction{{Action: "delete_file", Path: "share/shell.d/nvm@0.40.6.zsh", ContentHash: "new"}},
-			wantWarn: false,
+			name:       "a failed install reconciles nothing",
+			installErr: errors.New("download failed"),
+			install: func(t *testing.T, mgr *install.Manager) {
+				// A partial install that got as far as recording state is the
+				// case worth pinning: the error still has to suppress the
+				// reconcile, or an update that did not land warns about a
+				// change the user never received.
+				recordUpdateVersion(t, mgr, "tool", "2.0.0", []install.CleanupAction{
+					updateFragment("tool", "2.0.0", "bash", "after"),
+				})
+			},
+			wantErr: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oldStderr := os.Stderr
-			r, w, _ := os.Pipe()
-			os.Stderr = w
-			reporter := progress.NewTTYReporter(os.Stderr)
+			cfg, cleanup := testutil.NewTestConfig(t)
+			defer cleanup()
 
-			warnShellInitChanges("nvm", tt.old, tt.new, reporter)
+			mgr := install.New(cfg)
+			recordUpdateVersion(t, mgr, "tool", "1.0.0", []install.CleanupAction{
+				updateFragment("tool", "1.0.0", "bash", "before"),
+			})
 
-			w.Close()
-			os.Stderr = oldStderr
+			var warns []string
+			installed := false
+			err := updateWithCleanup(mgr, "tool", func(format string, args ...any) {
+				warns = append(warns, fmt.Sprintf(format, args...))
+			}, func() error {
+				installed = true
+				tt.install(t, mgr)
+				return tt.installErr
+			})
 
-			var buf bytes.Buffer
-			_, _ = buf.ReadFrom(r)
-			if gotWarn := buf.Len() > 0; gotWarn != tt.wantWarn {
-				t.Errorf("warned = %v, want %v (output: %q)", gotWarn, tt.wantWarn, buf.String())
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("updateWithCleanup() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !installed {
+				t.Fatal("updateWithCleanup() never ran the install")
+			}
+			if len(warns) != len(tt.wantWarns) {
+				t.Fatalf("warnings = %q, want %q", warns, tt.wantWarns)
+			}
+			for i, want := range tt.wantWarns {
+				if warns[i] != want {
+					t.Errorf("warning %d = %q, want %q", i, warns[i], want)
+				}
 			}
 		})
 	}

--- a/internal/install/remove.go
+++ b/internal/install/remove.go
@@ -466,14 +466,14 @@ func shellFromCleanupPath(path string) string {
 	return ext[1:] // strip leading dot
 }
 
-// TargetFromCleanupPath extracts the target a shell.d cleanup path was written
+// targetFromCleanupPath extracts the target a shell.d cleanup path was written
 // for, dropping the version key and the shell suffix. Returns "" if the path
 // doesn't look like a shell.d file.
 //
 // Comparing two versions' fragments has to go through this: version-keyed
 // filenames mean the same target has a different path in every version, so a
 // comparison keyed on the raw path sees two unrelated files.
-func TargetFromCleanupPath(path string) string {
+func targetFromCleanupPath(path string) string {
 	shell := shellFromCleanupPath(path)
 	if shell == "" {
 		return ""

--- a/internal/install/shelld.go
+++ b/internal/install/shelld.go
@@ -28,10 +28,7 @@ func BuildShellDSelection(state *State) shellenv.ShellDSelection {
 	}
 
 	for _, ts := range state.Installed {
-		activeVersion := ts.ActiveVersion
-		if activeVersion == "" {
-			activeVersion = ts.Version // legacy state files
-		}
+		activeVersion := activeVersionOf(ts)
 		for version, vs := range ts.Versions {
 			for _, ca := range vs.CleanupActions {
 				if !strings.HasPrefix(ca.Path, shellDPrefix) {

--- a/internal/install/shelld_test.go
+++ b/internal/install/shelld_test.go
@@ -162,8 +162,8 @@ func TestTargetFromCleanupPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.path, func(t *testing.T) {
-			if got := TargetFromCleanupPath(tt.path); got != tt.want {
-				t.Errorf("TargetFromCleanupPath(%q) = %q, want %q", tt.path, got, tt.want)
+			if got := targetFromCleanupPath(tt.path); got != tt.want {
+				t.Errorf("targetFromCleanupPath(%q) = %q, want %q", tt.path, got, tt.want)
 			}
 		})
 	}

--- a/internal/install/update.go
+++ b/internal/install/update.go
@@ -77,6 +77,139 @@ func (m *Manager) ExecuteStaleCleanup(staleActions []CleanupAction) {
 	}
 }
 
+// WarnFunc reports a non-fatal finding to the user. The update paths print
+// through different machinery -- a TTY reporter in the foreground, a notice
+// inbox in the background -- so the shared pass takes the printer rather than
+// picking one.
+type WarnFunc func(format string, args ...any)
+
+// CleanupSnapshot is what one version of a tool recorded writing outside its own
+// tool directory, captured before an update replaces that version.
+//
+// The zero value is inert: reconciling it does nothing.
+type CleanupSnapshot struct {
+	Tool    string
+	Version string
+	Actions []CleanupAction
+}
+
+// SnapshotCleanup captures the tool's active version and the cleanup actions
+// that version recorded. Call it before the install that replaces the version --
+// afterwards the active version is the new one and there is nothing left to
+// compare against.
+//
+// A tool that is not installed, or whose active version records nothing, yields
+// the zero snapshot.
+func (m *Manager) SnapshotCleanup(tool string) CleanupSnapshot {
+	state, err := m.state.Load()
+	if err != nil || state == nil {
+		return CleanupSnapshot{}
+	}
+	ts, ok := state.Installed[tool]
+	if !ok {
+		return CleanupSnapshot{}
+	}
+	version := activeVersionOf(ts)
+	vs, ok := ts.Versions[version]
+	if !ok {
+		return CleanupSnapshot{}
+	}
+	return CleanupSnapshot{Tool: tool, Version: version, Actions: vs.CleanupActions}
+}
+
+// ReconcileUpdate settles what the replaced version left behind, once an update
+// has made a different version active. It does two things:
+//
+//   - Deletes the paths the old version wrote that the new one does not, and
+//     that no installed version still records, rebuilding the shell caches those
+//     paths belong to. Right after an update the replaced version is still
+//     installed as the rollback target, so its own paths are exempt and the
+//     deletion waits for garbage collection to reap it -- see ExecuteStaleCleanup.
+//   - Warns when a shell init fragment's content changed across the upgrade.
+//     That is the only signal a user gets that a tool rewrote the script their
+//     shell sources on every start.
+//
+// The new active version is read back out of state rather than taken as an
+// argument. Every caller would otherwise have to re-derive it, and re-deriving
+// it differently is how these paths drifted apart in the first place.
+//
+// warn may be nil, which drops the warning half.
+func (m *Manager) ReconcileUpdate(snap CleanupSnapshot, warn WarnFunc) {
+	if snap.Tool == "" || len(snap.Actions) == 0 {
+		return
+	}
+
+	state, err := m.state.Load()
+	if err != nil || state == nil {
+		return
+	}
+	ts, ok := state.Installed[snap.Tool]
+	if !ok {
+		return
+	}
+	newVersion := activeVersionOf(ts)
+	if newVersion == "" || newVersion == snap.Version {
+		return
+	}
+	vs, ok := ts.Versions[newVersion]
+	if !ok {
+		return
+	}
+
+	m.ExecuteStaleCleanup(StaleCleanupActions(snap.Actions, vs.CleanupActions))
+	warnShellInitChanges(snap.Tool, snap.Actions, vs.CleanupActions, warn)
+}
+
+// activeVersionOf reads the active version out of a tool's state, falling back
+// to the pre-multi-version field that legacy state files carry.
+func activeVersionOf(ts ToolState) string {
+	if ts.ActiveVersion != "" {
+		return ts.ActiveVersion
+	}
+	return ts.Version
+}
+
+// warnShellInitChanges compares content hashes between the old and new versions'
+// cleanup actions for shell.d fragments. When the same (target, shell) has
+// different hashes across versions, the tool's shell init output changed during
+// the update -- a signal worth surfacing, since an upstream binary that alters
+// its init output would otherwise do so unannounced.
+//
+// The comparison is keyed on (target, shell) rather than on the raw path
+// because shell.d filenames carry a version key, so every fragment has a new
+// path in every version and a path-keyed comparison would never match.
+func warnShellInitChanges(toolName string, old, new []CleanupAction, warn WarnFunc) {
+	if warn == nil {
+		return
+	}
+
+	type fragment struct{ target, shell string }
+
+	oldHashes := make(map[fragment]string)
+	for _, ca := range old {
+		shell := shellFromCleanupPath(ca.Path)
+		if shell == "" || ca.ContentHash == "" {
+			continue
+		}
+		oldHashes[fragment{TargetFromCleanupPath(ca.Path), shell}] = ca.ContentHash
+	}
+
+	for _, ca := range new {
+		shell := shellFromCleanupPath(ca.Path)
+		if shell == "" || ca.ContentHash == "" {
+			continue
+		}
+		oldHash, exists := oldHashes[fragment{TargetFromCleanupPath(ca.Path), shell}]
+		if !exists {
+			// Not present in the old version -- a newly added shell, not a change.
+			continue
+		}
+		if oldHash != ca.ContentHash {
+			warn("shell init changed for %s (%s)", toolName, shell)
+		}
+	}
+}
+
 // recordedPaths is the set of cleanup paths every installed version of every
 // tool still references. A path in this set belongs to something that is still
 // installed and must not be deleted.

--- a/internal/install/update.go
+++ b/internal/install/update.go
@@ -135,6 +135,9 @@ func (m *Manager) SnapshotCleanup(tool string) CleanupSnapshot {
 //
 // warn may be nil, which drops the warning half.
 func (m *Manager) ReconcileUpdate(snap CleanupSnapshot, warn WarnFunc) {
+	// A snapshot with nothing in it produces no stale actions and no warnings
+	// either way; this only saves the state read below, which `--all` would
+	// otherwise pay once per tool that writes nothing outside its own directory.
 	if snap.Tool == "" || len(snap.Actions) == 0 {
 		return
 	}

--- a/internal/install/update.go
+++ b/internal/install/update.go
@@ -194,7 +194,7 @@ func warnShellInitChanges(toolName string, old, new []CleanupAction, warn WarnFu
 		if shell == "" || ca.ContentHash == "" {
 			continue
 		}
-		oldHashes[fragment{TargetFromCleanupPath(ca.Path), shell}] = ca.ContentHash
+		oldHashes[fragment{targetFromCleanupPath(ca.Path), shell}] = ca.ContentHash
 	}
 
 	for _, ca := range new {
@@ -202,7 +202,7 @@ func warnShellInitChanges(toolName string, old, new []CleanupAction, warn WarnFu
 		if shell == "" || ca.ContentHash == "" {
 			continue
 		}
-		oldHash, exists := oldHashes[fragment{TargetFromCleanupPath(ca.Path), shell}]
+		oldHash, exists := oldHashes[fragment{targetFromCleanupPath(ca.Path), shell}]
 		if !exists {
 			// Not present in the old version -- a newly added shell, not a change.
 			continue

--- a/internal/install/update_test.go
+++ b/internal/install/update_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
 	"testing"
 	"time"
 
@@ -582,6 +584,23 @@ func TestReconcileUpdate_Inert(t *testing.T) {
 			name: "the active version did not change",
 			snap: func(mgr *Manager) CleanupSnapshot { return mgr.SnapshotCleanup("mytool") },
 		},
+		{
+			// `tsuku update` on a tool already at latest installs over the same
+			// version, and that install rewrites the version's cleanup record.
+			// Reconciling then would compare a version against its own newer
+			// record and delete the difference -- reinstall semantics, on a path
+			// that did not ask for them. The version check is what stops it, so
+			// this snapshot records a path nothing installed still claims.
+			name: "the active version did not change but its record was rewritten",
+			snap: func(mgr *Manager) CleanupSnapshot {
+				snap := mgr.SnapshotCleanup("mytool")
+				snap.Actions = append(append([]CleanupAction{}, snap.Actions...), CleanupAction{
+					Action: "delete_file",
+					Path:   "share/shell.d/" + orphanFragment,
+				})
+				return snap
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -591,18 +610,51 @@ func TestReconcileUpdate_Inert(t *testing.T) {
 			mgr := New(cfg)
 			twoVersionTool(t, mgr, cfg, "mytool", "1.0.0")
 
+			// A file no installed version records. Every guard under test sits
+			// upstream of the retained-path check, so this is the one thing a
+			// reconcile that should not have run is able to delete.
+			shellDDir := filepath.Join(cfg.HomeDir, "share", "shell.d")
+			if err := os.WriteFile(filepath.Join(shellDDir, orphanFragment), []byte("# orphan\n"), 0600); err != nil {
+				t.Fatal(err)
+			}
+
+			before := shellDContents(t, shellDDir)
+
 			var warns []string
 			mgr.ReconcileUpdate(tt.snap(mgr), recordWarns(&warns))
 
 			if len(warns) != 0 {
 				t.Errorf("warnings = %q, want none", warns)
 			}
-			for _, v := range []string{"1.0.0", "2.0.0"} {
-				path := filepath.Join(cfg.HomeDir, "share", "shell.d", "mytool@"+v+".bash")
-				if _, err := os.Stat(path); err != nil {
-					t.Errorf("mytool@%s.bash was deleted: %v", v, err)
+			after := shellDContents(t, shellDDir)
+			for _, name := range before {
+				if !slices.Contains(after, name) {
+					t.Errorf("%s was deleted by a reconcile that should have done nothing", name)
 				}
 			}
 		})
 	}
+}
+
+// orphanFragment names a shell.d file no version of any tool records. Nothing
+// protects it, so it is what a reconcile that ran when it should not have would
+// take with it.
+const orphanFragment = "mytool@0.9.0.bash"
+
+// shellDContents lists the files in a shell.d directory, sorted.
+func shellDContents(t *testing.T, dir string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading %s: %v", dir, err)
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	sort.Strings(names)
+	return names
 }

--- a/internal/install/update_test.go
+++ b/internal/install/update_test.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -273,5 +274,335 @@ func TestUpdateStaleCleanup_EndToEnd(t *testing.T) {
 		if _, err := os.Stat(f); os.IsNotExist(err) {
 			t.Errorf("%s file should still exist", shell)
 		}
+	}
+}
+
+// recordWarns collects what a WarnFunc was handed, so a test can assert on the
+// message a user would see rather than on a boolean.
+func recordWarns(into *[]string) WarnFunc {
+	return func(format string, args ...any) {
+		*into = append(*into, fmt.Sprintf(format, args...))
+	}
+}
+
+// TestWarnShellInitChanges covers the whole comparison in one table. The keying
+// cases matter most: version-keyed filenames mean the same fragment has a
+// different path in every version, so a comparison keyed on the raw path would
+// never find a match and this warning would silently stop firing.
+func TestWarnShellInitChanges(t *testing.T) {
+	tests := []struct {
+		name string
+		tool string
+		old  []CleanupAction
+		new  []CleanupAction
+		want []string
+	}{
+		{
+			name: "matching hashes say nothing",
+			tool: "tool",
+			old: []CleanupAction{
+				{Action: "delete_file", Path: "share/shell.d/tool.bash", ContentHash: "abc123"},
+				{Action: "delete_file", Path: "share/shell.d/tool.zsh", ContentHash: "def456"},
+			},
+			new: []CleanupAction{
+				{Action: "delete_file", Path: "share/shell.d/tool.bash", ContentHash: "abc123"},
+				{Action: "delete_file", Path: "share/shell.d/tool.zsh", ContentHash: "def456"},
+			},
+		},
+		{
+			name: "only the shell whose hash changed is named",
+			tool: "tool",
+			old: []CleanupAction{
+				{Action: "delete_file", Path: "share/shell.d/tool.bash", ContentHash: "abc123"},
+				{Action: "delete_file", Path: "share/shell.d/tool.zsh", ContentHash: "def456"},
+			},
+			new: []CleanupAction{
+				{Action: "delete_file", Path: "share/shell.d/tool.bash", ContentHash: "changed"},
+				{Action: "delete_file", Path: "share/shell.d/tool.zsh", ContentHash: "def456"},
+			},
+			want: []string{"shell init changed for tool (bash)"},
+		},
+		{
+			name: "every changed shell is named",
+			tool: "tool",
+			old: []CleanupAction{
+				{Action: "delete_file", Path: "share/shell.d/tool.bash", ContentHash: "hash1"},
+				{Action: "delete_file", Path: "share/shell.d/tool.zsh", ContentHash: "hash2"},
+				{Action: "delete_file", Path: "share/shell.d/tool.fish", ContentHash: "hash3"},
+			},
+			new: []CleanupAction{
+				{Action: "delete_file", Path: "share/shell.d/tool.bash", ContentHash: "changed1"},
+				{Action: "delete_file", Path: "share/shell.d/tool.zsh", ContentHash: "changed2"},
+				{Action: "delete_file", Path: "share/shell.d/tool.fish", ContentHash: "hash3"},
+			},
+			want: []string{
+				"shell init changed for tool (bash)",
+				"shell init changed for tool (zsh)",
+			},
+		},
+		{
+			name: "a shell the old version did not have is an addition, not a change",
+			tool: "tool",
+			old:  []CleanupAction{},
+			new: []CleanupAction{
+				{Action: "delete_file", Path: "share/shell.d/tool.bash", ContentHash: "abc123"},
+			},
+		},
+		{
+			name: "actions without a recorded hash are skipped",
+			tool: "tool",
+			old:  []CleanupAction{{Action: "delete_file", Path: "share/shell.d/tool.bash"}},
+			new:  []CleanupAction{{Action: "delete_file", Path: "share/shell.d/tool.bash"}},
+		},
+		{
+			name: "same target and shell across version keys, content changed",
+			tool: "nvm",
+			old:  []CleanupAction{{Action: "delete_file", Path: "share/shell.d/nvm@0.40.5.bash", ContentHash: "old"}},
+			new:  []CleanupAction{{Action: "delete_file", Path: "share/shell.d/nvm@0.40.6.bash", ContentHash: "new"}},
+			want: []string{"shell init changed for nvm (bash)"},
+		},
+		{
+			name: "same target and shell across version keys, content unchanged",
+			tool: "nvm",
+			old:  []CleanupAction{{Action: "delete_file", Path: "share/shell.d/nvm@0.40.5.bash", ContentHash: "same"}},
+			new:  []CleanupAction{{Action: "delete_file", Path: "share/shell.d/nvm@0.40.6.bash", ContentHash: "same"}},
+		},
+		{
+			name: "a different target is a new fragment, not a change",
+			tool: "nvm",
+			old:  []CleanupAction{{Action: "delete_file", Path: "share/shell.d/nvm@0.40.5.bash", ContentHash: "old"}},
+			new:  []CleanupAction{{Action: "delete_file", Path: "share/shell.d/00-env-nvm@0.40.6.bash", ContentHash: "new"}},
+		},
+		{
+			name: "a different shell is a new fragment, not a change",
+			tool: "nvm",
+			old:  []CleanupAction{{Action: "delete_file", Path: "share/shell.d/nvm@0.40.5.bash", ContentHash: "old"}},
+			new:  []CleanupAction{{Action: "delete_file", Path: "share/shell.d/nvm@0.40.6.zsh", ContentHash: "new"}},
+		},
+		{
+			name: "a path outside shell.d is not a shell init fragment",
+			tool: "tool",
+			old:  []CleanupAction{{Action: "delete_file", Path: "share/completions/zsh/_tool", ContentHash: "old"}},
+			new:  []CleanupAction{{Action: "delete_file", Path: "share/completions/zsh/_tool", ContentHash: "new"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got []string
+			warnShellInitChanges(tt.tool, tt.old, tt.new, recordWarns(&got))
+
+			// The order is the order of the new version's actions, which is a
+			// slice, so it is deterministic and worth asserting on.
+			if len(got) != len(tt.want) {
+				t.Fatalf("warnings = %q, want %q", got, tt.want)
+			}
+			for i, want := range tt.want {
+				if got[i] != want {
+					t.Errorf("warning %d = %q, want %q", i, got[i], want)
+				}
+			}
+		})
+	}
+}
+
+// A nil sink is the auto-apply-with-no-reporter case. It has to be inert rather
+// than a panic in a background process nobody is watching.
+func TestWarnShellInitChanges_NilSink(t *testing.T) {
+	warnShellInitChanges("tool",
+		[]CleanupAction{{Action: "delete_file", Path: "share/shell.d/tool@1.0.0.bash", ContentHash: "old"}},
+		[]CleanupAction{{Action: "delete_file", Path: "share/shell.d/tool@2.0.0.bash", ContentHash: "new"}},
+		nil)
+}
+
+// TestSnapshotCleanup covers what the snapshot has to survive: a tool that is
+// not installed, a legacy state file with no ActiveVersion, and the normal case.
+func TestSnapshotCleanup(t *testing.T) {
+	cfg, cleanup := testutil.NewTestConfig(t)
+	defer cleanup()
+	mgr := New(cfg)
+
+	if got := mgr.SnapshotCleanup("absent"); got.Tool != "" {
+		t.Errorf("SnapshotCleanup on an uninstalled tool = %+v, want the zero snapshot", got)
+	}
+
+	twoVersionTool(t, mgr, cfg, "mytool", "1.0.0")
+
+	snap := mgr.SnapshotCleanup("mytool")
+	if snap.Tool != "mytool" || snap.Version != "1.0.0" {
+		t.Fatalf("SnapshotCleanup() = %s@%s, want mytool@1.0.0", snap.Tool, snap.Version)
+	}
+	if len(snap.Actions) != 1 || snap.Actions[0].Path != "share/shell.d/mytool@1.0.0.bash" {
+		t.Errorf("snapshot actions = %v, want the active version's fragment", snap.Actions)
+	}
+
+}
+
+// activeVersionOf's fallback to the pre-multi-version field is defensive: a
+// state file loaded from disk has already been through migrateToMultiVersion,
+// which sets ActiveVersion. It is asserted directly rather than through a load
+// for exactly that reason -- a test that went through the loader would be
+// asserting the migration, not this.
+func TestActiveVersionOf(t *testing.T) {
+	tests := []struct {
+		name string
+		ts   ToolState
+		want string
+	}{
+		{"active version wins", ToolState{ActiveVersion: "2.0.0", Version: "1.0.0"}, "2.0.0"},
+		{"legacy field is the fallback", ToolState{Version: "1.0.0"}, "1.0.0"},
+		{"neither is set", ToolState{}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := activeVersionOf(tt.ts); got != tt.want {
+				t.Errorf("activeVersionOf(%+v) = %q, want %q", tt.ts, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestReconcileUpdate_DeletesOnlyWhatNothingRecords is the acceptance case from
+// issue #2470, run through the real state machinery in both configurations.
+//
+// A tool drops a shell between versions. While the replaced version is still
+// installed -- which it is immediately after an update, as the rollback target --
+// its fragment is retained and stays on disk. Once that version is reaped, the
+// same reconcile deletes it. Asserting only the first half would pass against a
+// reconcile that never deletes anything at all.
+func TestReconcileUpdate_DeletesOnlyWhatNothingRecords(t *testing.T) {
+	cfg, cleanup := testutil.NewTestConfig(t)
+	defer cleanup()
+	mgr := New(cfg)
+
+	shellDDir := filepath.Join(cfg.HomeDir, "share", "shell.d")
+	if err := os.MkdirAll(shellDDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// v1 integrates with bash and zsh; v2 drops zsh. The recorded hashes have to
+	// be real digests of the files on disk, or the cache rebuild that follows
+	// the cleanup drops the fragments as tampered-with.
+	body := "export TOOL_HOME=1\n"
+	writeFragment := func(path string) CleanupAction {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(cfg.HomeDir, filepath.FromSlash(path)), []byte(body), 0600); err != nil {
+			t.Fatal(err)
+		}
+		return CleanupAction{Action: "delete_file", Path: path, ContentHash: hashOf(body)}
+	}
+
+	v1 := []CleanupAction{
+		writeFragment("share/shell.d/mytool@1.0.0.bash"),
+		writeFragment("share/shell.d/mytool@1.0.0.zsh"),
+	}
+	v2 := []CleanupAction{
+		writeFragment("share/shell.d/mytool@2.0.0.bash"),
+	}
+
+	if err := mgr.state.UpdateTool("mytool", func(ts *ToolState) {
+		ts.ActiveVersion = "1.0.0"
+		ts.Versions = map[string]VersionState{"1.0.0": {CleanupActions: v1}}
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	snap := mgr.SnapshotCleanup("mytool")
+
+	// The update lands: v2 becomes active, v1 stays installed as the rollback
+	// target.
+	if err := mgr.state.UpdateTool("mytool", func(ts *ToolState) {
+		ts.ActiveVersion = "2.0.0"
+		ts.PreviousVersion = "1.0.0"
+		ts.Versions["2.0.0"] = VersionState{CleanupActions: v2}
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var warns []string
+	mgr.ReconcileUpdate(snap, recordWarns(&warns))
+
+	droppedShell := filepath.Join(cfg.HomeDir, "share", "shell.d", "mytool@1.0.0.zsh")
+	if _, err := os.Stat(droppedShell); err != nil {
+		t.Fatalf("the rollback target's zsh fragment was deleted while 1.0.0 is still installed: %v", err)
+	}
+	if len(warns) != 0 {
+		t.Errorf("warnings = %q, want none: bash is the only shared shell and its target changed version, not content", warns)
+	}
+
+	// Reap 1.0.0 the way garbage collection eventually does, then reconcile the
+	// same snapshot again. Nothing records the zsh fragment now.
+	if err := mgr.state.UpdateTool("mytool", func(ts *ToolState) {
+		delete(ts.Versions, "1.0.0")
+		ts.PreviousVersion = ""
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mgr.ReconcileUpdate(snap, nil)
+
+	if _, err := os.Stat(droppedShell); !os.IsNotExist(err) {
+		t.Errorf("the dropped shell's fragment survived once no installed version recorded it: %v", err)
+	}
+	// The shell the new version still integrates with keeps its file.
+	if _, err := os.Stat(filepath.Join(cfg.HomeDir, "share", "shell.d", "mytool@2.0.0.bash")); err != nil {
+		t.Errorf("the active version's own fragment was deleted: %v", err)
+	}
+}
+
+// TestReconcileUpdate_Inert covers every shape that must do nothing. Each one
+// reaching ExecuteStaleCleanup would compare a version against itself or against
+// a version that is not there, and delete on the strength of it.
+func TestReconcileUpdate_Inert(t *testing.T) {
+	tests := []struct {
+		name string
+		snap func(mgr *Manager) CleanupSnapshot
+	}{
+		{
+			name: "the zero snapshot",
+			snap: func(*Manager) CleanupSnapshot { return CleanupSnapshot{} },
+		},
+		{
+			name: "a snapshot with no recorded actions",
+			snap: func(*Manager) CleanupSnapshot {
+				return CleanupSnapshot{Tool: "mytool", Version: "1.0.0"}
+			},
+		},
+		{
+			name: "a tool that is no longer installed",
+			snap: func(*Manager) CleanupSnapshot {
+				return CleanupSnapshot{
+					Tool:    "removed",
+					Version: "1.0.0",
+					Actions: []CleanupAction{{Action: "delete_file", Path: "share/shell.d/removed@1.0.0.bash"}},
+				}
+			},
+		},
+		{
+			name: "the active version did not change",
+			snap: func(mgr *Manager) CleanupSnapshot { return mgr.SnapshotCleanup("mytool") },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, cleanup := testutil.NewTestConfig(t)
+			defer cleanup()
+			mgr := New(cfg)
+			twoVersionTool(t, mgr, cfg, "mytool", "1.0.0")
+
+			var warns []string
+			mgr.ReconcileUpdate(tt.snap(mgr), recordWarns(&warns))
+
+			if len(warns) != 0 {
+				t.Errorf("warnings = %q, want none", warns)
+			}
+			for _, v := range []string{"1.0.0", "2.0.0"} {
+				path := filepath.Join(cfg.HomeDir, "share", "shell.d", "mytool@"+v+".bash")
+				if _, err := os.Stat(path); err != nil {
+					t.Errorf("mytool@%s.bash was deleted: %v", v, err)
+				}
+			}
+		})
 	}
 }

--- a/plugins/tsuku-user/skills/tsuku-user/SKILL.md
+++ b/plugins/tsuku-user/skills/tsuku-user/SKILL.md
@@ -251,6 +251,24 @@ By default, tsuku checks for updates in the background and applies them within y
 
 Exact-pinned tools (`go = "1.23.4"`) are never auto-updated.
 
+### When a tool changes its shell init
+
+Some tools ship a script your shell runs at every start (see Shell Integration
+below). When an update changes what that script contains, tsuku says so:
+
+```
+warning: shell init changed for nvm (bash)
+```
+
+Every update path reports it — `tsuku update <tool>`, `tsuku update --all`, and
+the background auto-apply. Auto-apply has no terminal to print to, so its warning
+arrives as a notice shown by your next tsuku command instead.
+
+It isn't an error. It means the tool rewrote code that runs in your shell, which
+is worth a look if you didn't expect it. Read the new fragment under
+`$TSUKU_HOME/share/shell.d/` if you want to see what changed, and
+`tsuku rollback <tool>` if you'd rather go back.
+
 Reclamation only touches versions tsuku installed and still records in its state. A
 directory under `$TSUKU_HOME/tools` that tsuku has no record of -- left behind by an
 interrupted install, or put there by hand -- is left alone however old it is. Remove


### PR DESCRIPTION
`tsuku update <tool>` snapshotted what the outgoing version wrote outside its own
tool directory, installed, then reconciled: deleted what the new version no longer
writes, rebuilt the shell caches those paths belong to, and warned when a shell
init fragment's content changed across the upgrade. `tsuku update --all` and the
background auto-apply did none of it.

The pass now lives in one place. `install.Manager` gains `SnapshotCleanup`, which
captures the active version's recorded cleanup actions, and `ReconcileUpdate`,
which reads the new active version back out of state and settles the difference.
Reading that version rather than accepting it as an argument removes the one value
each caller would otherwise re-derive differently. `warnShellInitChanges` moves
into the same package, next to the path helpers it already depended on, and takes
a warn sink instead of a progress reporter -- the three paths print through
different machinery, and `internal/updates` cannot import `cmd/tsuku`.

In `cmd/tsuku`, `updateWithCleanup` owns the snapshot-install-reconcile ordering so
no call site can hold two thirds of it, and `updateInstalledTool` adds the version
readback both update commands need, replacing two divergent copies of the same
`List`/`IsActive` scan. `runUpdate`, `runUpdateAll`, and the auto-apply install
callback all go through them.

Auto-apply warns through the `InboxReporter` its install already writes through, so
the message lands as a notice under `$TSUKU_HOME/notices/` and is shown by the next
foreground command. That matters because `apply-updates` sends stdout and stderr to
`/dev/null` before it does anything, so a printed warning could never reach anyone
there. The callback that builds it is a named function rather than an inline
closure so a test can drive the wiring without a network.

`plugins/tsuku-user` documents the warning and where it shows up on the background
path.

---

Fixes #2470

## The acceptance criterion that does not hold

The issue asks that a tool dropping a shell between versions leave no orphaned
fragment after `--all`. It cannot, and it does not on the single-tool path either.

PR #2465 landed after the issue was written and gave `ExecuteStaleCleanup` a
retained-path guard: it never deletes a path some installed version still records.
Right after an update the replaced version is still installed -- it is the rollback
target, and `GarbageCollectVersions` explicitly refuses to reap it -- so every path
in the snapshot is exempt and nothing is deleted. That is correct rather than
accidental: `tsuku rollback` re-activates that version and expects its fragments to
still be on disk.

The issue's other stated consequence, that the orphan keeps being sourced, also no
longer holds. Fragments are version-keyed and `BuildShellDSelection` excludes
anything known-but-not-active from the init cache, so the dropped shell's fragment
drops out the moment the new version becomes active.

What is genuinely missing on `--all` and auto-apply, and what this PR delivers, is
`warnShellInitChanges` -- the only signal a user gets that a tool rewrote the
script their shell runs at every start.

The tests assert the reachable behavior rather than the stated one:
`TestReconcileUpdate_DeletesOnlyWhatNothingRecords` checks both halves, that the
fragment survives while the rollback target records it and goes once nothing does,
and `TestShellDLifecycle_UpdateAllDropsAShell` drives the `--all` sequence with a
real install and a real bash subshell.

## Extraction, not a third copy

The issue asked for this and it is worth naming: the block was extracted rather
than copied. `install_deps.go` and `plan_install.go` drifted apart exactly this way
and silently lost a `RecordCleanup` call for months.

One further export went away as a consequence. `TargetFromCleanupPath` was exported
only for `cmd/tsuku`'s copy of the warning; with that copy gone it is unexported.
`ShellFromCleanupPath` keeps its export, since `finishPostInstall` still calls it.

## Mutation testing

15 defects injected, 14 killed.

| # | Defect | Killed by |
|---|--------|-----------|
| 1 | `updateWithCleanup` never reconciles | `TestUpdateInstalledTool`, `TestShellDLifecycle_UpdateAllDropsAShell`, `TestAutoApplyInstaller_ShellInitChangeReachesTheNoticeInbox` |
| 2 | Snapshot taken after the install instead of before | same three |
| 3 | Reconcile runs even when the install failed | `TestUpdateInstalledTool/a_failed_install_reconciles_nothing` |
| 4 | `updateInstalledTool` skips the cleanup bracket | `TestUpdateInstalledTool`, `TestShellDLifecycle_UpdateAllDropsAShell` |
| 5 | Auto-apply reverted to a bare install | `TestAutoApplyInstaller_ShellInitChangeReachesTheNoticeInbox` |
| 6 | Auto-apply flushes notices before the reconcile | same |
| 7 | `ReconcileUpdate` drops the same-version guard | `TestReconcileUpdate_Inert/..._but_its_record_was_rewritten` |
| 8 | `ReconcileUpdate` drops the empty-snapshot guard | **expected survivor** -- see below |
| 9 | `SnapshotCleanup` always returns the zero snapshot | `TestSnapshotCleanup`, `TestReconcileUpdate_DeletesOnlyWhatNothingRecords`, and three more |
| 10 | `ExecuteStaleCleanup` drops the retained-path guard | `TestExecuteStaleCleanup_KeepsPathsAnInstalledVersionRecords`, `TestShellDLifecycle_UpdateThenRollback`, and two more |
| 11 | `warnShellInitChanges` keys on the raw path | `TestWarnShellInitChanges` (3 subtests) and the two e2e tests |
| 12 | `warnShellInitChanges` warns for a newly added shell | `TestWarnShellInitChanges` (3 subtests) |
| 13 | `warnShellInitChanges` drops the nil-sink guard | `TestWarnShellInitChanges_NilSink` (panic) |
| 14 | `activeVersionOf` drops the legacy fallback | `TestActiveVersionOf`, `TestBuildShellDSelection` |
| 15 | `activeVersionAfterUpdate` ignores `IsActive` | `TestUpdateInstalledTool` (2 subtests), `TestShellDLifecycle_UpdateAllDropsAShell` |

Number 8 survives because it is a short-circuit, not a barrier: with an empty
snapshot `StaleCleanupActions` returns nil and the hash comparison has an empty map
either way. It only saves a state read, which `--all` would otherwise pay once per
tool that writes nothing outside its own directory. The code says so.

Two mutations that first survived are the reason the tests look the way they do.
The inert-reconcile cases could not tell a working guard from a reconcile that ran
and found nothing to delete, because every path in the fixture was recorded by an
installed version and therefore exempt anyway; they now plant a file nothing
records. And reverting `--all` and the single-tool path to bare installs went
unnoticed until the shared core took the install as a parameter, which is what made
the sequence drivable without a recipe or a download.

## Live verification

Against real upstream downloads in a throwaway `$TSUKU_HOME`:

- `tsuku update --all` upgraded nvm 0.40.1 to 0.40.6 and printed
  `warning: shell init changed for nvm (bash)` and `(zsh)`. On main it prints
  neither. Afterwards 0.40.1's four fragments were still on disk and both init
  caches carried only 0.40.6 -- both halves of the finding above.
- `tsuku apply-updates` performed the same upgrade silently and left
  `notices/nvm.json` carrying both warnings.
- `tsuku update jq` and `tsuku update --all` on an up-to-date tool still report
  "already at the latest version" and "All tools are up to date", so the
  updated/up-to-date accounting survived sharing the version readback.

`go build`, `go vet`, `gofmt` and `go test ./...` are clean; the root suite runs
golangci-lint, gofmt and `go mod tidy -diff` as tests and all three pass.

## Filed rather than folded in

- #2511 -- a `ContentHash` shorter than twelve characters panics the shell cache
  rebuild, in the branch that exists to report corrupted state. Found via a test
  fixture with a placeholder hash.
- #2514 -- `notices.KindShellInitChange` has a dedicated renderer and no producer.
  This path is the natural producer, but `InboxReporter` picks its kind by sniffing
  message text, and the prefix that would select it would also show up in the two
  foreground paths' terminal output. Fixing it properly means changing how the
  reporter is told its kind, which is wider than this issue.

## Scope

Nothing under `.github/workflows/`, `internal/install/library.go`, `manager.go`,
`cmd/tsuku/verify.go`, `internal/executor/plan.go`, `cmd/tsuku/plan_install.go`,
`plan_utils.go`, or `internal/install/state.go`. No changed file is on the
golden-plan workflow's path allowlist, so it is not armed.
