### PR TITLE
fix(doctor): follow symlinks before calling a managed binary shadowed

### DIFF
--- a/internal/shellenv/precedence.go
+++ b/internal/shellenv/precedence.go
@@ -61,16 +61,20 @@ type PrecedenceInput struct {
 // on PATH behind a competing installer's prefix and never be reached. The
 // invariant is that a binary tsuku put on PATH is the one that answers.
 //
-// A binary is shadowed when the first executable of that name along PATH lies
-// outside $TSUKU_HOME entirely. The question is whether a competing installer's
-// prefix is winning, so anywhere under $TSUKU_HOME counts as tsuku's and none of
-// them is a conflict. There are more of those than the two the env file puts on
-// PATH: $TSUKU_HOME/bin holds shims and comes first, $TSUKU_HOME/tools/current
-// holds the version symlinks, and a tool's own $TSUKU_HOME/tools/<name>-<version>/bin
-// lands on PATH whenever a recipe exports it or tsuku runs the tool with its
-// runtime dependencies. Comparing against tools/current alone reports all three
-// of the others, which on a real machine means a warning per shim and per
-// exported install directory.
+// A binary is shadowed when the first executable of that name along PATH is a
+// file outside $TSUKU_HOME. The question is whether a competing installer's
+// prefix is winning, so any file under $TSUKU_HOME counts as tsuku's and none of
+// them is a conflict. There are more places for one than the two directories the
+// env file puts on PATH: $TSUKU_HOME/bin holds shims and comes first,
+// $TSUKU_HOME/tools/current holds the version symlinks, and a tool's own
+// $TSUKU_HOME/tools/<name>-<version>/bin lands on PATH whenever a recipe exports
+// it or tsuku runs the tool with its runtime dependencies. Comparing against
+// tools/current alone reports all three of the others, which on a real machine
+// means a warning per shim and per exported install directory.
+//
+// The test follows symlinks, so a managed binary linked into a directory ahead
+// of $TSUKU_HOME is tsuku's file under another name rather than a shadow. See
+// withinHome for what that deliberately does not distinguish.
 //
 // A binary that resolves nowhere is not reported. That is a broken install
 // rather than a precedence problem, and the tools/current and bin checks
@@ -136,14 +140,52 @@ func absHome(tsukuHome string) string {
 	return home
 }
 
-// withinHome reports whether path lies inside home. Both are already cleaned
-// absolute paths.
+// withinHome reports whether path is a file inside home, following symlinks
+// when the literal path is not. Both arguments are cleaned absolute paths.
+//
+// The literal comparison comes first because it answers for every PATH entry
+// tsuku puts there itself, without a syscall.
+//
+// Following links is what covers the user who symlinks managed binaries into a
+// directory already on PATH -- ~/.local/bin, on a machine where editing the
+// shell profile is awkward -- rather than putting $TSUKU_HOME/bin on PATH. The
+// name is outside $TSUKU_HOME while the file it runs is tsuku's, so a literal
+// test alone reports every one of those tools as shadowed.
+//
+// Resolution is deliberately full rather than hop-by-hop, which means a link
+// aimed straight at a version directory reads the same as one aimed at
+// tools/current. It has to: tools/current/<bin> is itself a symlink into a
+// version directory, so a link through tools/current resolves into one too, and
+// no comparison of the final path can tell the two apart. Telling them apart
+// would mean inspecting every hop of the chain. That is a different diagnostic
+// -- "this PATH entry or link pins a version and will not track updates" -- and
+// it applies just as much to a PATH entry naming a version directory outright,
+// which this check treats as tsuku's. Tracked as issue #2522.
+func withinHome(home, path string) bool {
+	if hasPrefixDir(path, home) {
+		return true
+	}
+
+	realPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return false
+	}
+	// The home is resolved too, so a $TSUKU_HOME reached through a symlinked
+	// parent -- /home a link to /var/home, say -- still recognizes its own files.
+	realHome, err := filepath.EvalSymlinks(home)
+	if err != nil {
+		return false
+	}
+	return hasPrefixDir(realPath, realHome)
+}
+
+// hasPrefixDir reports whether path sits under dir.
 //
 // The trailing separator is what keeps a sibling from matching: without it
 // "/home/u/.tsuku-backup/bin/rg" reads as living under "/home/u/.tsuku". Same
 // reason ValidateSymlinkTarget adds one.
