### PR TITLE
style(tsuku-llm): format the crate, then gate cargo fmt --check

### DIFF
--- a/.github/workflows/check-rustfmt.yml
+++ b/.github/workflows/check-rustfmt.yml
@@ -1,0 +1,60 @@
+name: Check rustfmt
+
+# Fails a PR that leaves either Rust crate unformatted.
+#
+# Nothing ran `cargo fmt --check` before this, so drift accumulated unnoticed:
+# seven of tsuku-llm's twelve source files had diverged from rustfmt's output by
+# the time this gate was written. The damage that causes is indirect — the next
+# author who runs the obvious `cargo fmt` in that crate silently adopts every
+# pre-existing deviation and sweeps it into an unrelated PR.
+#
+# The two crates are independent cargo projects, not a workspace, and they pin
+# different channels (tsuku-llm reads `stable`, cmd/tsuku-dltest reads `1.80`).
+# So the check runs once per crate with `working-directory:` set, letting each
+# crate's own rust-toolchain.toml resolve exactly as it does for that crate's
+# build step in test.yml. A gate that forced a single version on both would
+# disagree with one of the two builds.
+#
+# `cargo fmt --check` compiles nothing, so neither the protobuf compiler nor the
+# cargo cache that test.yml needs for its builds is required here.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - '**/rust-toolchain.toml'
+      - '.github/workflows/check-rustfmt.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**/*.rs'
+      - '**/Cargo.toml'
+      - '**/rust-toolchain.toml'
+      - '.github/workflows/check-rustfmt.yml'
+
+jobs:
+  check-rustfmt:
+    name: Check rustfmt
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Rust
+        # SHA pin for dtolnay/rust-toolchain@stable (resolved from the stable
+        # branch HEAD). No `toolchain:` input: the action reads the
+        # rust-toolchain.toml nearest the working directory, which is what makes
+        # the per-crate resolution below work. rustup fetches cmd/tsuku-dltest's
+        # pinned 1.80 on first use in that directory.
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - name: Cargo fmt (tsuku-llm)
+        working-directory: tsuku-llm
+        run: cargo fmt --all --check
+
+      - name: Cargo fmt (cmd/tsuku-dltest)
+        working-directory: cmd/tsuku-dltest
+        run: cargo fmt --all --check

--- a/.github/workflows/check-rustfmt.yml
+++ b/.github/workflows/check-rustfmt.yml
@@ -45,11 +45,32 @@ jobs:
 
       - name: Set up Rust
         # SHA pin for dtolnay/rust-toolchain@stable (resolved from the stable
-        # branch HEAD). No `toolchain:` input: the action reads the
-        # rust-toolchain.toml nearest the working directory, which is what makes
-        # the per-crate resolution below work. rustup fetches cmd/tsuku-dltest's
-        # pinned 1.80 on first use in that directory.
+        # branch HEAD). This installs a working rustup plus the stable channel,
+        # which is what tsuku-llm pins.
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
+
+      - name: Install each crate's pinned channel, with rustfmt
+        # Do not rely on rustup's on-demand install. When `cargo fmt` is invoked
+        # in a directory whose rust-toolchain.toml names a channel that is not
+        # yet present, rustup fetches it with a minimal profile that has no
+        # rustfmt, and the step dies on "'cargo-fmt' is not installed for the
+        # toolchain". Installing each channel up front with an explicit
+        # --component rustfmt is what makes the per-crate resolution below work.
+        #
+        # The channel is read from each crate's own rust-toolchain.toml rather
+        # than hardcoded, so bumping a pin does not silently leave this behind.
+        run: |
+          set -euo pipefail
+          for crate in tsuku-llm cmd/tsuku-dltest; do
+            channel=$(sed -n 's/^channel[[:space:]]*=[[:space:]]*"\(.*\)"/\1/p' "$crate/rust-toolchain.toml")
+            if [ -z "$channel" ]; then
+              echo "::error::no channel found in $crate/rust-toolchain.toml"
+              exit 1
+            fi
+            echo "::group::$crate pins $channel"
+            rustup toolchain install "$channel" --profile minimal --component rustfmt
+            echo "::endgroup::"
+          done
 
       - name: Cargo fmt (tsuku-llm)
         working-directory: tsuku-llm

