### PR TITLE
feat(recipes): install vale from upstream GitHub releases

### DIFF
--- a/recipes/v/vale.toml
+++ b/recipes/v/vale.toml
@@ -1,22 +1,26 @@
 [metadata]
-  name = "vale"
-  description = "Syntax-aware linter for prose"
-  homepage = "https://vale.sh/"
-  version_format = ""
-  requires_sudo = false
-  tier = 0
-  type = ""
-  llm_validation = "skipped"
+name = "vale"
+description = "Syntax-aware linter for prose"
+homepage = "https://vale.sh/"
+version_format = "semver"
+curated = true
 supported_libc = ["glibc"]
+unsupported_reason = "Upstream publishes only glibc-linked Linux binaries (cgo-enabled); there is no musl release asset"
+
+[version]
+github_repo = "vale-cli/vale"
+tag_prefix = "v"
 
 [[steps]]
-  action = "homebrew"
-  formula = "vale"
-
-[[steps]]
-  action = "install_binaries"
-  binaries = ["bin/vale"]
+action = "github_archive"
+repo = "vale-cli/vale"
+asset_pattern = "vale_{version}_{os}_{arch}.tar.gz"
+checksum_asset = "vale_{version}_checksums.txt"
+strip_dirs = 0
+binaries = ["vale"]
+os_mapping = { darwin = "macOS", linux = "Linux" }
+arch_mapping = { amd64 = "64-bit", arm64 = "arm64" }
 
 [verify]
-  command = "vale --version"
-  pattern = ""
+command = "vale --version"
+pattern = "{version}"


### PR DESCRIPTION
Rewrite `recipes/v/vale.toml` to install vale from the project's own GitHub
release assets instead of a Homebrew bottle. The recipe now uses a single
`github_archive` step against `vale-cli/vale`, with `os_mapping` and
`arch_mapping` covering the goreleaser asset names (`Linux`/`macOS` and
`64-bit`/`arm64`), and `checksum_asset` pointing at the per-release
`vale_{version}_checksums.txt` so downloads are verified against upstream.

The `[verify]` pattern changes from an empty string to `{version}`, so a
mismatched or partial install fails instead of passing silently, and
`version_format` is set to `semver` to match the tag scheme. The recipe is
marked `curated = true` to bring it into the nightly cross-platform validation
run. The existing `supported_libc = ["glibc"]` constraint stays and gains an
`unsupported_reason`.

---

## Why

vale arrived through the batch Homebrew import, so installing it required brew
and pulled a bottle rather than the binaries the project publishes itself. The
project ships prebuilt archives for Linux and macOS on both amd64 and arm64,
which is a better fit for tsuku's self-contained model, and those releases carry
a checksums file that the Homebrew path could not use.

The empty `[verify]` pattern was the more pressing problem: verification ran the
command but compared against nothing, so any binary that happened to exit zero
would have been accepted.

## libc constraint

The Linux release assets are cgo-enabled and dynamically linked against glibc
(`libresolv`, `libpthread`), and upstream publishes no musl variant, so the
glibc-only constraint is accurate rather than inherited. The `unsupported_reason`
field now records that.

## Test plan

- `tsuku validate --strict recipes/v/vale.toml` passes.
- Installed into an isolated `TSUKU_HOME` on linux/amd64; `vale --version`
  reports `vale version 3.17.1` and verification passes.
- The generated plan resolves the archive checksum to
  `db947f89f2292e6a0381a61de155f6a5f5cb4cb460ca178ea412ef605559cefd`, matching
  the `Linux_64-bit` entry in the published `vale_3.17.1_checksums.txt`.
- macOS asset names and archive layout were confirmed against the release
  (flat archive containing `vale`, `LICENSE`, `README.md`, hence
  `strip_dirs = 0`), but not installed locally. The nightly curated run covers
  that path.