-func withinHome(home, path string) bool {
-	return strings.HasPrefix(path, home+string(filepath.Separator))
+func hasPrefixDir(path, dir string) bool {
+	return strings.HasPrefix(path, dir+string(filepath.Separator))
 }
 
 // ownedCopy returns tsuku's own path for a binary, preferring bin/ because PATH

--- a/internal/shellenv/precedence_test.go
+++ b/internal/shellenv/precedence_test.go
@@ -36,6 +36,30 @@ func newPrecedenceFixture(t *testing.T) precedenceFixture {
 	return f
 }
 
+// dir creates a directory under the fixture root and returns it.
+func (f precedenceFixture) dir(t *testing.T, parts ...string) string {
+	t.Helper()
+	path := filepath.Join(append([]string{f.root}, parts...)...)
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", path, err)
+	}
+	return path
+}
+
+// installDir creates a tool's own bin directory under $TSUKU_HOME/tools, the
+// shape a real install leaves: tools/<name>-<version>/bin.
+func (f precedenceFixture) installDir(t *testing.T, nameVersion string) string {
+	t.Helper()
+	return f.dir(t, "tsuku", "tools", nameVersion, "bin")
+}
+
+func (f precedenceFixture) symlink(t *testing.T, target, link string) {
+	t.Helper()
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("Symlink(%s -> %s): %v", link, target, err)
+	}
+}
+
 // writeExecutable creates a runnable file. Windows has no execute bit, so the
 // mode is advisory there and existence is what counts.
 func writeExecutable(t *testing.T, dir, name string) string {
@@ -136,6 +160,59 @@ func TestCheckPrecedence(t *testing.T) {
 				return []string{installBin, f.binDir, f.currentDir, f.otherDir},
 					[]ManagedBinaries{{Tool: "socat", Binaries: []string{"socat"}}}
 			},
+		},
+		{
+			// Linking managed binaries into a directory already on PATH is a
+			// normal alternative to putting $TSUKU_HOME/bin on it. The name is
+			// outside $TSUKU_HOME; the file it runs is tsuku's own.
+			name: "a link from outside into tools/current is not a shadow",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				versionBin := f.installDir(t, "ripgrep-14.1.0")
+				writeExecutable(t, versionBin, "rg")
+				f.symlink(t, filepath.Join(versionBin, "rg"), filepath.Join(f.currentDir, "rg"))
+
+				localBin := f.dir(t, "home", ".local", "bin")
+				f.symlink(t, filepath.Join(f.currentDir, "rg"), filepath.Join(localBin, "rg"))
+
+				return []string{localBin, f.binDir, f.currentDir},
+					[]ManagedBinaries{{Tool: "ripgrep", Binaries: []string{"rg"}}}
+			},
+		},
+		{
+			// Aimed straight at a version directory rather than through
+			// tools/current. Still tsuku's file, so still not a foreign shadow.
+			// Whether such a link pins a version that stops tracking updates is
+			// a separate diagnostic; the same exposure exists for a PATH entry
+			// naming a version directory outright, which this check allows.
+			name: "a link from outside into a version directory is not a shadow",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				versionBin := f.installDir(t, "ripgrep-14.1.0")
+				writeExecutable(t, versionBin, "rg")
+				writeExecutable(t, f.currentDir, "rg")
+
+				localBin := f.dir(t, "home", ".local", "bin")
+				f.symlink(t, filepath.Join(versionBin, "rg"), filepath.Join(localBin, "rg"))
+
+				return []string{localBin, f.binDir, f.currentDir},
+					[]ManagedBinaries{{Tool: "ripgrep", Binaries: []string{"rg"}}}
+			},
+		},
+		{
+			// The guard against over-resolving: following links must not turn a
+			// competing installer's own binary into tsuku's.
+			name: "a link to a binary outside the home is still a shadow",
+			setup: func(t *testing.T, f precedenceFixture) ([]string, []ManagedBinaries) {
+				foreign := f.dir(t, "koto-install", "bin")
+				writeExecutable(t, foreign, "koto")
+				writeExecutable(t, f.currentDir, "koto")
+
+				localBin := f.dir(t, "home", ".local", "bin")
+				f.symlink(t, filepath.Join(foreign, "koto"), filepath.Join(localBin, "koto"))
+
+				return []string{localBin, f.binDir, f.currentDir},
+					[]ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}}
+			},
+			wantShadowed: []string{"koto"},
 		},
 		{
 			// The trailing-separator case: a directory whose name merely starts
@@ -342,6 +419,70 @@ func TestCheckPrecedenceAttributesToolAndPaths(t *testing.T) {
 	}
 	if got[0].Expected != tsukuPath {
 		t.Errorf("Expected = %q, want %q", got[0].Expected, tsukuPath)
+	}
+}
+
+// TestWithinHomeUnresolvablePath pins the error branch directly, because
+// CheckPrecedence cannot reach it: resolveOnPath only hands over paths that
+// isExecutableFile already stat'd, so a dangling link never gets this far. A
+// path that cannot be resolved has not been shown to be tsuku's, and saying it
+// is would silence a real shadow.
+func TestWithinHomeUnresolvablePath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink resolution differs on Windows")
+	}
+
+	root := t.TempDir()
+	home := filepath.Join(root, "tsuku")
+	if err := os.MkdirAll(filepath.Join(home, "bin"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	dangling := filepath.Join(root, "elsewhere", "rg")
+	if err := os.MkdirAll(filepath.Dir(dangling), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(root, "gone", "rg"), dangling); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	if withinHome(home, dangling) {
+		t.Error("a path that cannot be resolved must not be claimed as tsuku's")
+	}
+}
+
+// TestCheckPrecedenceSymlinkedHome covers a $TSUKU_HOME reached through a
+// symlinked parent. PATH names the real location, the configured home names the
+// link, and nothing matches unless the home is resolved too -- which would warn
+// on every managed tool at once.
+func TestCheckPrecedenceSymlinkedHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("execute-bit resolution differs on Windows")
+	}
+
+	root := t.TempDir()
+	realParent := filepath.Join(root, "real")
+	realCurrent := filepath.Join(realParent, "tsuku", "tools", "current")
+	if err := os.MkdirAll(realCurrent, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(realCurrent, "koto"), []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	linkedParent := filepath.Join(root, "linked")
+	if err := os.Symlink(realParent, linkedParent); err != nil {
+		t.Fatalf("Symlink: %v", err)
+	}
+
+	got := CheckPrecedence(PrecedenceInput{
+		TsukuHome: filepath.Join(linkedParent, "tsuku"),
+		PathDirs:  []string{realCurrent},
+		Tools:     []ManagedBinaries{{Tool: "koto", Binaries: []string{"koto"}}},
+	})
+
+	if len(got) != 0 {
+		t.Errorf("a home reached through a symlinked parent must recognize its own files, got %+v", got)
 	}
 }
 

