### PR TITLE
test(functional): isolate scenario homes and drop the auto-apply lock race

### DIFF
--- a/test/functional/features/create.feature
+++ b/test/functional/features/create.feature
@@ -12,7 +12,7 @@ Feature: Create
     And the file "recipes/prettier.toml" exists
 
 Scenario: Create recipe with --output flag
-    When I run "tsuku create prettier --from npm --yes --skip-sandbox --output .tsuku-test/custom/prettier.toml"
+    When I run "tsuku create prettier --from npm --yes --skip-sandbox --output $TSUKU_HOME/custom/prettier.toml"
     Then the exit code is 0
     And the output contains "Recipe created:"
     And the file "custom/prettier.toml" exists

--- a/test/functional/features/environment.feature
+++ b/test/functional/features/environment.feature
@@ -9,7 +9,7 @@ Feature: Developer Environment
     When I run "tsuku shellenv"
     Then the exit code is 0
     And the output contains "export PATH="
-    And the output contains ".tsuku-test"
+    And the output contains "$TSUKU_HOME"
 
   @critical
   Scenario: doctor reports PATH issues in unconfigured environment

--- a/test/functional/features/project-auto-update.feature
+++ b/test/functional/features/project-auto-update.feature
@@ -51,7 +51,15 @@ Feature: Project-level auto-update integration
     # Without .tsuku.toml, auto-apply should attempt the update.
     # Use a fake tool name so the install fails fast on recipe lookup
     # — the test verifies cache consumption, not a real install.
-    Given I create home file "cache/updates/fake-auto-apply-tool.json" with content:
+    #
+    # The background update check is off so that `tsuku list` spawns only one
+    # detached process. It otherwise spawns `check-updates` a few milliseconds
+    # ahead of `apply-updates`, and the two race for state.json.lock: the loser
+    # is apply-updates, whose single non-blocking probe gives up silently and
+    # leaves the cache entry behind. Auto-apply itself is untouched -- it keys
+    # off TSUKU_AUTO_UPDATE, set in the Background above.
+    Given I set env "TSUKU_NO_UPDATE_CHECK" to "1"
+    And I create home file "cache/updates/fake-auto-apply-tool.json" with content:
       """
       {"tool":"fake-auto-apply-tool","active_version":"0.6.0","requested":"","latest_within_pin":"0.7.0","latest_overall":"0.7.0","source":"github","checked_at":"2026-04-01T00:00:00Z","expires_at":"2026-04-02T00:00:00Z","error":""}
       """
@@ -69,7 +77,9 @@ Feature: Project-level auto-update integration
   Scenario: undeclared tool in project config uses global pin
     # Project config declares python but not the cached tool -- the
     # cached tool uses global pin. Fake name fails install fast.
-    Given I create home file "cache/updates/fake-auto-apply-tool.json" with content:
+    # The background update check is off for the same reason as above.
+    Given I set env "TSUKU_NO_UPDATE_CHECK" to "1"
+    And I create home file "cache/updates/fake-auto-apply-tool.json" with content:
       """
       {"tool":"fake-auto-apply-tool","active_version":"0.6.0","requested":"","latest_within_pin":"0.7.0","latest_overall":"0.7.0","source":"github","checked_at":"2026-04-01T00:00:00Z","expires_at":"2026-04-02T00:00:00Z","error":""}
       """

--- a/test/functional/steps_test.go
+++ b/test/functional/steps_test.go
@@ -38,6 +38,20 @@ func unescapeArg(s string) string {
 	return b.String()
 }
 