--- a/tsuku-llm/build.rs
+++ b/tsuku-llm/build.rs
@@ -45,7 +45,10 @@ fn compile_llama_cpp() -> Result<(), Box<dyn std::error::Error>> {
         // driver can JIT-compile for newer architectures.
         if let Ok(archs) = env::var("TSUKU_CUDA_ARCHITECTURES") {
             cmake_config.define("CMAKE_CUDA_ARCHITECTURES", &archs);
-            println!("cargo:warning=Building with CUDA support (architectures: {})", archs);
+            println!(
+                "cargo:warning=Building with CUDA support (architectures: {})",
+                archs
+            );
         } else {
             println!("cargo:warning=Building with CUDA support (native architectures)");
         }

--- a/tsuku-llm/src/llama/grammar.rs
+++ b/tsuku-llm/src/llama/grammar.rs
@@ -8,9 +8,9 @@ use std::ffi::CString;
 use std::ptr::NonNull;
 
 use super::bindings::{
-    llama_sampler, llama_sampler_accept, llama_sampler_chain_add, llama_sampler_chain_default_params,
-    llama_sampler_chain_init, llama_sampler_free, llama_sampler_init_grammar,
-    llama_sampler_init_greedy, llama_sampler_sample, llama_vocab,
+    llama_sampler, llama_sampler_accept, llama_sampler_chain_add,
+    llama_sampler_chain_default_params, llama_sampler_chain_init, llama_sampler_free,
+    llama_sampler_init_grammar, llama_sampler_init_greedy, llama_sampler_sample, llama_vocab,
 };
 use super::error::{LlamaError, Result};
 
@@ -37,32 +37,24 @@ impl GrammarSampler {
     ///
     /// A sampler chain with grammar constraint followed by greedy sampling.
     /// Returns an error if the grammar is invalid.
-    pub fn new(
-        vocab: *const llama_vocab,
-        grammar_str: &str,
-        grammar_root: &str,
-    ) -> Result<Self> {
-        let grammar_c = CString::new(grammar_str).map_err(|e| {
-            LlamaError::Grammar(format!("Invalid grammar string: {}", e))
-        })?;
-        let root_c = CString::new(grammar_root).map_err(|e| {
-            LlamaError::Grammar(format!("Invalid root rule name: {}", e))
-        })?;
+    pub fn new(vocab: *const llama_vocab, grammar_str: &str, grammar_root: &str) -> Result<Self> {
+        let grammar_c = CString::new(grammar_str)
+            .map_err(|e| LlamaError::Grammar(format!("Invalid grammar string: {}", e)))?;
+        let root_c = CString::new(grammar_root)
+            .map_err(|e| LlamaError::Grammar(format!("Invalid root rule name: {}", e)))?;
 
         unsafe {
             // Create the sampler chain
             let params = llama_sampler_chain_default_params();
             let chain = llama_sampler_chain_init(params);
             if chain.is_null() {
-                return Err(LlamaError::Grammar("Failed to create sampler chain".to_string()));
+                return Err(LlamaError::Grammar(
+                    "Failed to create sampler chain".to_string(),
+                ));
             }
 
             // Create grammar sampler
-            let grammar = llama_sampler_init_grammar(
-                vocab,
-                grammar_c.as_ptr(),
-                root_c.as_ptr(),
-            );
+            let grammar = llama_sampler_init_grammar(vocab, grammar_c.as_ptr(), root_c.as_ptr());
             if grammar.is_null() {
                 llama_sampler_free(chain);
                 return Err(LlamaError::Grammar(format!(
@@ -154,9 +146,9 @@ impl GbnfBuilder {
 
     /// Process a JSON Schema and generate rules for the given rule name.
     fn process_schema(&mut self, schema: &serde_json::Value, rule_name: &str) -> Result<()> {
-        let obj = schema.as_object().ok_or_else(|| {
-            LlamaError::Grammar("Schema must be an object".to_string())
-        })?;
+        let obj = schema
+            .as_object()
+            .ok_or_else(|| LlamaError::Grammar("Schema must be an object".to_string()))?;
 
         let schema_type = obj.get("type").and_then(|v| v.as_str());
 
@@ -241,7 +233,9 @@ impl GbnfBuilder {
 
         // Add optional properties (each wrapped in optional marker)
         for (name, _) in &optional_props {
-            if !required_props.is_empty() || optional_props.iter().position(|(n, _)| n == name).unwrap() > 0 {
+            if !required_props.is_empty()
+                || optional_props.iter().position(|(n, _)| n == name).unwrap() > 0
+            {
                 object_rule.push_str(&format!(r#" ("," ws {})?"#, &kv_rules[name]));
             } else {
                 object_rule.push_str(&format!("({})?", &kv_rules[name]));
@@ -331,10 +325,7 @@ impl GbnfBuilder {
             );
         }
         if !self.defined_rules.contains("array") {
-            self.add_rule(
-                "array",
-                r#""[" ws (value ("," ws value)*)? ws "]""#,
-            );
+            self.add_rule("array", r#""[" ws (value ("," ws value)*)? ws "]""#);
         }
         if !self.defined_rules.contains("string") {
             self.add_rule(
@@ -360,7 +351,8 @@ impl GbnfBuilder {
     fn build(mut self) -> String {
         // Add whitespace rule at the end
         if !self.defined_rules.contains("ws") {
-            self.rules.push(r#"ws ::= | " " | "\n" [ \t]{0,20}"#.to_string());
+            self.rules
+                .push(r#"ws ::= | " " | "\n" [ \t]{0,20}"#.to_string());
         }
 
         self.rules.join("\n")
@@ -401,7 +393,11 @@ mod tests {
         assert!(grammar.contains("root ::="), "root rule missing");
         assert!(grammar.contains("root-path-kv"), "path-kv rule missing");
         // The key should be escaped with backslash-quote in GBNF
-        assert!(grammar.contains(r#"\"path\""#), "path key missing in grammar: {}", grammar);
+        assert!(
+            grammar.contains(r#"\"path\""#),
+            "path key missing in grammar: {}",
+            grammar
+        );
     }
 
     #[test]
@@ -484,7 +480,11 @@ mod tests {
 
         assert!(grammar.contains("root ::="), "root rule missing");
         // The key should be escaped with backslash-quote in GBNF
-        assert!(grammar.contains(r#"\"path\""#), "path key missing: {}", grammar);
+        assert!(
+            grammar.contains(r#"\"path\""#),
+            "path key missing: {}",
+            grammar
+        );
         // Root should require path
         assert!(grammar.contains("root-path-kv"), "path-kv rule missing");
     }

--- a/tsuku-llm/src/llama/model.rs
+++ b/tsuku-llm/src/llama/model.rs
@@ -51,9 +51,7 @@ impl LlamaModel {
         backend_init();
 
         // Convert path to C string
-        let path_str = path
-            .to_str()
-            .ok_or(LlamaError::InvalidPathEncoding)?;
+        let path_str = path.to_str().ok_or(LlamaError::InvalidPathEncoding)?;
         let c_path = CString::new(path_str)?;
 
         // Load the model

--- a/tsuku-llm/src/llama/sampler.rs
+++ b/tsuku-llm/src/llama/sampler.rs
@@ -62,7 +62,10 @@ impl Sampler {
         // Softmax for probabilities
         let max_logit = scaled.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
         let exp_sum: f32 = scaled.iter().map(|x| (x - max_logit).exp()).sum();
-        let probs: Vec<f32> = scaled.iter().map(|x| (x - max_logit).exp() / exp_sum).collect();
+        let probs: Vec<f32> = scaled
+            .iter()
+            .map(|x| (x - max_logit).exp() / exp_sum)
+            .collect();
 
         // Sample from distribution
         let random: f32 = rand_simple();

--- a/tsuku-llm/src/main.rs
+++ b/tsuku-llm/src/main.rs
@@ -702,8 +702,12 @@ async fn main() -> Result<()> {
 
     // Select and load model (env overrides for testing)
     let model_config = model::ModelConfig {
-        local_model: std::env::var("TSUKU_LLM_MODEL").ok().filter(|s| !s.is_empty()),
-        local_backend: std::env::var("TSUKU_LLM_BACKEND").ok().filter(|s| !s.is_empty()),
+        local_model: std::env::var("TSUKU_LLM_MODEL")
+            .ok()
+            .filter(|s| !s.is_empty()),
+        local_backend: std::env::var("TSUKU_LLM_BACKEND")
+            .ok()
+            .filter(|s| !s.is_empty()),
     };
     let selector = model::ModelSelector::with_config(model_config);
     let model_spec = selector

--- a/tsuku-llm/src/model.rs
+++ b/tsuku-llm/src/model.rs
@@ -40,7 +40,10 @@ impl std::str::FromStr for Backend {
             "cuda" => Ok(Backend::Cuda),
             "metal" => Ok(Backend::Metal),
             "vulkan" => Ok(Backend::Vulkan),
-            _ => Err(format!("unknown backend: {} (gpu required, cpu not supported)", s)),
+            _ => Err(format!(
+                "unknown backend: {} (gpu required, cpu not supported)",
+                s
+            )),
         }
     }
 }
@@ -68,19 +71,11 @@ pub enum SelectionError {
     /// No GPU detected — GPU acceleration is required
     NoGpuDetected,
     /// GPU doesn't have enough VRAM for the minimum model (7B)
-    InsufficientVram {
-        vram_gb: f64,
-        minimum_gb: f64,
-    },
+    InsufficientVram { vram_gb: f64, minimum_gb: f64 },
     /// Config specifies unknown model name
-    InvalidConfigModel {
-        name: String,
-    },
+    InvalidConfigModel { name: String },
     /// Config specifies invalid or incompatible backend
-    InvalidConfigBackend {
-        backend: String,
-        reason: String,
-    },
+    InvalidConfigBackend { backend: String, reason: String },
 }
 
 impl std::fmt::Display for SelectionError {
@@ -92,7 +87,10 @@ impl std::fmt::Display for SelectionError {
                     "no GPU detected: tsuku-llm requires a GPU with at least 8 GB VRAM"
                 )
             }
-            SelectionError::InsufficientVram { vram_gb, minimum_gb } => {
+            SelectionError::InsufficientVram {
+                vram_gb,
+                minimum_gb,
+            } => {
                 write!(
                     f,
                     "insufficient VRAM: {:.1} GB available, {:.1} GB required for minimum model (7B)",
@@ -277,12 +275,13 @@ impl ModelSelector {
     fn select_backend(&self, profile: &HardwareProfile) -> Result<Backend, SelectionError> {
         // Check for config override
         if let Some(ref backend_str) = self.config.local_backend {
-            let backend: Backend = backend_str.parse().map_err(|_| {
-                SelectionError::InvalidConfigBackend {
-                    backend: backend_str.clone(),
-                    reason: "must be one of: cuda, metal, vulkan".to_string(),
-                }
-            })?;
+            let backend: Backend =
+                backend_str
+                    .parse()
+                    .map_err(|_| SelectionError::InvalidConfigBackend {
+                        backend: backend_str.clone(),
+                        reason: "must be one of: cuda, metal, vulkan".to_string(),
+                    })?;
 
             self.validate_backend(backend, profile)?;
             return Ok(backend);
@@ -298,7 +297,11 @@ impl ModelSelector {
     }
 
     /// Validate that a backend is available on the current hardware.
-    fn validate_backend(&self, backend: Backend, profile: &HardwareProfile) -> Result<(), SelectionError> {
+    fn validate_backend(
+        &self,
+        backend: Backend,
+        profile: &HardwareProfile,
+    ) -> Result<(), SelectionError> {
         let backend_str = backend.to_string();
 
         match backend {
@@ -319,7 +322,9 @@ impl ModelSelector {
                 }
             }
             Backend::Vulkan => {
-                if profile.gpu_backend != GpuBackend::Vulkan && profile.gpu_backend != GpuBackend::Cuda {
+                if profile.gpu_backend != GpuBackend::Vulkan
+                    && profile.gpu_backend != GpuBackend::Cuda
+                {
                     return Err(SelectionError::InvalidConfigBackend {
                         backend: backend_str,
                         reason: "Vulkan not available on this system".to_string(),
@@ -337,11 +342,12 @@ impl ModelSelector {
         model_name: &str,
         profile: &HardwareProfile,
     ) -> Result<ModelSpec, SelectionError> {
-        let entry = self.manifest.get(model_name).ok_or_else(|| {
-            SelectionError::InvalidConfigModel {
-                name: model_name.to_string(),
-            }
-        })?;
+        let entry =
+            self.manifest
+                .get(model_name)
+                .ok_or_else(|| SelectionError::InvalidConfigModel {
+                    name: model_name.to_string(),
+                })?;
 
         let backend = self.select_backend(profile)?;
 
@@ -368,11 +374,12 @@ impl ModelSelector {
 
     /// Build a ModelSpec from auto-selected model name and backend.
     fn build_spec(&self, model_name: &str, backend: Backend) -> Result<ModelSpec, SelectionError> {
-        let entry = self.manifest.get(model_name).ok_or_else(|| {
-            SelectionError::InvalidConfigModel {
-                name: model_name.to_string(),
-            }
-        })?;
+        let entry =
+            self.manifest
+                .get(model_name)
+                .ok_or_else(|| SelectionError::InvalidConfigModel {
+                    name: model_name.to_string(),
+                })?;
 
         Ok(ModelSpec {
             name: model_name.to_string(),
@@ -438,7 +445,10 @@ mod tests {
         let profile = make_profile(GpuBackend::Vulkan, 4, 16);
 
         let result = selector.select(&profile);
-        assert!(matches!(result, Err(SelectionError::InsufficientVram { .. })));
+        assert!(matches!(
+            result,
+            Err(SelectionError::InsufficientVram { .. })
+        ));
     }
 
     #[test]

--- a/tsuku-llm/src/models.rs
+++ b/tsuku-llm/src/models.rs
@@ -34,10 +34,7 @@ pub enum ModelError {
     },
 
     #[error("download failed after {attempts} attempts: {last_error}")]
-    DownloadFailed {
-        attempts: u32,
-        last_error: String,
-    },
+    DownloadFailed { attempts: u32, last_error: String },
 }
 
 /// Progress information during download.
@@ -115,7 +112,8 @@ impl ModelManager {
 
     /// Get the temporary path for an in-progress download.
     fn temp_path(&self, model_name: &str) -> PathBuf {
-        self.download_dir().join(format!("{}.gguf.part", model_name))
+        self.download_dir()
+            .join(format!("{}.gguf.part", model_name))
     }
 
     /// Check if a model exists and has valid checksum.
@@ -155,7 +153,10 @@ impl ModelManager {
 
         // Skip verification when checksum is not yet computed
         if entry.sha256.is_empty() {
-            debug!("Skipping checksum verification for {} (no checksum in manifest)", model_name);
+            debug!(
+                "Skipping checksum verification for {} (no checksum in manifest)",
+                model_name
+            );
             return Ok(true);
         }
 
@@ -185,11 +186,7 @@ impl ModelManager {
     ///
     /// # Returns
     /// Path to the downloaded model file (first split for split models)
-    pub async fn download<F>(
-        &self,
-        model_name: &str,
-        progress: F,
-    ) -> Result<PathBuf, ModelError>
+    pub async fn download<F>(&self, model_name: &str, progress: F) -> Result<PathBuf, ModelError>
     where
         F: Fn(DownloadProgress) + Send,
     {
@@ -218,24 +215,31 @@ impl ModelManager {
 
             for (i, (url, path)) in urls.iter().zip(paths.iter()).enumerate() {
                 if path.exists() {
-                    info!("Split file {}/{} already exists, skipping", i + 1, entry.split_count);
+                    info!(
+                        "Split file {}/{} already exists, skipping",
+                        i + 1,
+                        entry.split_count
+                    );
                     continue;
                 }
 
-                let temp_path = self.download_dir().join(
-                    format!("{}.part", path.file_name().unwrap_or_default().to_string_lossy())
-                );
+                let temp_path = self.download_dir().join(format!(
+                    "{}.part",
+                    path.file_name().unwrap_or_default().to_string_lossy()
+                ));
 
-                info!("Downloading split {}/{} from {}", i + 1, entry.split_count, url);
+                info!(
+                    "Downloading split {}/{} from {}",
+                    i + 1,
+                    entry.split_count,
+                    url
+                );
 
                 // Retry with exponential backoff
                 let mut last_error = String::new();
                 let mut downloaded = false;
                 for attempt in 1..=3 {
-                    match self
-                        .download_file(url, &temp_path, &progress)
-                        .await
-                    {
+                    match self.download_file(url, &temp_path, &progress).await {
                         Ok(()) => {
                             fs::rename(&temp_path, path).await?;
                             info!("Split {}/{} downloaded", i + 1, entry.split_count);
@@ -246,7 +250,10 @@ impl ModelManager {
                             last_error = e.to_string();
                             warn!(
                                 "Download attempt {} failed for split {}/{}: {}",
-                                attempt, i + 1, entry.split_count, e
+                                attempt,
+                                i + 1,
+                                entry.split_count,
+                                e
                             );
                             let _ = fs::remove_file(&temp_path).await;
                             if attempt < 3 {
@@ -275,7 +282,10 @@ impl ModelManager {
 
             // Clean up existing invalid file
             if final_path.exists() {
-                warn!("Model {} exists but failed verification, re-downloading", model_name);
+                warn!(
+                    "Model {} exists but failed verification, re-downloading",
+                    model_name
+                );
                 fs::remove_file(&final_path).await?;
             }
 
@@ -334,9 +344,7 @@ impl ModelManager {
     {
         let response = self.client.get(url).send().await?.error_for_status()?;
 
-        let total_bytes = response
-            .content_length()
-            .unwrap_or(expected_size);
+        let total_bytes = response.content_length().unwrap_or(expected_size);
 
         let mut file = File::create(temp_path).await?;
         let mut hasher = Sha256::new();
@@ -482,8 +490,8 @@ async fn compute_file_sha256(path: &Path) -> Result<String, std::io::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
     use crate::model::{Backend, ModelEntry};
+    use std::collections::HashMap;
 
     fn test_manifest() -> ModelManifest {
         let mut models = HashMap::new();
@@ -492,7 +500,8 @@ mod tests {
             ModelEntry {
                 quantization: "q4_k_m".to_string(),
                 size_bytes: 1000,
-                sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_string(), // SHA256 of empty file
+                sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    .to_string(), // SHA256 of empty file
                 download_url: "https://example.com/test-model.gguf".to_string(),
                 split_count: 1,
                 supported_backends: vec![Backend::Cuda],
@@ -606,9 +615,11 @@ mod tests {
         let progress_count = Arc::new(AtomicU64::new(0));
         let progress_count_clone = Arc::clone(&progress_count);
 
-        let result = manager.download("test-model", move |_progress| {
-            progress_count_clone.fetch_add(1, Ordering::SeqCst);
-        }).await;
+        let result = manager
+            .download("test-model", move |_progress| {
+                progress_count_clone.fetch_add(1, Ordering::SeqCst);
+            })
+            .await;
 
         assert!(result.is_ok());
         // Since file already exists and is valid, no progress updates should happen
@@ -634,7 +645,8 @@ mod tests {
             ModelEntry {
                 quantization: "test".to_string(),
                 size_bytes: 11,
-                sha256: "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9".to_string(),
+                sha256: "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+                    .to_string(),
                 download_url: "https://httpbin.org/base64/aGVsbG8gd29ybGQ=".to_string(),
                 split_count: 1,
                 supported_backends: vec![Backend::Cuda],
@@ -650,10 +662,12 @@ mod tests {
         let progress_calls = Arc::new(AtomicU64::new(0));
         let progress_calls_clone = Arc::clone(&progress_calls);
 
-        let result = manager.download("test-download", move |progress| {
-            bytes_received_clone.store(progress.bytes_downloaded, Ordering::SeqCst);
-            progress_calls_clone.fetch_add(1, Ordering::SeqCst);
-        }).await;
+        let result = manager
+            .download("test-download", move |progress| {
+                bytes_received_clone.store(progress.bytes_downloaded, Ordering::SeqCst);
+                progress_calls_clone.fetch_add(1, Ordering::SeqCst);
+            })
+            .await;
 
         // Should succeed
         assert!(result.is_ok(), "Download failed: {:?}", result.err());
@@ -667,8 +681,15 @@ mod tests {
         assert_eq!(content, "hello world");
 
         // Progress callback should have been called
-        assert!(progress_calls.load(Ordering::SeqCst) > 0, "Progress callback was never called");
-        assert_eq!(bytes_received.load(Ordering::SeqCst), 11, "Final bytes should be 11");
+        assert!(
+            progress_calls.load(Ordering::SeqCst) > 0,
+            "Progress callback was never called"
+        );
+        assert_eq!(
+            bytes_received.load(Ordering::SeqCst),
+            11,
+            "Final bytes should be 11"
+        );
 
         // Verification should pass
         assert!(manager.verify("test-download").await.unwrap());
@@ -686,7 +707,8 @@ mod tests {
             ModelEntry {
                 quantization: "test".to_string(),
                 size_bytes: 11,
-                sha256: "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+                sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+                    .to_string(),
                 download_url: "https://httpbin.org/base64/aGVsbG8gd29ybGQ=".to_string(),
                 split_count: 1,
                 supported_backends: vec![Backend::Cuda],
@@ -707,9 +729,18 @@ mod tests {
         let first_url = "https://example.com/model-q4_k_m-00001-of-00003.gguf";
         let urls = split_file_urls(first_url, 3);
         assert_eq!(urls.len(), 3);
-        assert_eq!(urls[0], "https://example.com/model-q4_k_m-00001-of-00003.gguf");
-        assert_eq!(urls[1], "https://example.com/model-q4_k_m-00002-of-00003.gguf");
-        assert_eq!(urls[2], "https://example.com/model-q4_k_m-00003-of-00003.gguf");
+        assert_eq!(
+            urls[0],
+            "https://example.com/model-q4_k_m-00001-of-00003.gguf"
+        );
+        assert_eq!(
+            urls[1],
+            "https://example.com/model-q4_k_m-00002-of-00003.gguf"
+        );
+        assert_eq!(
+            urls[2],
+            "https://example.com/model-q4_k_m-00003-of-00003.gguf"
+        );
     }
 
     #[test]
@@ -717,9 +748,18 @@ mod tests {
         let first_url = "https://example.com/model-q4_k_m-00001-of-00003.gguf";
         let paths = split_file_paths(Path::new("/tmp/models"), first_url, 3);
         assert_eq!(paths.len(), 3);
-        assert_eq!(paths[0], PathBuf::from("/tmp/models/model-q4_k_m-00001-of-00003.gguf"));
-        assert_eq!(paths[1], PathBuf::from("/tmp/models/model-q4_k_m-00002-of-00003.gguf"));
-        assert_eq!(paths[2], PathBuf::from("/tmp/models/model-q4_k_m-00003-of-00003.gguf"));
+        assert_eq!(
+            paths[0],
+            PathBuf::from("/tmp/models/model-q4_k_m-00001-of-00003.gguf")
+        );
+        assert_eq!(
+            paths[1],
+            PathBuf::from("/tmp/models/model-q4_k_m-00002-of-00003.gguf")
+        );
+        assert_eq!(
+            paths[2],
+            PathBuf::from("/tmp/models/model-q4_k_m-00003-of-00003.gguf")
+        );
     }
 
     #[tokio::test]
@@ -731,7 +771,8 @@ mod tests {
                 quantization: "q4_k_m".to_string(),
                 size_bytes: 9000,
                 sha256: "".to_string(),
-                download_url: "https://example.com/split-model-q4_k_m-00001-of-00003.gguf".to_string(),
+                download_url: "https://example.com/split-model-q4_k_m-00001-of-00003.gguf"
+                    .to_string(),
                 split_count: 3,
                 supported_backends: vec![Backend::Cuda],
             },


### PR DESCRIPTION
Formats `tsuku-llm` with rustfmt, then adds a `Check rustfmt` workflow so the
drift cannot come back. Seven of the crate's twelve source files had diverged
from rustfmt's output, and nothing in CI had ever run `cargo fmt --check`.

The damage that combination causes is indirect. An author who formats only the
file they touched is fine; an author who runs the obvious `cargo fmt` in the
crate silently adopts every pre-existing deviation and sweeps seven unrelated
files into their PR, putting a reviewer's attention on the wrong lines. The
order here matters for the same reason: gating first would have failed every
open PR touching Rust, and sweeping without gating would leave the trap armed
for the next drift.

Two commits, deliberately separate. `3d64fe32` is the sweep and contains nothing
but rustfmt's output. `6532deb2` adds the workflow.

---

## The sweep is formatting-only, demonstrated

`cargo fmt --all` in `tsuku-llm` rewrote exactly the seven files the check named:
`build.rs`, `src/main.rs`, `src/model.rs`, `src/models.rs`, and
`src/llama/{grammar,model,sampler}.rs`. 174 insertions, 115 deletions.

A whitespace-only comparison is not enough to call that safe, and neither is the
whitespace-and-commas comparison that usually follows it. Three character classes
have to come out before the two sides line up:

- **whitespace** — rustfmt rewraps lines;
- **commas** — it adds and removes trailing commas as it rewraps;
- **braces** — it collapses a single-expression closure body, turning
  `|| { expr }` into `|| expr`.

And one difference no character-stripping can absorb: `reorder_imports` is on by
default, so rustfmt sorts `use` lines. That permutes whole lines rather than
characters. In this diff it swapped two imports in `src/models.rs`, which is why
a strip-and-compare reports that file as changed even after all three classes
are removed.

So the proof compares imports as a sorted set and the remaining body as a byte
stream:

```
for p in $(git diff --name-only); do
  git show "HEAD:$p" > _a; cp "$p" _b
  for s in a b; do
    grep -E  '^[[:space:]]*use ' "_$s" | sed 's/^[[:space:]]*//' | sort > "_${s}_use"
    grep -vE '^[[:space:]]*use ' "_$s" | tr -d '[:space:],{}'         > "_${s}_body"
  done
  cmp -s _a_use _b_use && u=same || u=CHANGED
  cmp -s _a_body _b_body && y=same || y=CHANGED
  printf 'imports:%-8s body:%-8s %s\n' "$u" "$y" "$p"
done
```

```
imports:same     body:same     tsuku-llm/build.rs
imports:same     body:same     tsuku-llm/src/llama/grammar.rs
imports:same     body:same     tsuku-llm/src/llama/model.rs
imports:same     body:same     tsuku-llm/src/llama/sampler.rs
imports:same     body:same     tsuku-llm/src/main.rs
imports:same     body:same     tsuku-llm/src/model.rs
imports:same     body:same     tsuku-llm/src/models.rs
```

Same import set, byte-identical bodies, all seven files. Import order has no
effect on meaning in Rust, so this is a formatting-only change.

## Why the gate runs per crate

`tsuku-llm` and `cmd/tsuku-dltest` are independent cargo projects, not workspace
members, and they pin different channels — `stable` and `1.80` respectively. The
workflow therefore runs `cargo fmt --all --check` once per crate with
`working-directory:` set, letting each crate's own `rust-toolchain.toml` resolve
exactly as it does for that crate's build step in `test.yml`. A gate that forced
one version on both would be at odds with one of the two builds.

It is path-filtered to Rust sources, their manifests, and the workflow file, in
keeping with how the rest of this repo's workflows scope themselves — this repo
is 784 Go files against 13 Rust ones, and installing a Rust toolchain on every
Go PR buys nothing. `cargo fmt --check` compiles nothing, so it needs neither the
protobuf compiler nor the cargo cache the builds in `test.yml` set up.

## Verification

`cargo fmt --all --check` exits 0 in both crates. Against a deliberately mangled
`src/models.rs` the same command exits 1, and 0 again after reverting — a green
check on an already-clean tree proves nothing by itself.

`cargo check --all-targets` on `tsuku-llm` finishes clean (only the crate's
pre-existing dead-code warnings), and `cargo test` passes 58 tests.
`cmd/tsuku-dltest` builds `--release` and has no tests. The repo's own workflow
lints, `retired-runners.sh` and `ci-patterns-lint.sh`, both exit 0, and the new
YAML parses.

One substitution worth recording: CI builds `tsuku-llm` with
`cargo build --release`, and this used `cargo check --all-targets` plus
`cargo test` in the dev profile instead. Both drive the same sources through the
same frontend; release differs only in optimization, which a formatting change
cannot reach. No existing test was added, removed, or modified.

## Two findings, reported rather than fixed

Neither is in scope here, and both would change behavior rather than formatting.

**`tsuku-llm` pins the floating `stable` channel.** rustfmt's output changes
between releases, so a future stable can re-open drift and turn this gate red
with nobody having touched the code. Pinning an explicit version would fix that,
but it changes what the *build* uses too, which is a maintainer's call.

**A Rust-only PR gets no build signal.** `test.yml` — including both
`cargo build --release` steps — is filtered on `**/*.go`, `go.mod`, `go.sum`,
`testdata/**` and friends, with no Rust path among them. So a PR touching only
`.rs` files never triggers a Rust build. This very PR is an instance: the new
rustfmt check is the only Rust job it will run. Worth widening those filters
separately.

## Scope

Two commits, seven `.rs` files and one workflow. No `cargo clippy`, no
`rustfmt.toml` (the repo has none and this does not add one), no change to any
toolchain pin, no behavior change. Incidental `Cargo.lock` churn from local
builds was reverted.

Follows `tsukumogami/shirabe#288`, which did the same thing for that repo.