--- a/plugins/tsuku-user/skills/tsuku-user/SKILL.md
+++ b/plugins/tsuku-user/skills/tsuku-user/SKILL.md
@@ -239,6 +239,8 @@ Two ways out: move the tsuku entries ahead of the competing prefix in your profi
 
 Only tools that are visible on PATH are checked. Execution dependencies tsuku installed for its own use — the npm or Python behind a recipe — are deliberately kept off PATH, so a system copy answering for them isn't a conflict.
 
+Symlinks are followed, so if you link managed binaries into a directory that's already on your PATH instead of adding `$TSUKU_HOME/bin` to it, none of them is reported. The name is outside `$TSUKU_HOME`, but the file it runs is tsuku's. Point those links at `$TSUKU_HOME/tools/current/<binary>` rather than at a specific version's directory — a link to `current` follows updates, and one pinned to `tools/<tool>-<version>/bin/<binary>` keeps running that version after you upgrade. Doctor doesn't yet flag the pinned case.
+
 ## Troubleshooting
 
 ### Exit Codes


### PR DESCRIPTION

The tool-precedence check asked whether the first executable a shell reaches
is a file under `$TSUKU_HOME`, but tested the path as it appears on PATH
rather than the file that path leads to. `resolveOnPath` returns
`filepath.Abs(candidate)` and `withinHome` ran its containment test on that,
so a symlink into `$TSUKU_HOME` sitting earlier on PATH was reported as a
shadow even though it resolves to the identical file.

Linking individual managed binaries into a directory already on PATH is a
normal alternative to putting `$TSUKU_HOME/bin` on PATH, and it is the usual
approach where the shell profile is centrally managed. Every tool linked that
way warned, on every run. The check is warn-only, so nothing broke; what it
cost was the credibility that makes the warning worth reading, which is the
thing the check's whole design was arguing about.

`withinHome` now keeps the literal comparison as a fast path -- it answers for
every PATH entry tsuku puts there itself, without a syscall -- and falls back
to comparing fully resolved paths. The home is resolved as well, or a
`$TSUKU_HOME` reached through a symlinked parent stops recognizing its own
files and every managed tool warns at once.