+// homePlaceholder is the token a feature file writes where it needs the
+// scenario's home directory spelled out. Each scenario gets a fresh temporary
+// home, so no feature file can name that path literally; expandHome substitutes
+// it in command arguments and in output assertions.
+const homePlaceholder = "$TSUKU_HOME"
+
+// expandHome replaces every homePlaceholder in s with the scenario's home path.
+func expandHome(state *testState, s string) string {
+	if state == nil || !strings.Contains(s, homePlaceholder) {
+		return s
+	}
+	return strings.ReplaceAll(s, homePlaceholder, state.homeDir)
+}
+
 // iRun executes a command string, replacing "tsuku" with the test binary path.
 func iRun(ctx context.Context, command string) (context.Context, error) {
 	state := getState(ctx)
@@ -46,13 +60,13 @@ func iRun(ctx context.Context, command string) (context.Context, error) {
 	}
 
 	// Replace "tsuku" at the start of the command with the test binary path
-	args := strings.Fields(unescapeArg(command))
+	args := strings.Fields(expandHome(state, unescapeArg(command)))
 	if len(args) > 0 && args[0] == "tsuku" {
 		args[0] = state.binPath
 	}
 
 	cmd := exec.Command(args[0], args[1:]...)
-	// Run from the same directory as the binary, where .tsuku-test lives
+	// Run from the repo root, so relative recipe and registry paths resolve
 	cmd.Dir = filepath.Dir(state.binPath)
 
 	// Determine registry URL: empty directory for @empty-registry, or repo root for local recipes
@@ -119,7 +133,7 @@ func theExitCodeIsNot(ctx context.Context, notExpected int) error {
 
 func theOutputContains(ctx context.Context, text string) error {
 	state := getState(ctx)
-	text = unescapeArg(text)
+	text = expandHome(state, unescapeArg(text))
 	if !strings.Contains(state.stdout, text) {
 		return fmt.Errorf("expected stdout to contain %q, got:\n%s", text, state.stdout)
 	}
@@ -128,7 +142,7 @@ func theOutputContains(ctx context.Context, text string) error {
 
 func theOutputDoesNotContain(ctx context.Context, text string) error {
 	state := getState(ctx)
-	text = unescapeArg(text)
+	text = expandHome(state, unescapeArg(text))
 	if strings.Contains(state.stdout, text) {
 		return fmt.Errorf("expected stdout not to contain %q, got:\n%s", text, state.stdout)
 	}
@@ -137,7 +151,7 @@ func theOutputDoesNotContain(ctx context.Context, text string) error {
 
 func theErrorOutputContains(ctx context.Context, text string) error {
 	state := getState(ctx)
-	text = unescapeArg(text)
+	text = expandHome(state, unescapeArg(text))
 	if !strings.Contains(state.stderr, text) {
 		return fmt.Errorf("expected stderr to contain %q, got:\n%s", text, state.stderr)
 	}
@@ -146,7 +160,7 @@ func theErrorOutputContains(ctx context.Context, text string) error {
 
 func theErrorOutputDoesNotContain(ctx context.Context, text string) error {
 	state := getState(ctx)
-	text = unescapeArg(text)
+	text = expandHome(state, unescapeArg(text))
 	if strings.Contains(state.stderr, text) {
 		return fmt.Errorf("expected stderr not to contain %q, got:\n%s", text, state.stderr)
 	}
@@ -235,7 +249,7 @@ func iRunFromDir(ctx context.Context, dir, command string) (context.Context, err
 		return ctx, fmt.Errorf("creating dir %s: %w", dir, err)
 	}
 
-	args := strings.Fields(unescapeArg(command))
+	args := strings.Fields(expandHome(state, unescapeArg(command)))
 	if len(args) > 0 && args[0] == "tsuku" {
 		args[0] = state.binPath
 	}
@@ -356,9 +370,13 @@ func iCanRun(ctx context.Context, command string) (context.Context, error) {
 		}
 	}
 
-	cmd := exec.Command("bash", "-c", unescapeArg(command))
+	cmd := exec.Command("bash", "-c", expandHome(state, unescapeArg(command)))
 	cmd.Env = append(os.Environ(),
 		"PATH="+toolBins+":"+os.Getenv("PATH"),
+		// The scenario home is a temporary directory, so a command that reaches
+		// for tsuku has to be told where it is rather than falling back to the
+		// binary's compiled-in default.
+		"TSUKU_HOME="+state.homeDir,
 		"TSUKU_NO_TELEMETRY=1",
 	)
 

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -57,6 +57,17 @@ func TestFeatures(t *testing.T) {
 		paths = strings.Split(p, string(os.PathListSeparator))
 	}
 
+	// One root for the whole run, holding a directory per scenario. A detached
+	// background process can outlive the scenario that spawned it and re-create
+	// paths under its home after the After hook has removed them, so the run
+	// clears the root once at the end rather than trusting per-scenario removal
+	// to be the last write.
+	suiteRoot, err := os.MkdirTemp("", "tsuku-functional-")
+	if err != nil {
+		t.Fatalf("creating suite home root: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(suiteRoot) }()
+
 	opts := &godog.Options{
 		Format: "pretty",
 		Paths:  paths,
@@ -73,7 +84,7 @@ func TestFeatures(t *testing.T) {
 
 	suite := godog.TestSuite{
 		ScenarioInitializer: func(ctx *godog.ScenarioContext) {
-			initializeScenario(ctx, binPath)
+			initializeScenario(ctx, binPath, suiteRoot)
 		},
 		Options: opts,
 	}
@@ -82,15 +93,27 @@ func TestFeatures(t *testing.T) {
 	}
 }
 
-func initializeScenario(ctx *godog.ScenarioContext, binPath string) {
-	// Reset home directory before each scenario
+func initializeScenario(ctx *godog.ScenarioContext, binPath, suiteRoot string) {
+	// Give every scenario its own home directory.
+	//
+	// Scenarios that exercise auto-update deliberately trigger detached
+	// background processes -- `tsuku check-updates` and `tsuku apply-updates` --
+	// that outlive the command that spawned them, and nothing reaps them. A
+	// single shared home would let such a process from one scenario read and
+	// write the paths the next scenario is setting up under it. Each scenario
+	// gets its own directory instead, so a stray process carries the TSUKU_HOME
+	// of the scenario that started it and cannot name any other scenario's
+	// files.
 	ctx.Before(func(ctx context.Context, sc *godog.Scenario) (context.Context, error) {
 		repoRoot := filepath.Dir(binPath)
-		// homeDir is relative to the binary's directory (repo root)
-		homeDir := filepath.Join(repoRoot, ".tsuku-test")
-		os.RemoveAll(homeDir)
-		if err := os.MkdirAll(homeDir, 0o755); err != nil {
-			return ctx, err
+		homeDir, err := os.MkdirTemp(suiteRoot, "scenario-")
+		if err != nil {
+			return ctx, fmt.Errorf("creating scenario home: %w", err)
+		}
+		// MkdirTemp uses 0700; keep the 0755 the fixed home had, so scenarios
+		// that inspect directory permissions see what they saw before.
+		if err := os.Chmod(homeDir, 0o755); err != nil {
+			return ctx, fmt.Errorf("setting scenario home permissions: %w", err)
 		}
 
 		// Seed the discovery registry cache from the repo's per-tool files
@@ -150,6 +173,17 @@ func initializeScenario(ctx *godog.ScenarioContext, binPath string) {
 			envOverrides:   envOverrides,
 		}
 		return setState(ctx, state), nil
+	})
+
+	// Best-effort removal, so a long suite does not hold every scenario's home
+	// at once. A detached process can re-create paths here afterward -- the
+	// update checker reliably does -- which is why the suite root is cleared
+	// again at the end of the run.
+	ctx.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
+		if state := getState(ctx); state != nil && state.homeDir != "" {
+			_ = os.RemoveAll(state.homeDir)
+		}
+		return ctx, nil
 	})
 
 	for _, def := range stepDefinitions() {


### PR DESCRIPTION
Give every functional scenario its own home directory instead of the fixed
`.tsuku-test` under the repo root. `TestFeatures` creates one temporary root for the
run, `initializeScenario`'s `Before` hook creates a directory per scenario under it,
and a new `After` hook removes that directory. A detached background process that
outlives its scenario now carries a `TSUKU_HOME` no other scenario can name. The
update checker reliably re-creates its cache path after the `After` hook has run, so
the run clears the root once more at the end rather than trusting per-scenario
removal to be the last write.

Add a `$TSUKU_HOME` placeholder that `iRun`, `iRunFromDir`, `iCanRun`, and the four
output-assertion steps expand to the scenario's home, so feature files can still
refer to a path that is no longer fixed. Move the two hard-coded `.tsuku-test`
references onto it: the `shellenv` assertion in `environment.feature` and the
`--output` argument in `create.feature`. `iCanRun` now also sets `TSUKU_HOME`,
which it previously left to the binary's compiled-in default.

Set `TSUKU_NO_UPDATE_CHECK=1` on the two auto-apply scenarios in
`project-auto-update.feature`. Without it, `tsuku list` spawns `check-updates`
milliseconds ahead of `apply-updates` and the two race for `state.json.lock`;
`apply-updates` probes that lock once without blocking and returns silently when it
loses, leaving the cache entry the scenarios assert on. Auto-apply itself is
untouched -- it keys off `TSUKU_AUTO_UPDATE`, which the feature's Background
already sets.

---

Fixes #2526

## Root cause, and where the issue's analysis does not hold

The issue attributes the flake to the shared home directory letting a detached
process from one scenario reach into the next. That hazard is real, but it is not
what fails these two scenarios.

`rootCmd.PersistentPreRun` calls `CheckAndSpawnUpdateCheck` and then
`MaybeSpawnAutoApply`, two lines apart. Each spawns a detached copy of the same
binary. `strace -f -tt -e trace=execve,flock,openat` on one
`TSUKU_AUTO_UPDATE=1 tsuku list`:

| Time | Process | Event |
|------|---------|-------|
| 38.2326 | `tsuku list` | spawn `check-updates` |
| 38.2393 | `tsuku list` | spawn `apply-updates` |
| 38.2415-38.2425 | `tsuku list` | `state.json.lock` LOCK_SH |
| 38.2578-38.2595 | `check-updates` | `state.json.lock` LOCK_SH, twice |
| 38.2649 | `apply-updates` | `state.json.lock` LOCK_EX\|LOCK_NB -- the probe |

The probe lands 5.4 ms after `check-updates` releases. Lose that margin and
`MaybeAutoApply` returns at the probe, nothing retries, and the entry survives --
which is why the failure is always a full 90-second timeout rather than a slow
pass.

Reproduced outside godog with a **private home directory per iteration**, so
cross-scenario contamination was impossible by construction:

| Condition | Failures |
|-----------|----------|
| Idle machine | 0/30 |
| 64 CPU spinners on 32 cores | 1/20 |
| 96 CPU spinners on 32 cores | 1/25 |
| All processes pinned to one CPU (`taskset`) | **7/30** |
| Pinned to one CPU, `TSUKU_NO_UPDATE_CHECK=1` | **0/30** |

And through godog, on this branch, with the per-scenario homes already in place:

| Feature file | Pinned runs |
|--------------|-------------|
| Before the `TSUKU_NO_UPDATE_CHECK` line | 1/8 failed |
| After | 0/20 failed |

So the per-scenario home change fixes no observable failure. It is here because it
is what the third acceptance criterion asks for, and because the hazard is
genuine: the first two scenarios in this feature file spawn detached
`apply-updates` processes that really do attempt to install `serve` into the shared
home, and they outlive their scenarios.

## Residual hazard

The parent command's own shared read lock on `state.json.lock` can still, in
principle, be held when `apply-updates` probes. The margin is 22 ms rather than
5.4 ms and no failure was observed in 75 pinned or loaded iterations, but the
underlying defect -- a one-shot probe with no retry, in a process that sends its
output to `/dev/null` -- is production behavior and is filed as #2528 rather than
worked around further here.

## Mutation testing

Each defect injected in production code, both scenarios run, then reverted.

| Defect injected | Where | Observed |
|-----------------|-------|----------|
| Drop the `RemoveEntry(cacheDir, entry.Tool)` that consumes the entry | `internal/updates/apply.go` | both scenarios fail at 90 s |
| Return from `MaybeSpawnAutoApply` before spawning | `internal/updates/trigger.go` | both scenarios fail at 90 s |
| `IsPendingEntry` always returns false | `internal/updates/apply.go` | both scenarios fail at 90 s |

No survivors. The assertions still pin what they claim to pin: the entry is
consumed by a real detached process that a real command triggered.

## Reachability finding

`MaybeAutoApply` has exactly one production caller, `cmd_apply_updates.go`, and it
passes `projectCfg = nil`. Its project-pin filtering block is therefore unreachable
outside unit tests, and a `.tsuku.toml` exact pin does not suppress background
auto-apply -- verified by reproduction. The first two scenarios in this feature
file do not catch that: they assert the cache entry still exists immediately after
`tsuku list` returns, and it does, because the detached process has not got to it
yet. Filed as #2527, with the note that the fix should also make those two
scenarios assert suppression over a poll window.

Neither issue is fixed here; both are production changes and out of scope.

## Runs observed

Given the failure mode, one green run is weak evidence. The pinned runs carry most
of the weight -- they fail 23% of the time without the fix, so 20 consecutive passes
is a much stronger signal than any number of unamplified CI runs.

| Where | Runs |
|-------|------|
| CI `Functional Tests` on this branch (full suite, since the diff touches `test/functional/**`) | 4 green |
| Local `make test-functional`, full suite | 2 green (254 s, 304 s) |
| Local `make test-functional-critical` | 1 green |
| Local, two scenarios only, every process pinned to one CPU | 20 green |

## Scope notes

Only `test/functional/` changes, so no `plugins/tsuku-recipes/` or
`plugins/tsuku-user/` skill is affected -- the plugin-maintenance table keys on
`internal/` and `cmd/tsuku/` paths, and this PR adds no user-facing surface for a
skill to document. None of the changed files are on the
`validate-golden-code.yml` path allowlist, so that workflow is not armed.
