### PR TITLE
fix(install): stage library installs and swap them into place

### DIFF
--- a/internal/install/library.go
+++ b/internal/install/library.go
@@ -25,12 +25,13 @@ type LibraryInstallOptions struct {
 // - Do not create symlinks in current/
 // - Track used_by instead of required_by
 //
-// Installation is atomic, the same way Manager.InstallWithOptions is: files are
-// copied into a staging directory, the existing library directory is removed,
-// and staging is renamed into place. The rename makes the replacement
-// all-or-nothing; the removal makes the resulting file set match the plan
-// rather than accumulate across installs, which is what `tsuku verify` promises
-// when it tells a user to reinstall a library to restore the original.
+// The library directory is never written in place. Files are copied into a
+// staging directory and swapped in by swapIntoPlace, so a failed install leaves
+// the previous library where it was rather than a mix of old and new files.
+// Clearing the destination during the swap is what makes the resulting file set
+// match the plan rather than accumulate across installs, which is what `tsuku
+// verify` promises when it tells a user to reinstall a library to restore the
+// original. See swapIntoPlace for what the swap does and does not guarantee.
 //
 // Publishes on the install lifecycle bus:
 //   - err == nil -> LibraryInstalled
@@ -74,8 +75,10 @@ func (m *Manager) InstallLibrary(ctx context.Context, name, version, workDir str
 	libDir := m.config.LibDir(name, version)
 	stagingDir := m.libStagingDir(name, version)
 
-	// Clean up any stale staging directory from a previous failed installation
-	if err := os.RemoveAll(stagingDir); err != nil && !os.IsNotExist(err) {
+	// Clean up a staging directory a previous failed installation left behind.
+	// The other half of the swap, previousDirFor(libDir), is swapIntoPlace's to
+	// clear.
+	if err := os.RemoveAll(stagingDir); err != nil {
 		return fmt.Errorf("failed to clean up stale staging directory: %w", err)
 	}
 
@@ -93,28 +96,22 @@ func (m *Manager) InstallLibrary(ctx context.Context, name, version, workDir str
 		return fmt.Errorf("failed to copy library installation: %w", err)
 	}
 
-	// Last cancellation check while bailing out is still free. copyDir does
-	// not watch ctx, so a cancellation during a long copy first becomes
-	// visible here. The tool path runs the equivalent check after removing the
-	// destination; running it before means a canceled install leaves the
-	// existing library where it was instead of deleting it and stopping.
+	// Last cancellation check while bailing out is still free. copyDir does not
+	// watch ctx, so a cancellation during a long copy first becomes visible
+	// here. The tool path runs the equivalent check after removing the
+	// destination, which deletes the installation and then stops (issue #2512);
+	// running it before the swap leaves the existing library where it was.
 	if err := ctx.Err(); err != nil {
 		os.RemoveAll(stagingDir)
 		return err
 	}
 
-	// Remove the existing directory before the rename. This is what makes a
-	// reinstall replace the library rather than merge into it: copyFile
-	// truncates the files the plan writes, but nothing removes a file the plan
-	// does not write, and the checksums computed below would then record that
-	// file as part of the library.
-	if err := os.RemoveAll(libDir); err != nil && !os.IsNotExist(err) {
-		os.RemoveAll(stagingDir)
-		return fmt.Errorf("failed to remove existing library installation: %w", err)
-	}
-
-	// Atomically rename staging into the final location
-	if err := os.Rename(stagingDir, libDir); err != nil {
+	// Replace the destination with the staged tree. Clearing the destination
+	// is what makes a reinstall replace the library rather than merge into it:
+	// copyFile truncates the files the plan writes, but nothing removes a file
+	// the plan does not write, and the checksums computed below would then
+	// record that file as part of the library.
+	if err := swapIntoPlace(stagingDir, libDir); err != nil {
 		os.RemoveAll(stagingDir)
 		return fmt.Errorf("failed to finalize library installation: %w", err)
 	}
@@ -185,10 +182,78 @@ func (m *Manager) publishLibraryInstallOutcome(name, version string, source inst
 	})
 }
 
+// previousDirFor returns the path an existing tree is moved to while dst is
+// being replaced. It is a dot-prefixed sibling of dst, so the swap's renames
+// stay within one filesystem and directory scans that skip dot-prefixed entries
+// skip it too.
+func previousDirFor(dst string) string {
+	return filepath.Join(filepath.Dir(dst), "."+filepath.Base(dst)+".previous")
+}
+
+// swapIntoPlace replaces the tree at dst with the one assembled at staging,
+// which must be a sibling of dst so the rename stays within one filesystem.
+// Nothing else is required of the caller: any leftover previousDirFor(dst) from
+// an earlier crash is cleared here, because renaming onto a non-empty directory
+// fails and the resulting error would point at dst rather than at the leftover.
+//
+// The existing tree moves aside to previousDirFor(dst) rather than being
+// deleted outright, the way updates.ApplySelfUpdate swaps the tsuku binary.
+// Deleting first would leave dst missing for as long as a recursive delete of
+// the whole tree takes, and anything resolving a path through dst during that
+// window would fail. Two renames narrow the window to a single syscall and
+// leave something to restore. Manager.InstallWithOptions still deletes first;
+// unifying the two is issue #2512.
+//
+// On error, dst holds what it held before: either nothing moved, or the
+// previous tree went back. The one case where that is not true -- both the
+// swap and the restore failing -- is reported in the returned error, because
+// it is the case where dst ends up missing entirely.
+func swapIntoPlace(staging, dst string) error {
+	previous := previousDirFor(dst)
+	if err := os.RemoveAll(previous); err != nil {
+		return fmt.Errorf("failed to clear %s left by an earlier install: %w", filepath.Base(previous), err)
+	}
+
+	movedAside := false
+	if _, err := os.Lstat(dst); err == nil {
+		if err := os.Rename(dst, previous); err != nil {
+			return fmt.Errorf("failed to move aside the existing installation: %w", err)
+		}
+		movedAside = true
+	}
+
+	if err := os.Rename(staging, dst); err != nil {
+		if movedAside {
+			if restoreErr := os.Rename(previous, dst); restoreErr != nil {
+				return fmt.Errorf("failed to move the new installation into place: %w; the previous installation could not be restored either and %s is now missing: %v", err, filepath.Base(dst), restoreErr)
+			}
+		}
+		return fmt.Errorf("failed to move the new installation into place: %w", err)
+	}
+
+	// The new tree is in place, so the previous one is unreachable. Removing it
+	// is cleanup, not part of the swap, and a failure here is not worth failing
+	// an otherwise complete install over. What it leaves is a dot-prefixed
+	// directory that scanners skip and the next swap of this path clears. It is
+	// a full copy of a library, so `tsuku doctor` should report it -- that it
+	// does not is issue #2517.
+	if movedAside {
+		_ = os.RemoveAll(previous)
+	}
+
+	return nil
+}
+
 // libStagingDir returns the path to the staging directory for an atomic library
-// installation. It sits in the same parent as the final library directory so
-// os.Rename stays within one filesystem, and it is dot-prefixed so the two
-// places that enumerate $TSUKU_HOME/libs by directory scan can skip it.
+// installation: where the new tree is assembled before it is swapped into
+// place.
+//
+// It sits in the same parent as the final library directory so os.Rename stays
+// within one filesystem, and it is dot-prefixed so directory scans of
+// $TSUKU_HOME/libs can skip it. Four scans read that directory: ListLibraries
+// and collectLibraryPaths skip dot-prefixed entries explicitly, while
+// GetInstalledLibraryVersion and actions.discoverLibraryVersion match on a
+// "<name>-" prefix a dot-prefixed entry cannot satisfy.
 func (m *Manager) libStagingDir(name, version string) string {
 	return filepath.Join(m.config.LibsDir, fmt.Sprintf(".%s-%s.staging", name, version))
 }

--- a/internal/install/library.go
+++ b/internal/install/library.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/tsukumogami/tsuku/internal/config"
@@ -23,6 +24,13 @@ type LibraryInstallOptions struct {
 // - Are installed to libs/ instead of tools/
 // - Do not create symlinks in current/
 // - Track used_by instead of required_by
+//
+// Installation is atomic, the same way Manager.InstallWithOptions is: files are
+// copied into a staging directory, the existing library directory is removed,
+// and staging is renamed into place. The rename makes the replacement
+// all-or-nothing; the removal makes the resulting file set match the plan
+// rather than accumulate across installs, which is what `tsuku verify` promises
+// when it tells a user to reinstall a library to restore the original.
 //
 // Publishes on the install lifecycle bus:
 //   - err == nil -> LibraryInstalled
@@ -63,17 +71,52 @@ func (m *Manager) InstallLibrary(ctx context.Context, name, version, workDir str
 		return err
 	}
 
-	// Create library-specific directory
 	libDir := m.config.LibDir(name, version)
-	if err := os.MkdirAll(libDir, 0755); err != nil {
-		return fmt.Errorf("failed to create library directory: %w", err)
+	stagingDir := m.libStagingDir(name, version)
+
+	// Clean up any stale staging directory from a previous failed installation
+	if err := os.RemoveAll(stagingDir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to clean up stale staging directory: %w", err)
 	}
 
-	// Copy from work directory to library directory
+	// Create staging directory
+	if err := os.MkdirAll(stagingDir, 0755); err != nil {
+		return fmt.Errorf("failed to create staging directory: %w", err)
+	}
+
+	// Copy from work directory into staging, never into the live directory.
+	// A copy that dies partway leaves the previous installation untouched.
 	srcInstallDir := filepath.Join(workDir, ".install")
 
-	if err := copyDir(srcInstallDir, libDir); err != nil {
+	if err := copyDir(srcInstallDir, stagingDir); err != nil {
+		os.RemoveAll(stagingDir)
 		return fmt.Errorf("failed to copy library installation: %w", err)
+	}
+
+	// Last cancellation check while bailing out is still free. copyDir does
+	// not watch ctx, so a cancellation during a long copy first becomes
+	// visible here. The tool path runs the equivalent check after removing the
+	// destination; running it before means a canceled install leaves the
+	// existing library where it was instead of deleting it and stopping.
+	if err := ctx.Err(); err != nil {
+		os.RemoveAll(stagingDir)
+		return err
+	}
+
+	// Remove the existing directory before the rename. This is what makes a
+	// reinstall replace the library rather than merge into it: copyFile
+	// truncates the files the plan writes, but nothing removes a file the plan
+	// does not write, and the checksums computed below would then record that
+	// file as part of the library.
+	if err := os.RemoveAll(libDir); err != nil && !os.IsNotExist(err) {
+		os.RemoveAll(stagingDir)
+		return fmt.Errorf("failed to remove existing library installation: %w", err)
+	}
+
+	// Atomically rename staging into the final location
+	if err := os.Rename(stagingDir, libDir); err != nil {
+		os.RemoveAll(stagingDir)
+		return fmt.Errorf("failed to finalize library installation: %w", err)
 	}
 
 	// Compute checksums for integrity verification (before state update)
@@ -140,6 +183,14 @@ func (m *Manager) publishLibraryInstallOutcome(name, version string, source inst
 		Source:           source,
 		Timestamp:        now,
 	})
+}
+
+// libStagingDir returns the path to the staging directory for an atomic library
+// installation. It sits in the same parent as the final library directory so
+// os.Rename stays within one filesystem, and it is dot-prefixed so the two
+// places that enumerate $TSUKU_HOME/libs by directory scan can skip it.
+func (m *Manager) libStagingDir(name, version string) string {
+	return filepath.Join(m.config.LibsDir, fmt.Sprintf(".%s-%s.staging", name, version))
 }
 
 // IsLibraryInstalled checks if a specific library version is already installed
@@ -226,6 +277,15 @@ func (m *Manager) ListLibraries() ([]InstalledLibrary, error) {
 
 		// Expected format: name-version (e.g., libyaml-0.2.5)
 		name := entry.Name()
+
+		// Skip tsuku's own bookkeeping directories. An in-flight or
+		// crash-orphaned staging directory is named .<name>-<version>.staging,
+		// which would otherwise parse as a library called ".<name>" at version
+		// "<version>.staging".
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+
 		lastHyphen := -1
 		// Find the last hyphen that's followed by a digit (version start)
 		for i := len(name) - 1; i >= 0; i-- {

--- a/internal/install/library_staging_test.go
+++ b/internal/install/library_staging_test.go
@@ -180,6 +180,8 @@ func TestManager_InstallLibrary_ReinstallReplacesDirectory(t *testing.T) {
 			if !reflect.DeepEqual(gotPaths, wantPaths) {
 				t.Errorf("recorded checksums cover %v, want exactly the plan's files %v", gotPaths, wantPaths)
 			}
+
+			assertNoWorkDirectoriesLeft(t, cfg, "libyaml", "0.2.5")
 		})
 	}
 }
@@ -189,11 +191,11 @@ func TestManager_InstallLibrary_ReinstallReplacesDirectory(t *testing.T) {
 // library holding a mix of old and new files, and every tool whose RPATH points
 // into it links against that mix.
 //
-// The failure is injected the way TestManager_InstallWithOptions_SymlinkFailureRollback
-// injects its own: something the process cannot read. Directory entries are
-// walked in name order, so a file copies successfully before the unreadable
-// directory is reached -- that is what makes it a partial copy rather than a
-// copy that never started.
+// The failure is injected with a permission the process does not have, the way
+// TestInstallWithOptions_RollbackOnSymlinkFailure injects its own. Directory
+// entries are walked in name order, so a file copies successfully before the
+// unreadable directory is reached -- that is what makes it a partial copy
+// rather than a copy that never started.
 func TestManager_InstallLibrary_FailedCopyLeavesPreviousInstallIntact(t *testing.T) {
 	if os.Geteuid() == 0 {
 		t.Skip("running as root: an unreadable directory is still readable, so the copy cannot be made to fail")
@@ -241,43 +243,66 @@ func TestManager_InstallLibrary_FailedCopyLeavesPreviousInstallIntact(t *testing
 		t.Error("a file from the failed install reached the live library directory")
 	}
 
-	stagingDir := filepath.Join(cfg.LibsDir, ".libyaml-0.2.5.staging")
-	if _, err := os.Stat(stagingDir); !os.IsNotExist(err) {
-		t.Error("staging directory should not survive a failed install")
+	assertNoWorkDirectoriesLeft(t, cfg, "libyaml", "0.2.5")
+}
+
+// TestManager_InstallLibrary_StaleWorkDirectoriesAreReplaced covers what a crash
+// leaves behind. An install killed mid-swap leaves a staging directory, a
+// moved-aside previous directory, or both; neither may block or contaminate the
+// next install.
+func TestManager_InstallLibrary_StaleWorkDirectoriesAreReplaced(t *testing.T) {
+	tests := []struct {
+		name string
+		dir  string
+	}{
+		{name: "staging directory", dir: ".libyaml-0.2.5.staging"},
+		{name: "moved-aside previous directory", dir: ".libyaml-0.2.5.previous"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, cleanup := testutil.NewTestConfig(t)
+			defer cleanup()
+
+			mgr := New(cfg)
+
+			stale := filepath.Join(cfg.LibsDir, tt.dir)
+			if err := os.MkdirAll(filepath.Join(stale, "lib"), 0755); err != nil {
+				t.Fatalf("failed to create stale dir: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(stale, "lib", "leftover.so"), []byte("stale"), 0644); err != nil {
+				t.Fatalf("failed to write stale file: %v", err)
+			}
+
+			workDir := newLibraryWorkDir(t, map[string]string{"lib/libyaml.so": "fresh"})
+			if err := mgr.InstallLibrary(libraryTestCtx(), "libyaml", "0.2.5", workDir, LibraryInstallOptions{}); err != nil {
+				t.Fatalf("InstallLibrary() error = %v", err)
+			}
+
+			libDir := cfg.LibDir("libyaml", "0.2.5")
+			if _, err := os.Stat(filepath.Join(libDir, "lib", "leftover.so")); !os.IsNotExist(err) {
+				t.Error("stale content reached the installed library")
+			}
+			if _, err := os.Stat(filepath.Join(libDir, "lib", "libyaml.so")); err != nil {
+				t.Errorf("installed library missing its own file: %v", err)
+			}
+			assertNoWorkDirectoriesLeft(t, cfg, "libyaml", "0.2.5")
+		})
 	}
 }
 
-// TestManager_InstallLibrary_StaleStagingDirectoryIsReplaced covers what a crash
-// leaves behind: an install killed between creating the staging directory and
-// renaming it must not block or contaminate the next one.
-func TestManager_InstallLibrary_StaleStagingDirectoryIsReplaced(t *testing.T) {
-	cfg, cleanup := testutil.NewTestConfig(t)
-	defer cleanup()
+// assertNoWorkDirectoriesLeft checks that neither half of the swap for
+// name@version is still on disk. Both are dot-prefixed, so both would linger
+// unnoticed: the LibsDir scans skip dot-prefixed entries by design.
+func assertNoWorkDirectoriesLeft(t *testing.T, cfg *config.Config, name, version string) {
+	t.Helper()
 
+	libDir := cfg.LibDir(name, version)
 	mgr := New(cfg)
-
-	stagingDir := filepath.Join(cfg.LibsDir, ".libyaml-0.2.5.staging")
-	if err := os.MkdirAll(filepath.Join(stagingDir, "lib"), 0755); err != nil {
-		t.Fatalf("failed to create stale staging dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(stagingDir, "lib", "leftover.so"), []byte("stale"), 0644); err != nil {
-		t.Fatalf("failed to write stale staging file: %v", err)
-	}
-
-	workDir := newLibraryWorkDir(t, map[string]string{"lib/libyaml.so": "fresh"})
-	if err := mgr.InstallLibrary(libraryTestCtx(), "libyaml", "0.2.5", workDir, LibraryInstallOptions{}); err != nil {
-		t.Fatalf("InstallLibrary() error = %v", err)
-	}
-
-	libDir := cfg.LibDir("libyaml", "0.2.5")
-	if _, err := os.Stat(filepath.Join(libDir, "lib", "leftover.so")); !os.IsNotExist(err) {
-		t.Error("stale staging content reached the installed library")
-	}
-	if _, err := os.Stat(filepath.Join(libDir, "lib", "libyaml.so")); err != nil {
-		t.Errorf("installed library missing its own file: %v", err)
-	}
-	if _, err := os.Stat(stagingDir); !os.IsNotExist(err) {
-		t.Error("staging directory should not survive a successful install")
+	for _, dir := range []string{mgr.libStagingDir(name, version), previousDirFor(libDir)} {
+		if _, err := os.Stat(dir); !os.IsNotExist(err) {
+			t.Errorf("%s should not survive the install", filepath.Base(dir))
+		}
 	}
 }
 
@@ -295,9 +320,10 @@ func TestLibsDirScans_IgnoreStagingDirectories(t *testing.T) {
 	if err := os.MkdirAll(filepath.Join(realLib, "lib"), 0755); err != nil {
 		t.Fatalf("failed to create library dir: %v", err)
 	}
-	staging := filepath.Join(cfg.LibsDir, ".libffi-3.4.4.staging")
-	if err := os.MkdirAll(filepath.Join(staging, "lib"), 0755); err != nil {
-		t.Fatalf("failed to create staging dir: %v", err)
+	for _, name := range []string{".libffi-3.4.4.staging", ".libffi-3.4.4.previous"} {
+		if err := os.MkdirAll(filepath.Join(cfg.LibsDir, name, "lib"), 0755); err != nil {
+			t.Fatalf("failed to create %s: %v", name, err)
+		}
 	}
 
 	t.Run("ListLibraries", func(t *testing.T) {
@@ -322,18 +348,67 @@ func TestLibsDirScans_IgnoreStagingDirectories(t *testing.T) {
 	})
 }
 
-// TestLibStagingDir_SharesParentWithLibraryDir pins the property the atomic
-// rename depends on: staging and destination sit in the same directory, so they
-// are always on the same filesystem.
-func TestLibStagingDir_SharesParentWithLibraryDir(t *testing.T) {
+// TestSwapIntoPlace_RestoresPreviousWhenTheSwapFails is the reason the swap
+// moves the existing tree aside instead of deleting it. Half a swap must not
+// leave the destination missing, because every tool whose RPATH points into a
+// library directory resolves through that path.
+//
+// The failure is injected by pointing the swap at a staging directory that does
+// not exist: the move-aside succeeds, the move-in cannot, and the restore is
+// what decides whether the destination survives.
+func TestSwapIntoPlace_RestoresPreviousWhenTheSwapFails(t *testing.T) {
+	root := t.TempDir()
+	dst := filepath.Join(root, "libyaml-0.2.5")
+	previous := previousDirFor(dst)
+	missingStaging := filepath.Join(root, ".libyaml-0.2.5.staging")
+
+	if err := os.MkdirAll(filepath.Join(dst, "lib"), 0755); err != nil {
+		t.Fatalf("failed to create destination: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dst, "lib", "libyaml.so"), []byte("original"), 0644); err != nil {
+		t.Fatalf("failed to write destination file: %v", err)
+	}
+
+	if err := swapIntoPlace(missingStaging, dst); err == nil {
+		t.Fatal("swapIntoPlace() should fail when the staged tree is not there")
+	}
+
+	got, err := os.ReadFile(filepath.Join(dst, "lib", "libyaml.so"))
+	if err != nil {
+		t.Fatalf("destination did not survive the failed swap: %v", err)
+	}
+	if string(got) != "original" {
+		t.Errorf("destination file = %q, want %q", got, "original")
+	}
+	if _, err := os.Stat(previous); !os.IsNotExist(err) {
+		t.Error("the moved-aside tree should be back at the destination, not left at previous")
+	}
+}
+
+// TestLibWorkDirs_SharesParentWithLibraryDir pins the two properties the swap
+// depends on: both work directories sit in the same parent as the destination,
+// so every rename stays within one filesystem, and both are dot-prefixed, so
+// the LibsDir scans skip them.
+func TestLibWorkDirs_SharesParentWithLibraryDir(t *testing.T) {
 	cfg := &config.Config{LibsDir: "/home/user/.tsuku/libs"}
 	mgr := New(cfg)
 
-	staging := mgr.libStagingDir("libyaml", "0.2.5")
-	if got, want := filepath.Dir(staging), filepath.Dir(cfg.LibDir("libyaml", "0.2.5")); got != want {
-		t.Errorf("libStagingDir parent = %q, want %q", got, want)
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "staging", got: mgr.libStagingDir("libyaml", "0.2.5"), want: ".libyaml-0.2.5.staging"},
+		{name: "previous", got: previousDirFor(cfg.LibDir("libyaml", "0.2.5")), want: ".libyaml-0.2.5.previous"},
 	}
-	if got, want := filepath.Base(staging), ".libyaml-0.2.5.staging"; got != want {
-		t.Errorf("libStagingDir base = %q, want %q", got, want)
+
+	wantParent := filepath.Dir(cfg.LibDir("libyaml", "0.2.5"))
+	for _, tt := range tests {
+		if got := filepath.Dir(tt.got); got != wantParent {
+			t.Errorf("%s parent = %q, want %q", tt.name, got, wantParent)
+		}
+		if got := filepath.Base(tt.got); got != tt.want {
+			t.Errorf("%s base = %q, want %q", tt.name, got, tt.want)
+		}
 	}
 }

--- a/internal/install/library_staging_test.go
+++ b/internal/install/library_staging_test.go
@@ -1,0 +1,339 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/tsukumogami/tsuku/internal/config"
+	"github.com/tsukumogami/tsuku/internal/testutil"
+)
+
+// newLibraryWorkDir builds the work directory shape InstallLibrary copies from:
+// a temp directory holding an .install subtree with the given relative paths
+// and contents. An empty map still produces an empty .install directory.
+func newLibraryWorkDir(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	workDir := t.TempDir()
+	installDir := filepath.Join(workDir, ".install")
+	if err := os.MkdirAll(installDir, 0755); err != nil {
+		t.Fatalf("failed to create .install dir: %v", err)
+	}
+
+	for rel, content := range files {
+		path := filepath.Join(installDir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatalf("failed to create dir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatalf("failed to write %s: %v", rel, err)
+		}
+	}
+
+	return workDir
+}
+
+// storedLibraryChecksumPaths returns the relative paths the library's recorded
+// checksums cover, sorted. Those checksums are what `tsuku verify --integrity`
+// compares against, so they are the state half of "the reinstall restored the
+// original".
+func storedLibraryChecksumPaths(t *testing.T, mgr *Manager, name, version string) []string {
+	t.Helper()
+
+	state, err := mgr.GetState().Load()
+	if err != nil {
+		t.Fatalf("failed to load state: %v", err)
+	}
+	versions, ok := state.Libs[name]
+	if !ok {
+		t.Fatalf("state has no entry for library %s", name)
+	}
+	libState, ok := versions[version]
+	if !ok {
+		t.Fatalf("state has no entry for library %s@%s", name, version)
+	}
+
+	paths := make([]string, 0, len(libState.Checksums))
+	for rel := range libState.Checksums {
+		paths = append(paths, rel)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// sortedKeys returns a map's keys in sorted order, for comparison against
+// storedLibraryChecksumPaths.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TestManager_InstallLibrary_ReinstallReplacesDirectory covers what `tsuku verify`
+// promises when it tells a user to run `tsuku install <library> --reinstall` to
+// restore the original: the library directory afterwards holds the plan's files
+// and nothing else.
+//
+// Copying over the live directory passes a test that only checks a modified file
+// was restored, because copyFile truncates the destination. What it does not do
+// is remove a file the plan never wrote, and the checksums recorded after the
+// install then claim that file as part of the library.
+func TestManager_InstallLibrary_ReinstallReplacesDirectory(t *testing.T) {
+	tests := []struct {
+		name string
+		// first is the .install tree of the original install.
+		first map[string]string
+		// addedAfterInstall is written straight into the live library
+		// directory once the first install has finished, standing in for
+		// anything that lands there outside a plan.
+		addedAfterInstall map[string]string
+		// second is the .install tree of the reinstall.
+		second map[string]string
+		// wantGone are paths, relative to the library directory, that must
+		// not exist once the reinstall has finished.
+		wantGone []string
+	}{
+		{
+			name:              "file added after installation",
+			first:             map[string]string{"lib/libyaml.so": "original"},
+			addedAfterInstall: map[string]string{"lib/evil.so": "payload"},
+			second:            map[string]string{"lib/libyaml.so": "original"},
+			wantGone:          []string{"lib/evil.so"},
+		},
+		{
+			name:              "modified file restored and added file removed together",
+			first:             map[string]string{"lib/libyaml.so": "original"},
+			addedAfterInstall: map[string]string{"lib/libyaml.so": "tampered", "lib/evil.so": "payload"},
+			second:            map[string]string{"lib/libyaml.so": "original"},
+			wantGone:          []string{"lib/evil.so"},
+		},
+		{
+			name:              "whole subdirectory added after installation",
+			first:             map[string]string{"lib/libyaml.so": "original"},
+			addedAfterInstall: map[string]string{"lib/hooks/preload.so": "payload"},
+			second:            map[string]string{"lib/libyaml.so": "original"},
+			wantGone:          []string{"lib/hooks/preload.so", "lib/hooks"},
+		},
+		{
+			name:     "file the previous install wrote and the new plan omits",
+			first:    map[string]string{"lib/libyaml.so": "v1", "lib/libyaml-compat.so": "v1"},
+			second:   map[string]string{"lib/libyaml.so": "v2"},
+			wantGone: []string{"lib/libyaml-compat.so"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, cleanup := testutil.NewTestConfig(t)
+			defer cleanup()
+
+			mgr := New(cfg)
+			opts := LibraryInstallOptions{}
+
+			if err := mgr.InstallLibrary(libraryTestCtx(), "libyaml", "0.2.5", newLibraryWorkDir(t, tt.first), opts); err != nil {
+				t.Fatalf("first InstallLibrary() error = %v", err)
+			}
+
+			libDir := cfg.LibDir("libyaml", "0.2.5")
+			for rel, content := range tt.addedAfterInstall {
+				path := filepath.Join(libDir, rel)
+				if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+					t.Fatalf("failed to create dir for %s: %v", rel, err)
+				}
+				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+					t.Fatalf("failed to write %s: %v", rel, err)
+				}
+			}
+
+			if err := mgr.InstallLibrary(libraryTestCtx(), "libyaml", "0.2.5", newLibraryWorkDir(t, tt.second), opts); err != nil {
+				t.Fatalf("reinstall InstallLibrary() error = %v", err)
+			}
+
+			for _, rel := range tt.wantGone {
+				if _, err := os.Lstat(filepath.Join(libDir, rel)); !os.IsNotExist(err) {
+					t.Errorf("%s survived the reinstall; the library directory should hold only what the plan wrote", rel)
+				}
+			}
+
+			for rel, want := range tt.second {
+				got, err := os.ReadFile(filepath.Join(libDir, rel))
+				if err != nil {
+					t.Errorf("plan file %s missing after reinstall: %v", rel, err)
+					continue
+				}
+				if string(got) != want {
+					t.Errorf("plan file %s = %q, want %q", rel, got, want)
+				}
+			}
+
+			// The recorded checksums are what `verify --integrity` compares
+			// against. A survivor recorded here is a survivor the state calls
+			// part of the library.
+			gotPaths := storedLibraryChecksumPaths(t, mgr, "libyaml", "0.2.5")
+			wantPaths := sortedKeys(tt.second)
+			if !reflect.DeepEqual(gotPaths, wantPaths) {
+				t.Errorf("recorded checksums cover %v, want exactly the plan's files %v", gotPaths, wantPaths)
+			}
+		})
+	}
+}
+
+// TestManager_InstallLibrary_FailedCopyLeavesPreviousInstallIntact covers the
+// second failure mode: without staging, a copy that dies partway leaves the live
+// library holding a mix of old and new files, and every tool whose RPATH points
+// into it links against that mix.
+//
+// The failure is injected the way TestManager_InstallWithOptions_SymlinkFailureRollback
+// injects its own: something the process cannot read. Directory entries are
+// walked in name order, so a file copies successfully before the unreadable
+// directory is reached -- that is what makes it a partial copy rather than a
+// copy that never started.
+func TestManager_InstallLibrary_FailedCopyLeavesPreviousInstallIntact(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: an unreadable directory is still readable, so the copy cannot be made to fail")
+	}
+
+	cfg, cleanup := testutil.NewTestConfig(t)
+	defer cleanup()
+
+	mgr := New(cfg)
+	opts := LibraryInstallOptions{}
+
+	first := map[string]string{"lib/libyaml.so": "original", "share/doc/README": "original docs"}
+	if err := mgr.InstallLibrary(libraryTestCtx(), "libyaml", "0.2.5", newLibraryWorkDir(t, first), opts); err != nil {
+		t.Fatalf("first InstallLibrary() error = %v", err)
+	}
+
+	// "aaa.txt" sorts before "zzz", so copyDir copies it and then fails.
+	failingWorkDir := newLibraryWorkDir(t, map[string]string{"aaa.txt": "replacement"})
+	unreadable := filepath.Join(failingWorkDir, ".install", "zzz")
+	if err := os.MkdirAll(unreadable, 0755); err != nil {
+		t.Fatalf("failed to create source subdirectory: %v", err)
+	}
+	if err := os.Chmod(unreadable, 0000); err != nil {
+		t.Fatalf("failed to make source subdirectory unreadable: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(unreadable, 0755) })
+
+	if err := mgr.InstallLibrary(libraryTestCtx(), "libyaml", "0.2.5", failingWorkDir, opts); err == nil {
+		t.Fatal("InstallLibrary() should fail when the copy cannot complete")
+	}
+
+	libDir := cfg.LibDir("libyaml", "0.2.5")
+	for rel, want := range first {
+		got, err := os.ReadFile(filepath.Join(libDir, rel))
+		if err != nil {
+			t.Errorf("previous install lost %s: %v", rel, err)
+			continue
+		}
+		if string(got) != want {
+			t.Errorf("previous install file %s = %q, want %q", rel, got, want)
+		}
+	}
+
+	if _, err := os.Stat(filepath.Join(libDir, "aaa.txt")); !os.IsNotExist(err) {
+		t.Error("a file from the failed install reached the live library directory")
+	}
+
+	stagingDir := filepath.Join(cfg.LibsDir, ".libyaml-0.2.5.staging")
+	if _, err := os.Stat(stagingDir); !os.IsNotExist(err) {
+		t.Error("staging directory should not survive a failed install")
+	}
+}
+
+// TestManager_InstallLibrary_StaleStagingDirectoryIsReplaced covers what a crash
+// leaves behind: an install killed between creating the staging directory and
+// renaming it must not block or contaminate the next one.
+func TestManager_InstallLibrary_StaleStagingDirectoryIsReplaced(t *testing.T) {
+	cfg, cleanup := testutil.NewTestConfig(t)
+	defer cleanup()
+
+	mgr := New(cfg)
+
+	stagingDir := filepath.Join(cfg.LibsDir, ".libyaml-0.2.5.staging")
+	if err := os.MkdirAll(filepath.Join(stagingDir, "lib"), 0755); err != nil {
+		t.Fatalf("failed to create stale staging dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stagingDir, "lib", "leftover.so"), []byte("stale"), 0644); err != nil {
+		t.Fatalf("failed to write stale staging file: %v", err)
+	}
+
+	workDir := newLibraryWorkDir(t, map[string]string{"lib/libyaml.so": "fresh"})
+	if err := mgr.InstallLibrary(libraryTestCtx(), "libyaml", "0.2.5", workDir, LibraryInstallOptions{}); err != nil {
+		t.Fatalf("InstallLibrary() error = %v", err)
+	}
+
+	libDir := cfg.LibDir("libyaml", "0.2.5")
+	if _, err := os.Stat(filepath.Join(libDir, "lib", "leftover.so")); !os.IsNotExist(err) {
+		t.Error("stale staging content reached the installed library")
+	}
+	if _, err := os.Stat(filepath.Join(libDir, "lib", "libyaml.so")); err != nil {
+		t.Errorf("installed library missing its own file: %v", err)
+	}
+	if _, err := os.Stat(stagingDir); !os.IsNotExist(err) {
+		t.Error("staging directory should not survive a successful install")
+	}
+}
+
+// TestLibsDirScans_IgnoreStagingDirectories pins the two places that enumerate
+// $TSUKU_HOME/libs by reading the directory rather than by reading state. A
+// staging directory is visible to both while an install is in flight, and stays
+// visible if a crash leaves one behind.
+func TestLibsDirScans_IgnoreStagingDirectories(t *testing.T) {
+	cfg, cleanup := testutil.NewTestConfig(t)
+	defer cleanup()
+
+	mgr := New(cfg)
+
+	realLib := cfg.LibDir("libyaml", "0.2.5")
+	if err := os.MkdirAll(filepath.Join(realLib, "lib"), 0755); err != nil {
+		t.Fatalf("failed to create library dir: %v", err)
+	}
+	staging := filepath.Join(cfg.LibsDir, ".libffi-3.4.4.staging")
+	if err := os.MkdirAll(filepath.Join(staging, "lib"), 0755); err != nil {
+		t.Fatalf("failed to create staging dir: %v", err)
+	}
+
+	t.Run("ListLibraries", func(t *testing.T) {
+		libs, err := mgr.ListLibraries()
+		if err != nil {
+			t.Fatalf("ListLibraries() error = %v", err)
+		}
+		if len(libs) != 1 {
+			t.Fatalf("ListLibraries() returned %d entries, want 1: %+v", len(libs), libs)
+		}
+		if libs[0].Name != "libyaml" || libs[0].Version != "0.2.5" {
+			t.Errorf("ListLibraries() returned %s@%s, want libyaml@0.2.5", libs[0].Name, libs[0].Version)
+		}
+	})
+
+	t.Run("collectLibraryPaths", func(t *testing.T) {
+		paths := mgr.collectLibraryPaths(libraryTestCtx())
+		want := []string{filepath.Join(realLib, "lib")}
+		if !reflect.DeepEqual(paths, want) {
+			t.Errorf("collectLibraryPaths() = %v, want %v", paths, want)
+		}
+	})
+}
+
+// TestLibStagingDir_SharesParentWithLibraryDir pins the property the atomic
+// rename depends on: staging and destination sit in the same directory, so they
+// are always on the same filesystem.
+func TestLibStagingDir_SharesParentWithLibraryDir(t *testing.T) {
+	cfg := &config.Config{LibsDir: "/home/user/.tsuku/libs"}
+	mgr := New(cfg)
+
+	staging := mgr.libStagingDir("libyaml", "0.2.5")
+	if got, want := filepath.Dir(staging), filepath.Dir(cfg.LibDir("libyaml", "0.2.5")); got != want {
+		t.Errorf("libStagingDir parent = %q, want %q", got, want)
+	}
+	if got, want := filepath.Base(staging), ".libyaml-0.2.5.staging"; got != want {
+		t.Errorf("libStagingDir base = %q, want %q", got, want)
+	}
+}

--- a/internal/install/manager.go
+++ b/internal/install/manager.go
@@ -662,9 +662,12 @@ func (m *Manager) collectLibraryPaths(ctx context.Context) []string {
 		if !entry.IsDir() {
 			continue
 		}
-		// Skip tsuku's own bookkeeping directories. A library staging
-		// directory holds a tree that is still being written, or one a crashed
-		// install abandoned; neither belongs on a tool's library search path.
+		// Skip tsuku's own bookkeeping directories. The dot-prefixed entries
+		// under libs are a library install's work directories: a staging tree
+		// still being written, or a superseded tree kept until the swap
+		// finishes. Neither belongs on a tool's library search path, and a
+		// superseded one least of all -- it is a complete copy of an older
+		// library, so admitting it would put two versions on the same path.
 		if strings.HasPrefix(entry.Name(), ".") {
 			continue
 		}

--- a/internal/install/manager.go
+++ b/internal/install/manager.go
@@ -662,6 +662,12 @@ func (m *Manager) collectLibraryPaths(ctx context.Context) []string {
 		if !entry.IsDir() {
 			continue
 		}
+		// Skip tsuku's own bookkeeping directories. A library staging
+		// directory holds a tree that is still being written, or one a crashed
+		// install abandoned; neither belongs on a tool's library search path.
+		if strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
 		libLibDir := filepath.Join(libsDir, entry.Name(), "lib")
 		if info, err := os.Stat(libLibDir); err == nil && info.IsDir() {
 			if validateShellSafePath(libLibDir) == nil {


### PR DESCRIPTION
`Manager.InstallLibrary` created the library directory and copied the plan's files
straight into it. `copyFile` truncates what it writes, so a modified file came back,
but nothing removed a file the plan didn't write. A file added after installation
survived the reinstall, and the checksum walk that runs next recorded it as part of
the library.

That matters because `tsuku verify` and `docs/guides/GUIDE-troubleshooting-verification.md`
both tell users to run `tsuku install <library> --reinstall` to restore a library
whose integrity check failed. Before `--reinstall` landed, the two reuse checks in
`installLibrary` meant nothing re-ran an install over an existing library directory,
so the path was unreachable.

The library directory is no longer written in place. Files are copied into a
dot-prefixed staging directory beside the destination and swapped in by
`swapIntoPlace`, which moves the existing tree aside, renames staging into place, and
puts the previous tree back if that fails. Clearing the destination is what makes the
resulting file set match the plan instead of accumulating across installs.

The issue proposes the sequence `InstallWithOptions` uses, `RemoveAll` then `Rename`.
Moving the tree aside instead avoids importing that path's failure mode: once the
delete succeeds there's nothing to restore, so a rename that fails leaves no
installation at all. It also leaves the library path missing for as long as a
recursive delete of the whole tree takes, and anything resolving a shared object
through that path during the window fails to start. Two renames narrow that to a
single syscall. `updates.ApplySelfUpdate` already swaps the tsuku binary this way.

`ListLibraries` and `collectLibraryPaths` now skip dot-prefixed entries. Unlike
`ToolsDir`, which is enumerated from state, `libs` is enumerated by directory scan, so
without the skip a staging directory shows up in `tsuku list` as a library named
`.libyaml` at version `0.2.5.staging`, and its half-written tree lands on the library
search path baked into generated wrapper scripts.

The cancellation check sits before the swap rather than after clearing the
destination, so a context canceled during a long copy leaves the existing library
where it was.

---

Fixes #2486

## The issue's mechanism is half right, and the half that fails changes the framing

The issue says `ComputeLibraryChecksums` recording the survivor is what makes
`verify --integrity` report clean afterwards. It isn't. `verify.VerifyIntegrity`
iterates only the stored checksum map:

```go
for relPath, expected := range stored { ... }
```

It never walks the directory, so a file that's present on disk but absent from the map
is invisible to it — before the reinstall as well as after. Confirmed against a real
install: with two added `.so` files on disk, `verify --integrity` printed
`Integrity: OK (10 files verified)` against 12 files.

What does hold: the documented repair left the added files in place, and the recorded
checksums then claimed them as part of the library. The dirty-to-clean transition a
user sees when a tree was both modified and added to is what endorses the result.

The blind spot itself is a separate defect and is filed as #2497, not fixed here.

## What end-to-end QA turned up that the issue doesn't mention

Running the scenario against a binary built from `main` (1a4cbff0), the reinstall
doesn't just fail to remove the added files — it fails outright:

```
Error: failed to install library to permanent location: failed to copy library
installation: open .../libs/utf8proc-2.11.3/lib/libutf8proc.a: permission denied
```

`libutf8proc.a` installs mode `0444`, and `copyFile` opens the destination
`O_WRONLY|O_CREATE|O_TRUNC`, which fails on an existing read-only file. So for any
library that installs a read-only file, the documented repair never ran to completion
and left the directory partly overwritten — the second failure mode the issue
describes, reachable without any injected fault.

Staging into an empty directory means the destination is never reopened. The same
library reinstalls cleanly with this change:

| | pre-fix binary | this branch |
|---|---|---|
| `install utf8proc --reinstall` | fails, `permission denied` | succeeds |
| added `lib/evil.so` | survives | removed |
| added `lib/hooks/preload.so` | survives | removed |
| files on disk after | 12 | 10 |
| `verify --integrity` after | `OK (10 files verified)` | `OK (10 files verified)` |
| work directories left in `libs/` | — | none |

Both binaries print `OK` at the end, which is the point: the verdict is the same and
only one of the two trees is actually the library.

## Concurrency

Nothing locks a library or a tool directory. `internal/install/filelock.go` is used
only for `state.json` and for the `updates` package's own cache locks, so a tool
installing against a library while that library is being replaced is unsynchronized
today and stays unsynchronized here. What changes is the width and the shape of the
window: from "the whole duration of a recursive copy, during which the directory holds
a mix of old and new files" to "one rename, after which the directory holds one
complete tree or the other." A reader that loses the race now fails to find a file
rather than silently linking against a mixed tree.

## Tests

Every test below fails against the original code. All assert what a user can observe
— the state of the library directory and the checksums `verify --integrity` reads —
rather than intermediate state.

| Test | Pins |
|---|---|
| `TestManager_InstallLibrary_ReinstallReplacesDirectory` | Four cases: a file added after installation, a modified file and an added file together, a whole added subdirectory, and a file the previous install wrote that the new plan omits. Each also asserts the recorded checksums cover exactly the plan's files. |
| `TestManager_InstallLibrary_FailedCopyLeavesPreviousInstallIntact` | A copy that dies partway leaves the previous library byte-for-byte intact and nothing from the failed install in the live directory. |
| `TestManager_InstallLibrary_StaleWorkDirectoriesAreReplaced` | Neither half of a crashed swap blocks or contaminates the next install. |
| `TestLibsDirScans_IgnoreStagingDirectories` | Work directories reach neither `tsuku list` nor a wrapper's library search path. |
| `TestSwapIntoPlace_RestoresPreviousWhenTheSwapFails` | A failed swap puts the previous tree back rather than leaving the destination missing. |
| `TestLibWorkDirs_SharesParentWithLibraryDir` | Both work directories are dot-prefixed siblings of the destination, which is what keeps every rename on one filesystem. |

### Mutation testing

Sixteen defects injected one at a time, each reverted after the run.

| # | Injected defect | Result | Killed by |
|---|---|---|---|
| 1 | Skip moving the existing library aside | killed | `ReinstallReplacesDirectory` |
| 2 | Drop the stale staging cleanup | killed | `StaleWorkDirectoriesAreReplaced` |
| 3 | Leave staging behind when the copy fails | killed | `FailedCopyLeavesPreviousInstallIntact` |
| 4 | Copy into the live directory (the original defect) | killed | `FailedCopyLeavesPreviousInstallIntact` |
| 5 | Leave the moved-aside tree on disk | killed | `ReinstallReplacesDirectory` |
| 6 | Drop the dot-prefix skip in `ListLibraries` | killed | `IgnoreStagingDirectories/ListLibraries` |
| 7 | Drop the dot-prefix skip in `collectLibraryPaths` | killed | `IgnoreStagingDirectories/collectLibraryPaths` |
| 8 | Stage outside `LibsDir` | killed | `SharesParentWithLibraryDir` |
| 9 | Name the moved-aside directory without the dot prefix | killed | `SharesParentWithLibraryDir` |
| 10 | Drop the pre-swap cancellation check | **survived** | — |
| 11 | Record checksums for the wrong directory | killed | `ReinstallReplacesDirectory` |
| 12 | Drop the restore when the swap fails | killed | `RestoresPreviousWhenTheSwapFails` |
| 13 | Invert the move-aside guard | killed | `ReinstallReplacesDirectory` |
| 14 | Never remove the moved-aside tree | killed | `ReinstallReplacesDirectory` |
| 15 | Drop `swapIntoPlace`'s own stale-previous clear | killed | `StaleWorkDirectoriesAreReplaced` |
| 16 | Drop `InstallLibrary`'s stale-staging clear | killed | `StaleWorkDirectoriesAreReplaced` |

**#10 is an expected survivor.** Killing it needs a context that becomes canceled
between the copy finishing and the swap starting, and there's no seam to do that from
inside the process. The guard is still worth having: `copyDir` doesn't watch `ctx`, so
a cancellation during a long copy first becomes visible at that check, and running it
before the swap is what keeps the existing library in place. Recorded rather than
dropped from the table.

## Verification

`gofmt -l .` clean, `go build ./...`, `go vet ./...`, `golangci-lint run --timeout=5m ./...`
(0 issues), and `go test ./...` all pass.

Plugin maintenance: `internal/install/` isn't one of the eight source areas in the root
`CLAUDE.md` table, and no CLI surface, flag, or output format changed — a library
install still produces the same directory at the same path. No skill update is
warranted.

This change doesn't arm `validate-golden-code.yml`; its path allowlist doesn't cover
`internal/install/`.

## Follow-up issues filed

- #2497 — `verify --integrity` doesn't report files added to a library directory
- #2512 — a canceled or failed tool reinstall can leave no installation at all, which
  is the failure mode this PR declined to import
- #2517 — `tsuku doctor`'s orphaned-staging check matches `.staging-` as a prefix while
  the producer emits `.staging` as a suffix, so it has never fired; it also doesn't
  read `libs/`

## Out of scope

#2481 (`GetInstalledLibraryVersion` returning another library's version when names
share a prefix) lives in the same file and is untouched. This change doesn't make it
trivial: the work directories are dot-prefixed, so they can't collide with the
`<name>-` prefix match that issue is about.