Resolution is full rather than hop-by-hop, which means a link aimed straight
at a version directory reads the same as one aimed at `tools/current`. That is
not an oversight and it cannot be fixed by comparing endpoints:
`tools/current/<bin>` is itself a symlink into a version directory, so a link
through `tools/current` resolves into one too and the two have the same final
path. Telling them apart needs the chain walked hop by hop, and the same
staleness exposure already exists for a PATH entry naming a version directory
outright, which this check treats as tsuku's on purpose. That is a separate
diagnostic, tracked in its own issue.

Note the error branch in `withinHome` is unreachable from `CheckPrecedence` --
`resolveOnPath` only yields paths `isExecutableFile` already stat'd, so a
dangling link never arrives -- and is pinned by a direct unit test rather than
left to a caller that cannot exercise it.

---

## Before and after

Setup: the real binary in a version directory, `tools/current` linking to it, and the user linking that into a directory ahead of `$TSUKU_HOME` on PATH.

```
$TSUKU_HOME/tools/ripgrep-14.1.0/bin/rg     # the real file
$TSUKU_HOME/tools/current/rg -> ../ripgrep-14.1.0/bin/rg
~/.local/bin/rg              -> $TSUKU_HOME/tools/current/rg
PATH="~/.local/bin:$TSUKU_HOME/bin:$TSUKU_HOME/tools/current:..."
```

Before:

```
  Tool precedence ... WARN (1 shadowed)
    rg (ripgrep) resolves to ~/.local/bin/rg, not tsuku's $TSUKU_HOME/tools/current/rg
```

After: `Tool precedence ... ok`. Both paths ran the same bytes the whole time.

## Tests

Four cases added to the `CheckPrecedence` table plus two standalone:

| Case | Asserts |
|---|---|
| a link from outside into `tools/current` | not a shadow — the reported false positive |
| a link from outside into a version directory | not a shadow — documents what full resolution deliberately cannot separate |
| a link to a binary outside the home | still a shadow — the guard against over-resolving |
| `TestCheckPrecedenceSymlinkedHome` | a `$TSUKU_HOME` reached through a symlinked parent recognizes its own files |
| `TestWithinHomeUnresolvablePath` | a path that cannot be resolved is not claimed as tsuku's |

The last one is a direct unit test rather than a case driven through `CheckPrecedence`, because that path is unreachable from there: `resolveOnPath` only yields paths `isExecutableFile` already stat'd, so a dangling link never arrives. Testing it through the caller would have asserted nothing.

## Mutation testing

| # | Injected defect | Result |
|---|---|---|
| 16 | the symlink chain is not followed (the pre-fix behavior) | killed by `a_link_from_outside_into_tools/current_is_not_a_shadow` |
| 17 | the home is not resolved alongside the candidate | killed by `TestCheckPrecedenceSymlinkedHome` |
| 18 | an unresolvable path counts as inside the home | killed by `TestWithinHomeUnresolvablePath` |
| 19 | the containment helper drops its trailing separator | killed by `a_sibling_directory_sharing_the_home's_prefix_is_a_shadow` |
| 20 | the literal fast path is removed | **expected survivor** |

Entry 18 survived the first pass. The branch is unreachable from `CheckPrecedence`, so no case driven through the caller could kill it; the direct unit test above was added in response rather than recording it as expected.

Entry 20 is a genuine expected survivor and no test should kill it. The literal comparison is a syscall-avoiding fast path, and full resolution returns the same answer for every state tsuku can produce. The two diverge only if a file under `$TSUKU_HOME` is a symlink pointing out of it — which tsuku never writes, and where the fast path's answer is the better one anyway, since tsuku's own directory is still the one winning.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .`, `golangci-lint run --timeout=5m ./...` (0 issues), and `go test ./...` all pass on this branch off current `origin/main`.

The reviewer's original probe from the #2513 review — `.local/bin/rg -> tools/current/rg`, PATH ordered `[.local/bin, tools/current]` — returns no findings against this branch. It was run as a throwaway and removed; the three table cases cover the same ground durably.

## Scope and follow-ups

Only `withinHome` changes. The set of tools checked, the hidden-tool exclusion, the severity, and the message are all untouched.

- #2522 — a PATH entry or symlink that pins a tool to one version and stops tracking updates. This is the gap full resolution deliberately leaves; `withinHome`'s comment points at it. #2521 was a duplicate of it and is now closed.
- #2506 — `tsuku verify` reports a PATH conflict for a shimmed tool. Same class of defect in a different command; untouched here.

Per the plugin-maintenance table, `plugins/tsuku-user` is updated: the precedence section now says symlinks are followed and tells the reader to aim links at `tools/current` rather than a version directory. `plugins/tsuku-recipes` needs no change.

Fixes #2524
