### PR TITLE
fix(docs): declare schema on 141 documents so they are actually validated

### DIFF
--- a/docs/designs/DESIGN-curated-recipes.md
+++ b/docs/designs/DESIGN-curated-recipes.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Planned
 problem: |
   tsuku has ~1,400 recipes but roughly 20-50 developer tools that users install most

--- a/docs/designs/DESIGN-install-ux-v2.md
+++ b/docs/designs/DESIGN-install-ux-v2.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Accepted
 problem: |
   tsuku install produces 40+ sequential lines instead of a single updating status

--- a/docs/designs/current/DESIGN-auto-apply-rollback.md
+++ b/docs/designs/current/DESIGN-auto-apply-rollback.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 upstream: docs/prds/PRD-auto-update.md
 spawned_from:

--- a/docs/designs/current/DESIGN-automated-seeding.md
+++ b/docs/designs/current/DESIGN-automated-seeding.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The batch pipeline's unified queue has 5,275 entries but 97% come from Homebrew.

--- a/docs/designs/current/DESIGN-background-update-checks.md
+++ b/docs/designs/current/DESIGN-background-update-checks.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 upstream: docs/prds/PRD-auto-update.md
 spawned_from:

--- a/docs/designs/current/DESIGN-background-updates.md
+++ b/docs/designs/current/DESIGN-background-updates.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   tsuku runs full tool installs synchronously in PersistentPreRun before the

--- a/docs/designs/current/DESIGN-batch-operations.md
+++ b/docs/designs/current/DESIGN-batch-operations.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: The batch recipe generation pipeline can auto-merge recipes into the registry, but without operational controls, operators have no way to halt runaway generation, revert problematic recipes, or respond to incidents.
 decision: Batch ID metadata + git revert for rollback; Circuit breaker + control file for emergency stop; Time-windowed budget + sampling for cost control; Per-ecosystem SLIs with severity alerting; Hybrid storage (repository-primary)

--- a/docs/designs/current/DESIGN-batch-platform-validation.md
+++ b/docs/designs/current/DESIGN-batch-platform-validation.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The batch recipe generation pipeline validates recipes only on Linux x86_64 glibc before creating a PR. These recipes claim all-platform support by default, but nobody verifies that download URLs resolve to working binaries on ARM64, macOS, musl-based distros, or non-debian Linux families. Users on those platforms can get broken installs -- missing binaries, wrong architecture, or shared library failures -- with no warning until they run `tsuku install`.

--- a/docs/designs/current/DESIGN-batch-pr-coordination.md
+++ b/docs/designs/current/DESIGN-batch-pr-coordination.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The batch-generate workflow runs hourly, creating PRs that modify shared state files

--- a/docs/designs/current/DESIGN-batch-recipe-generation.md
+++ b/docs/designs/current/DESIGN-batch-recipe-generation.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: No CI pipeline exists to orchestrate batch recipe generation across deterministic ecosystem builders, validate recipes across target environments, record failures with structured metadata, and merge passing recipes at scale.
 decision: A GitHub Actions workflow (scheduled hourly + manual dispatch) that reads from the priority queue, runs a Go orchestrator for generation with progressive validation (Linux first, then arm64/musl/macOS on pass), records failures to JSONL artifacts, and creates one PR per batch with auto-merge gated on validation and run_command absence.

--- a/docs/designs/current/DESIGN-batch-workflow-coordination.md
+++ b/docs/designs/current/DESIGN-batch-workflow-coordination.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Batch recipe generation requires coordination between multiple concurrent workflows

--- a/docs/designs/current/DESIGN-binary-index.md
+++ b/docs/designs/current/DESIGN-binary-index.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Tsuku's shell integration features (command-not-found suggestions, auto-install)

--- a/docs/designs/current/DESIGN-binary-name-discovery.md
+++ b/docs/designs/current/DESIGN-binary-name-discovery.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Recipe builders discover binary names by fetching source files (Cargo.toml,
@@ -29,7 +30,7 @@ rationale: |
 
 ## Status
 
-**Current**
+Current
 
 ## Context and Problem Statement
 

--- a/docs/designs/current/DESIGN-blog-infrastructure.md
+++ b/docs/designs/current/DESIGN-blog-infrastructure.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   tsuku.dev needs a blog section but has no build system. The site is pure

--- a/docs/designs/current/DESIGN-cask-support.md
+++ b/docs/designs/current/DESIGN-cask-support.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Tsuku lacks support for macOS GUI applications distributed via Homebrew Casks, limiting unified tool management to CLI tools only.
 decision: Implement a hybrid approach using a cask version provider for metadata (URLs, checksums) combined with a generic app_bundle action for installation.

--- a/docs/designs/current/DESIGN-channel-aware-resolution.md
+++ b/docs/designs/current/DESIGN-channel-aware-resolution.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 upstream: docs/prds/PRD-auto-update.md
 spawned_from:

--- a/docs/designs/current/DESIGN-checksum-pinning.md
+++ b/docs/designs/current/DESIGN-checksum-pinning.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Installed binaries can be modified after installation (malware injection, disk corruption, unauthorized modifications) with no detection mechanism.
 decision: Compute and store SHA256 checksums of installed binaries after installation, then verify them on demand via `tsuku verify` to detect tampering or corruption.

--- a/docs/designs/current/DESIGN-ci-build-essentials-consolidation.md
+++ b/docs/designs/current/DESIGN-ci-build-essentials-consolidation.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The Build Essentials workflow allocates 7 separate Linux runners for tool
@@ -29,7 +30,7 @@ rationale: |
 
 ## Status
 
-**Status:** Current
+Current
 
 ## Upstream Design Reference
 

--- a/docs/designs/current/DESIGN-ci-job-consolidation.md
+++ b/docs/designs/current/DESIGN-ci-job-consolidation.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   PR CI runs in the tsuku repo spawn 50-87 GitHub Actions jobs because matrix
@@ -29,7 +30,7 @@ rationale: |
 
 ## Status
 
-**Status:** Current
+Current
 
 ## Implementation Issues
 

--- a/docs/designs/current/DESIGN-ci-macos-batching.md
+++ b/docs/designs/current/DESIGN-ci-macos-batching.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: GitHub-hosted macOS runners have low concurrency limits (5 jobs vs 20 for Linux), causing queue saturation and 30+ minute delays when PRs touch many recipes.
 decision: Aggregate macOS CI jobs into a single job per architecture that iterates over all changed items sequentially, reducing concurrent jobs from 170+ to 5 maximum.

--- a/docs/designs/current/DESIGN-command-not-found.md
+++ b/docs/designs/current/DESIGN-command-not-found.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   When users type an unknown command, the shell prints "command not found" and

--- a/docs/designs/current/DESIGN-consolidate-system-deps.md
+++ b/docs/designs/current/DESIGN-consolidate-system-deps.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Two overlapping implementations extract system packages from recipes and plans:
@@ -27,7 +28,7 @@ rationale: |
 
 ## Status
 
-**Current**
+Current
 
 ## Upstream Design Reference
 

--- a/docs/designs/current/DESIGN-container-image-digest-pinning.md
+++ b/docs/designs/current/DESIGN-container-image-digest-pinning.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Container images in container-images.json use mutable tags like alpine:3.21
@@ -25,7 +26,7 @@ rationale: |
 
 ## Status
 
-**Status:** Current
+Current
 
 ## Context and Problem Statement
 

--- a/docs/designs/current/DESIGN-dashboard-observability.md
+++ b/docs/designs/current/DESIGN-dashboard-observability.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The pipeline dashboard shows aggregate failure counts but can't answer "why did

--- a/docs/designs/current/DESIGN-dependency-pattern.md
+++ b/docs/designs/current/DESIGN-dependency-pattern.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Dependencies between tools are handled inconsistently across actions, creating opacity about what each tool needs and making dependency graphs impossible to compute statically.
 decision: Implement fully implicit dependencies where actions declare their install-time and runtime requirements, with step and recipe-level overrides for edge cases.

--- a/docs/designs/current/DESIGN-dependency-provisioning.md
+++ b/docs/designs/current/DESIGN-dependency-provisioning.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Tsuku recipes need to declare dependencies with different provisioning strategies (downloadable, buildable, system-required), but currently lack mechanisms to handle this or guide users when dependencies are missing.
 decision: Implement a unified recipe model where all dependencies are recipes whose actions determine provisioning strategy (homebrew, configure_make, or require_system).

--- a/docs/designs/current/DESIGN-dependency-validation-in-batch-pipeline.md
+++ b/docs/designs/current/DESIGN-dependency-validation-in-batch-pipeline.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The Homebrew builder writes unresolvable dependency names into generated

--- a/docs/designs/current/DESIGN-dependency-version-refs.md
+++ b/docs/designs/current/DESIGN-dependency-version-refs.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Recipes must hardcode dependency versions in action parameters like RPATH configuration, creating maintenance burden when dependency versions change and contradicting tsuku's version-aware design.
 decision: Extend variable expansion syntax to support dot-notation references like `{deps.openssl.version}` by flattening resolved dependency versions into the existing variable map.

--- a/docs/designs/current/DESIGN-deterministic-resolution.md
+++ b/docs/designs/current/DESIGN-deterministic-resolution.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Tsuku recipes are dynamic and non-deterministic; the same tool version can produce different installation results across days or machines due to platform detection, asset selection, and external API responses, preventing reproducible team installations and making recipe testing difficult.
 decision: Separate recipe evaluation (dynamic, produces deterministic installation plans) from plan execution (deterministic, downloads from exact URLs), making all installations plan-based to guarantee reproducibility by architecture.

--- a/docs/designs/current/DESIGN-dev-environment-isolation.md
+++ b/docs/designs/current/DESIGN-dev-environment-isolation.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Developers working on tsuku lack a zero-ceremony way to run against isolated environments without interfering with each other or the host's real installation.
 decision: Use build-time ldflags to give Makefile-built binaries a different default home directory, stop exporting TSUKU_HOME from the install script, and add tsuku shellenv and tsuku doctor commands for PATH setup and environment validation.

--- a/docs/designs/current/DESIGN-disambiguation.md
+++ b/docs/designs/current/DESIGN-disambiguation.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   When multiple ecosystem registries return matches for a tool name (e.g., "bat" exists

--- a/docs/designs/current/DESIGN-discovery-registry-bootstrap.md
+++ b/docs/designs/current/DESIGN-discovery-registry-bootstrap.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The discovery registry has 1 entry but needs ~500 for the resolver to deliver value.

--- a/docs/designs/current/DESIGN-discovery-resolver.md
+++ b/docs/designs/current/DESIGN-discovery-resolver.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   tsuku requires `--from` flags on every `tsuku create` invocation, forcing users to

--- a/docs/designs/current/DESIGN-discovery-telemetry.md
+++ b/docs/designs/current/DESIGN-discovery-telemetry.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The discovery resolver runs through up to three stages (registry lookup, ecosystem probe, LLM discovery) but produces no telemetry. There's no visibility into how often each stage fires, what tools users search for, or where resolution fails. Without this data, we can't prioritize registry curation, measure ecosystem probe reliability, or evaluate LLM discovery effectiveness once it ships.

--- a/docs/designs/current/DESIGN-distributed-recipes.md
+++ b/docs/designs/current/DESIGN-distributed-recipes.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 upstream: docs/prds/PRD-distributed-recipes.md
 problem: |

--- a/docs/designs/current/DESIGN-ecosystem-name-resolution.md
+++ b/docs/designs/current/DESIGN-ecosystem-name-resolution.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Tsuku's recipe resolution uses exact name matching with no fallback. When Homebrew calls a package `openssl@3` but the tsuku recipe is named `openssl`, the system fails to connect them. This produces duplicate recipes from the batch pipeline, false blockers on the dashboard, and `tsuku create` generating inferior copies of existing recipes. A static mapping file was tried (#1200) but never wired in, and the approach doesn't scale.

--- a/docs/designs/current/DESIGN-ecosystem-probe.md
+++ b/docs/designs/current/DESIGN-ecosystem-probe.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The ecosystem probe is the second stage of tsuku's discovery resolver chain, but it's currently a stub. Without it, tools not in the curated registry (~500 entries) fall through to LLM-based discovery, which requires an API key and costs money. Most popular developer tools exist in at least one package registry, so a deterministic probe could resolve them for free in under 3 seconds.

--- a/docs/designs/current/DESIGN-embedded-recipe-list.md
+++ b/docs/designs/current/DESIGN-embedded-recipe-list.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: The recipe registry separation design requires a validated embedded recipe list, but there's no runtime enforcement that action dependencies can actually be resolved from embedded recipes.
 decision: Add a --require-embedded flag to the loader that fails if action dependencies can't be resolved from the embedded registry. Use CI with this flag to iteratively discover and validate the embedded recipe list.

--- a/docs/designs/current/DESIGN-embedded-recipe-musl-coverage.md
+++ b/docs/designs/current/DESIGN-embedded-recipe-musl-coverage.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Six embedded recipes (rust, python-standalone, nodejs, ruby, perl,
@@ -30,7 +31,7 @@ rationale: |
 
 ## Status
 
-**Current**
+Current
 
 ## Implementation Issues
 

--- a/docs/designs/current/DESIGN-extract-symlink-escape.md
+++ b/docs/designs/current/DESIGN-extract-symlink-escape.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The extract action decides containment with string math and then performs writes

--- a/docs/designs/current/DESIGN-fossil-archive.md
+++ b/docs/designs/current/DESIGN-fossil-archive.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Tsuku lacks support for building tools from source when they are hosted on Fossil SCM repositories, limiting installation options for Fossil-hosted projects like SQLite and Tcl.
 decision: Implement a `fossil_archive` action that downloads and extracts tarballs from Fossil repositories, following the same pattern as `github_archive` but adapted for Fossil's URL conventions and timeline API.

--- a/docs/designs/current/DESIGN-gem-exec-wrappers.md
+++ b/docs/designs/current/DESIGN-gem-exec-wrappers.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   When gem_install recipes are decomposed into gem_exec for reproducible installs,
@@ -25,7 +26,7 @@ rationale: |
 
 ## Status
 
-**Status: Current**
+Current
 
 ## Context and Problem Statement
 

--- a/docs/designs/current/DESIGN-gherkin-functional-testing.md
+++ b/docs/designs/current/DESIGN-gherkin-functional-testing.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: >
   Tsuku's test suite covers internal correctness and specific integration dimensions

--- a/docs/designs/current/DESIGN-go-ecosystem.md
+++ b/docs/designs/current/DESIGN-go-ecosystem.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Go tools dominate DevOps and cloud-native environments, but tsuku lacks native support for building and installing Go modules, limiting utility for this critical user base.
 decision: Implement go_install action with explicit Go toolchain as a dependency, following the established npm_install/nodejs pattern for consistency and transparency.

--- a/docs/designs/current/DESIGN-golden-plan-testing.md
+++ b/docs/designs/current/DESIGN-golden-plan-testing.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Recipe changes and code updates can cause silent regressions in plan generation, and integration tests are slow and non-deterministic due to network dependencies on external services.
 decision: Implement golden plan testing by generating and validating deterministic installation plans for every recipe across all supported platforms, with CI workflows to detect and enforce updates.

--- a/docs/designs/current/DESIGN-gpu-backend-selection.md
+++ b/docs/designs/current/DESIGN-gpu-backend-selection.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The tsuku-llm addon builds 10 platform variants across GPU backends (CUDA, Vulkan, Metal, CPU),

--- a/docs/designs/current/DESIGN-hardcoded-version-detection.md
+++ b/docs/designs/current/DESIGN-hardcoded-version-detection.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Recipes can contain hardcoded version numbers in URLs, archive paths, and source directories instead of using dynamic {version} placeholders, violating best practices and requiring manual updates for each version bump.
 decision: Implement context-aware detection with field-level rules that understand which fields should contain version placeholders based on action type, combining with pattern matching to identify hardcoded versions.

--- a/docs/designs/current/DESIGN-homebrew-deterministic-mode.md
+++ b/docs/designs/current/DESIGN-homebrew-deterministic-mode.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: The Homebrew builder declares RequiresLLM()=true and fails when deterministic generation can't fall back to LLM, blocking the batch pipeline which must operate without API keys at $0 cost.
 decision: Add a DeterministicOnly session option that prevents LLM fallback and returns structured DeterministicFailedError on failure, with failure categories matching the failure-record schema.

--- a/docs/designs/current/DESIGN-homebrew.md
+++ b/docs/designs/current/DESIGN-homebrew.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Homebrew is the dominant package manager for developer tools on macOS with 6,000+ formulas, but requires a self-contained, reliable integration to provide tsuku users access without system dependencies.
 decision: Implement a `homebrew` action that downloads and installs pre-built Homebrew bottles with platform-specific binary patching and relocation, plus a HomebrewBuilder for deterministic recipe generation with LLM fallback.

--- a/docs/designs/current/DESIGN-http-json-version-source.md
+++ b/docs/designs/current/DESIGN-http-json-version-source.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Several upstreams publish their current release version in a JSON manifest

--- a/docs/designs/current/DESIGN-info-enhancements.md
+++ b/docs/designs/current/DESIGN-info-enhancements.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: The tsuku info command always resolves dependencies and doesn't support local recipe files, creating performance and usability friction for automation scenarios like golden plan testing and CI integration that only need static recipe metadata.
 decision: Add --recipe and --metadata-only flags to tsuku info, expand JSON output schema with static recipe fields including computed platform lists, maintaining backward compatibility with additive schema changes.

--- a/docs/designs/current/DESIGN-install-binaries-semantics.md
+++ b/docs/designs/current/DESIGN-install-binaries-semantics.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: The install_binaries action's binaries parameter conflates two separate concerns (files to export vs files to make executable) and uses misleading semantics, creating confusion for recipe authors and blocking static analysis.
 decision: Rename binaries parameter to outputs and infer executability from path prefix (bin/ = executable) with an optional executables parameter for edge cases.

--- a/docs/designs/current/DESIGN-install-sandbox.md
+++ b/docs/designs/current/DESIGN-install-sandbox.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Sandbox testing behavior was scattered across individual builders rather than being a unified recipe-driven operation, preventing independent invocation and creating duplicated action knowledge.
 decision: Implement a NetworkValidator interface on actions and a SandboxRequirements struct that derives container configuration from plan content, enabling unified sandbox testing via a single Sandbox() entry point.

--- a/docs/designs/current/DESIGN-install-ux.md
+++ b/docs/designs/current/DESIGN-install-ux.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   tsuku install and update emit 20–50+ lines per install via raw fmt.Printf() calls

--- a/docs/designs/current/DESIGN-library-recipe-generation.md
+++ b/docs/designs/current/DESIGN-library-recipe-generation.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The deterministic recipe generator fails on library-only Homebrew bottles

--- a/docs/designs/current/DESIGN-library-verification.md
+++ b/docs/designs/current/DESIGN-library-verification.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: The tsuku verify command does not support library recipes, failing when users run `tsuku verify gcc-libs` because libraries have no executables to verify and the command assumes all tools produce executable output for verification.
 decision: Implement tiered library verification combining header validation, dependency resolution, and dlopen load testing with optional integrity checksums, allowing users to choose verification depth via flags while keeping the default fast and practical.

--- a/docs/designs/current/DESIGN-library-verify-deps.md
+++ b/docs/designs/current/DESIGN-library-verify-deps.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Tools and libraries can have valid binary headers yet fail at runtime if their dependencies are missing or unresolvable, preventing proactive detection of these issues.
 decision: Implement hybrid dependency validation using soname extraction, pattern-based system library detection, RPATH-aware resolution, and recursive dependency checking to verify all runtime dependencies are available and compatible.

--- a/docs/designs/current/DESIGN-library-verify-dlopen.md
+++ b/docs/designs/current/DESIGN-library-verify-dlopen.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Levels 1-2 of library verification can't confirm a library will actually load; only dlopen() can test this, but it requires native code which conflicts with tsuku's CGO_ENABLED=0 build.
 decision: Use a dedicated Rust helper binary (tsuku-dltest) with JSON protocol and batched invocation.

--- a/docs/designs/current/DESIGN-library-verify-header.md
+++ b/docs/designs/current/DESIGN-library-verify-header.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Determine if a file is a valid shared library for the current platform, with cross-platform complexity across Linux (ELF) and macOS (Mach-O, including universal binaries).
 decision: Implement a unified ValidateHeader function with early magic number detection that efficiently dispatches to format-specific validators for ELF, Mach-O, and fat binary formats.

--- a/docs/designs/current/DESIGN-library-verify-integrity.md
+++ b/docs/designs/current/DESIGN-library-verify-integrity.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Libraries can be modified after installation (malware injection, disk corruption, unauthorized changes) but tsuku verify's Tiers 1-3 only check validity and loadability, not whether files match their original state.
 decision: Add optional Tier 4 integrity verification that compares SHA256 checksums of library files against values stored at installation time, enabled via the --integrity flag.

--- a/docs/designs/current/DESIGN-libtool-zig-cc.md
+++ b/docs/designs/current/DESIGN-libtool-zig-cc.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Libtool-based autotools projects fail to build with zig cc because libtool calls the compiler with `-print-prog-name=ld` to discover the linker, but zig cc doesn't support this GCC-specific flag.
 decision: Enhance the cc wrapper script to detect and handle `-print-prog-name` introspection flags by returning paths to the corresponding tool wrappers (ld, ar, ranlib).

--- a/docs/designs/current/DESIGN-llm-builder-infrastructure.md
+++ b/docs/designs/current/DESIGN-llm-builder-infrastructure.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Tsuku's ecosystem-specific builders only work for tools with structured metadata (Cargo, npm, PyPI), but fail for the majority of tools distributed via GitHub releases or documentation without standard metadata, limiting coverage.
 decision: Build LLM-based builder infrastructure using provider abstraction, container-based validation, and repair loops to generate recipes from unstructured sources like GitHub release assets and documentation.

--- a/docs/designs/current/DESIGN-llm-discovery-implementation.md
+++ b/docs/designs/current/DESIGN-llm-discovery-implementation.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The LLM discovery stage in tsuku's resolver chain is an unimplemented stub. Tools not

--- a/docs/designs/current/DESIGN-llm-testing-strategy.md
+++ b/docs/designs/current/DESIGN-llm-testing-strategy.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The local LLM runtime's test infrastructure covers lifecycle management and cloud provider recipe quality but has no automated way to detect local model quality regressions or server stability failures. This gap let two failure categories -- server crashes during long inference sessions and model quality regression on Rust-style naming patterns -- reach QA without being caught by any test. Changes to prompts, models, or inference parameters can ship regressions silently.

--- a/docs/designs/current/DESIGN-local-llm-runtime.md
+++ b/docs/designs/current/DESIGN-local-llm-runtime.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   tsuku's recipe generation requires cloud API keys (Anthropic or Google), breaking the self-contained promise. Users must create accounts, set up billing, and configure environment variables before core LLM features work. Small open-source models (1.5-3B parameters) now handle structured extraction well enough for tsuku's use cases.

--- a/docs/designs/current/DESIGN-merge-job-completion.md
+++ b/docs/designs/current/DESIGN-merge-job-completion.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The batch-generate merge job has working constraint derivation and PR creation but lacks structured commit messages with batch metadata, SLI metrics collection, circuit breaker state updates, and auto-merge gating required by DESIGN-batch-recipe-generation.md for pipeline observability and scale.

--- a/docs/designs/current/DESIGN-multi-satisfier-picker.md
+++ b/docs/designs/current/DESIGN-multi-satisfier-picker.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   `tsuku install <name>` cannot route the user through a choice when an alias

--- a/docs/designs/current/DESIGN-multi-version-support.md
+++ b/docs/designs/current/DESIGN-multi-version-support.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Tsuku currently supports only one installed version per tool, forcing developers to reinstall when switching between projects that require different versions.
 decision: Implement multi-version support with automatic state.json migration, new activate command, and modified install/remove/list behaviors to keep existing versions while managing an active version via symlinks.

--- a/docs/designs/current/DESIGN-non-deterministic-validation.md
+++ b/docs/designs/current/DESIGN-non-deterministic-validation.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Golden files for ecosystem recipes drift over time due to dependency resolution at eval time picking up new transitive versions, causing CI failures in validate-golden-code.yml even when recipes and tsuku code haven't changed.
 decision: Implement constrained evaluation by passing version constraints from golden files to tsuku eval via a --pin-from flag, ensuring all eval code paths execute while producing deterministic output for exact comparison.

--- a/docs/designs/current/DESIGN-notices-install-event-bus.md
+++ b/docs/designs/current/DESIGN-notices-install-event-bus.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Notice files under $TSUKU_HOME/notices/ drift from state.json because every

--- a/docs/designs/current/DESIGN-notices-out-of-context.md
+++ b/docs/designs/current/DESIGN-notices-out-of-context.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   tsuku's deferred-notice system flushes all unshown success notices at the head of

--- a/docs/designs/current/DESIGN-notification-routing.md
+++ b/docs/designs/current/DESIGN-notification-routing.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   When tsuku runs in background auto-update mode, all warnings and non-fatal events

--- a/docs/designs/current/DESIGN-notification-system.md
+++ b/docs/designs/current/DESIGN-notification-system.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 upstream: docs/prds/PRD-auto-update.md
 spawned_from:

--- a/docs/designs/current/DESIGN-nvm-data-root.md
+++ b/docs/designs/current/DESIGN-nvm-data-root.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   recipes/n/nvm.toml exports NVM_DIR as {install_dir}, which resolves to

--- a/docs/designs/current/DESIGN-org-scoped-project-config.md
+++ b/docs/designs/current/DESIGN-org-scoped-project-config.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Org-scoped recipes (like tsukumogami/koto) have no working syntax in

--- a/docs/designs/current/DESIGN-perl-ecosystem.md
+++ b/docs/designs/current/DESIGN-perl-ecosystem.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Tsuku lacks support for installing Perl/CPAN CLI tools despite Perl being prevalent in DevOps contexts.
 decision: Implement cpan_install action with explicit Perl dependency, following the go_install and npm_install patterns.

--- a/docs/designs/current/DESIGN-pgp-verification.md
+++ b/docs/designs/current/DESIGN-pgp-verification.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Tsuku recipes cannot verify downloads for projects that only provide PGP signatures instead of checksums, limiting adoption for security-critical tools like curl.
 decision: Use ProtonMail's gopenpgp v2 library with fingerprint-based key management, allowing recipes to specify signature and public key URLs with expected fingerprints for verification.

--- a/docs/designs/current/DESIGN-pipeline-blocker-tracking.md
+++ b/docs/designs/current/DESIGN-pipeline-blocker-tracking.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The pipeline dashboard's "Top Blockers" panel is nearly empty despite hundreds of

--- a/docs/designs/current/DESIGN-pipeline-dashboard-2.md
+++ b/docs/designs/current/DESIGN-pipeline-dashboard-2.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The batch pipeline runs hourly but generates zero new recipes because all remaining

--- a/docs/designs/current/DESIGN-pipeline-dashboard-overhaul.md
+++ b/docs/designs/current/DESIGN-pipeline-dashboard-overhaul.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Four of six ecosystem circuit breakers are permanently stuck open because

--- a/docs/designs/current/DESIGN-pipeline-dashboard.md
+++ b/docs/designs/current/DESIGN-pipeline-dashboard.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The batch recipe generation pipeline collects structured data about failures,
@@ -43,7 +44,7 @@ rationale: |
 
 ## Status
 
-**Current**
+Current
 
 ## Context and Problem Statement
 

--- a/docs/designs/current/DESIGN-pipx-pypi-version-pinning.md
+++ b/docs/designs/current/DESIGN-pipx-pypi-version-pinning.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   tsuku's `pipx_install` action installs Python CLI tools from PyPI, but

--- a/docs/designs/current/DESIGN-platform-compatibility-verification.md
+++ b/docs/designs/current/DESIGN-platform-compatibility-verification.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: tsuku claims support for multiple platforms and Linux families but testing doesn't verify actual compatibility, as discovered when musl-based systems couldn't load embedded libraries.
 decision: Adopt a hybrid approach - keep Homebrew bottles for glibc systems (preserving hermetic version control) while using system packages for musl systems (fixing Alpine compatibility).
@@ -9,7 +10,7 @@ rationale: Homebrew bottles work well on glibc and provide valuable version cont
 
 ## Status
 
-**Current**
+Current
 
 ## Implementation Issues
 

--- a/docs/designs/current/DESIGN-prerelease-detection.md
+++ b/docs/designs/current/DESIGN-prerelease-detection.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The GitHub version provider's `isStableVersion` filter uses substring matching

--- a/docs/designs/current/DESIGN-priority-queue.md
+++ b/docs/designs/current/DESIGN-priority-queue.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Batch recipe generation needs visibility infrastructure to track which packages to generate (priority queue) and what went wrong (failure records), but no structured schemas exist.
 decision: Use single JSON files with tiered priority scoring and latest-only failure records, prioritizing simplicity for Phase 0.

--- a/docs/designs/current/DESIGN-probe-quality-filtering.md
+++ b/docs/designs/current/DESIGN-probe-quality-filtering.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The ecosystem probe accepts any package name that exists on a registry as a valid match, regardless of whether the package is a placeholder, name-squatter, or unmaintained stub. This causes tools like prettier and httpie to resolve to crates.io squatters instead of their actual registries (npm and pypi).

--- a/docs/designs/current/DESIGN-project-aware-exec.md
+++ b/docs/designs/current/DESIGN-project-aware-exec.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 spawned_from:
   issue: 2168

--- a/docs/designs/current/DESIGN-project-configuration.md
+++ b/docs/designs/current/DESIGN-project-configuration.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 spawned_from:
   issue: 1680

--- a/docs/designs/current/DESIGN-project-level-auto-update.md
+++ b/docs/designs/current/DESIGN-project-level-auto-update.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The auto-update system ignores .tsuku.toml project-level version constraints.

--- a/docs/designs/current/DESIGN-queue-registry-validation.md
+++ b/docs/designs/current/DESIGN-queue-registry-validation.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The batch pipeline hardcodes `--force` when installing generated recipes for validation, meaning any queue entry that duplicates an existing recipe will silently overwrite it. Seed-time filtering (#1267) prevents new duplicates from entering the queue, but entries already present before that change -- or intentionally re-queued by operators -- have no safety net.

--- a/docs/designs/current/DESIGN-r2-golden-storage.md
+++ b/docs/designs/current/DESIGN-r2-golden-storage.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Registry recipes scaling to 10K+ makes git-based golden file storage unsustainable due to repo bloat and slow clones.
 decision: Migrate registry golden files to Cloudflare R2 with CI-generated files on merge, two-tier degradation (R2 or skip), and 6-phase rollout.
@@ -9,7 +10,7 @@ rationale: R2 eliminates git bloat while two-tier degradation keeps CI simple; C
 
 ## Status
 
-**Current**
+Current
 
 ## Implementation Issues
 

--- a/docs/designs/current/DESIGN-recipe-browser.md
+++ b/docs/designs/current/DESIGN-recipe-browser.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Users cannot discover what tools tsuku can install without installing the CLI and running `tsuku recipes`, despite the marketing claim of "150+ tools".
 decision: Build a static recipe browser page at `/recipes/` that fetches recipe metadata via client-side JavaScript and provides search/filter functionality.

--- a/docs/designs/current/DESIGN-recipe-builders.md
+++ b/docs/designs/current/DESIGN-recipe-builders.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Thousands of CLI tools exist across package ecosystems that are not included in tsuku's embedded recipes, preventing users from installing them without manually writing recipes.
 decision: Implement ecosystem-specific recipe builders as a thin layer that generates recipes by querying package registry APIs, returning pure Recipe structs that are written to local storage and executed through existing actions.

--- a/docs/designs/current/DESIGN-recipe-coverage-system.md
+++ b/docs/designs/current/DESIGN-recipe-coverage-system.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   M47 delivered platform compatibility infrastructure (libc detection, recipe conditionals, coverage analysis in internal/recipe/coverage.go) but 0 of 13 library recipes were migrated. Coverage analysis code exists and test infrastructure validates recipes on declared platforms, but there's no visibility into which recipes support which platforms. The execution-exclusions.json file tracks blockers but doesn't show the full coverage picture. We can't see the M47 gap (libraries without musl) or identify other coverage gaps across the 265-recipe registry.
@@ -12,7 +13,7 @@ rationale: |
 
 ## Status
 
-**Current**
+Current
 
 ## Implementation Issues
 

--- a/docs/designs/current/DESIGN-recipe-detail-pages.md
+++ b/docs/designs/current/DESIGN-recipe-detail-pages.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Users cannot see detailed information about recipes before installing them, including hidden dependencies, and there is no way to link directly to specific tool pages.
 decision: Implement recipe detail pages using client-side routing with the History API, extending recipes.json to include dependency information.

--- a/docs/designs/current/DESIGN-recipe-driven-ci-testing.md
+++ b/docs/designs/current/DESIGN-recipe-driven-ci-testing.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   GHA integration tests for musl/Alpine use hardcoded package lists instead of
@@ -26,7 +27,7 @@ rationale: |
 
 ## Status
 
-**Current**
+Current
 
 Implementation completed in [Milestone 74: Recipe-Driven CI Testing](https://github.com/tsukumogami/tsuku/milestone/74).
 

--- a/docs/designs/current/DESIGN-recipe-registry-separation.md
+++ b/docs/designs/current/DESIGN-recipe-registry-separation.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: All 171 recipes are embedded in the CLI binary, causing unnecessary bloat and coupling recipe updates to CLI releases.
 decision: Separate recipes into embedded (in binary) and registry (registry-fetched) based on directory location. Store registry golden files in Cloudflare R2 for scalability.
@@ -9,7 +10,7 @@ rationale: Location-based categorization is simplest. R2 storage scales to 10K+ 
 
 ## Status
 
-**Current**
+Current
 
 ## Implementation Issues
 

--- a/docs/designs/current/DESIGN-registry-cache-policy.md
+++ b/docs/designs/current/DESIGN-registry-cache-policy.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: The registry recipe cache stores recipes indefinitely with no TTL, no size limits, and no metadata tracking, causing network failures to result in hard failures instead of graceful degradation.
 decision: Implement TTL-based caching with JSON metadata sidecars, stale-if-error fallback, and LRU eviction.
@@ -9,7 +10,7 @@ rationale: Follows existing version cache patterns for consistency, provides bes
 
 ## Status
 
-**Current**
+Current
 
 ## Implementation Issues
 

--- a/docs/designs/current/DESIGN-registry-refresh-ttl-semantics.md
+++ b/docs/designs/current/DESIGN-registry-refresh-ttl-semantics.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   `tsuku update-registry` applies a 24-hour TTL to skip recently-cached recipes, so a

--- a/docs/designs/current/DESIGN-registry-scale-strategy.md
+++ b/docs/designs/current/DESIGN-registry-scale-strategy.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Tsuku has 329 registry recipes and an operational hourly batch pipeline, but thousands of developer tools remain uncovered across ecosystems (8K+ Homebrew formulas, 200K+ Rust crates, 11M+ npm packages). The pipeline works. The remaining challenge is closing quality gaps, resolving script/schema debt, and deciding whether file-based failure tracking needs to move to a database backend.
 decision: Adopt fully deterministic batch generation with structured failure analysis. Failures reveal capability gaps that drive manual fixes. LLM builders remain a user feature, not part of automation.

--- a/docs/designs/current/DESIGN-registry-versioning.md
+++ b/docs/designs/current/DESIGN-registry-versioning.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The CLI parses the registry manifest with no format compatibility check. The Manifest struct has a SchemaVersion field that's never validated. A breaking registry format change would cause silent parse failures or confusing errors, and old CLI versions have no way to know they're incompatible. There's no mechanism for registries to announce upcoming format changes or guide users through upgrades.

--- a/docs/designs/current/DESIGN-release-workflow-native.md
+++ b/docs/designs/current/DESIGN-release-workflow-native.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: The current release workflow can't handle native binaries like the Rust dlopen helper because cross-compilation to macOS requires the macOS SDK, which is only legally available on macOS hardware.
 decision: Use parallel matrix builds on native runners with a draft-then-publish pattern, both glibc and musl Linux variants, and ad-hoc code signing for macOS.

--- a/docs/designs/current/DESIGN-relocatable-library-deps.md
+++ b/docs/designs/current/DESIGN-relocatable-library-deps.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Native libraries required by tools like Ruby are embedded as 30+ lines of shell script in tool recipes, causing maintenance burden from hardcoded SHA256s, code duplication across tools, tight coupling to Homebrew internals, and inability to resolve library versions at runtime.
 decision: Libraries become first-class recipes with type = "library", installed via a suite of actions (homebrew, install_libraries, link_dependencies, set_rpath) that handle downloading, extraction, linking, and RPATH modification.

--- a/docs/designs/current/DESIGN-requeue-on-recipe-merge.md
+++ b/docs/designs/current/DESIGN-requeue-on-recipe-merge.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 spawned_from:
   issue: 1825

--- a/docs/designs/current/DESIGN-resilience.md
+++ b/docs/designs/current/DESIGN-resilience.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 upstream: docs/prds/PRD-auto-update.md
 spawned_from:

--- a/docs/designs/current/DESIGN-sandbox-build-cache.md
+++ b/docs/designs/current/DESIGN-sandbox-build-cache.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   When testing recipes across Linux families, each family independently installs

--- a/docs/designs/current/DESIGN-sandbox-ci-integration.md
+++ b/docs/designs/current/DESIGN-sandbox-ci-integration.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 spawned_from:
   issue: 1905

--- a/docs/designs/current/DESIGN-sandbox-dependencies.md
+++ b/docs/designs/current/DESIGN-sandbox-dependencies.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Sandbox testing fails for tools with declared dependencies because plan generation doesn't embed dependency information, so containers receive plans without the dependency tree needed for installation.
 decision: Ensure all plan generation paths pass RecipeLoader, producing self-contained plans with embedded dependency trees that work identically in normal and sandbox modes.

--- a/docs/designs/current/DESIGN-sandbox-image-unification.md
+++ b/docs/designs/current/DESIGN-sandbox-image-unification.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Container image versions for Linux families are defined independently in Go

--- a/docs/designs/current/DESIGN-secrets-manager.md
+++ b/docs/designs/current/DESIGN-secrets-manager.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Tsuku's LLM and discovery features require API keys that are currently read

--- a/docs/designs/current/DESIGN-seed-queue-pipeline.md
+++ b/docs/designs/current/DESIGN-seed-queue-pipeline.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: >
   The batch generation pipeline reads from data/priority-queue.json to decide which packages

--- a/docs/designs/current/DESIGN-self-update.md
+++ b/docs/designs/current/DESIGN-self-update.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 upstream: docs/prds/PRD-auto-update.md
 spawned_from:

--- a/docs/designs/current/DESIGN-shell-d-lifecycle.md
+++ b/docs/designs/current/DESIGN-shell-d-lifecycle.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Files under $TSUKU_HOME/share/shell.d have version-independent names but

--- a/docs/designs/current/DESIGN-shell-env-activation.md
+++ b/docs/designs/current/DESIGN-shell-env-activation.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 spawned_from:
   issue: 1681

--- a/docs/designs/current/DESIGN-shell-env-integration.md
+++ b/docs/designs/current/DESIGN-shell-env-integration.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   When a tool with install_shell_init is installed, its shell functions are written to

--- a/docs/designs/current/DESIGN-shell-integration-building-blocks.md
+++ b/docs/designs/current/DESIGN-shell-integration-building-blocks.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Tsuku requires explicit CLI invocation for every tool installation. Users must know which tools they need and manually install them. The vision is automatic command interception and on-demand provisioning, but the foundational building blocks are missing.

--- a/docs/designs/current/DESIGN-storage-plan-fields.md
+++ b/docs/designs/current/DESIGN-storage-plan-fields.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 spawned_from:
   issue: 2468

--- a/docs/designs/current/DESIGN-structured-error-subcategories.md
+++ b/docs/designs/current/DESIGN-structured-error-subcategories.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Pipeline failure classification is inconsistent across three producers:
@@ -29,7 +30,7 @@ rationale: |
 
 ## Status
 
-**Current**
+Current
 
 ## Implementation Issues
 

--- a/docs/designs/current/DESIGN-structured-install-guide.md
+++ b/docs/designs/current/DESIGN-structured-install-guide.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Recipes with system dependencies use free-form `install_guide` text that cannot be machine-executed, and platform filtering is inconsistent between step-level `when` clauses and embedded parameter keys.
 decision: Replace `install_guide` with typed actions (`apt_install`, `brew_cask`, etc.) and enforce platform filtering exclusively through step-level `when` clauses with `linux_family` support.

--- a/docs/designs/current/DESIGN-structured-logging.md
+++ b/docs/designs/current/DESIGN-structured-logging.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: tsuku lacks structured diagnostic logging, making it difficult for users to troubleshoot installation failures without examining code or using ad-hoc debug patterns scattered across the codebase.
 decision: Implement a unified Logger interface backed by Go stdlib slog, with subsystems receiving the logger via functional options, enabling debug and verbose output controlled by command-line flags.

--- a/docs/designs/current/DESIGN-system-dependency-actions.md
+++ b/docs/designs/current/DESIGN-system-dependency-actions.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: The current require_system action is polymorphic and conflates multiple concerns (checking, installing, filtering, configuring), uses free-form text that cannot be machine-executed, and relies on implicit platform assumptions that don't account for Linux family diversity.
 decision: Replace require_system with granular typed actions (apt_install, brew_cask, etc.) that use linux_family as a targeting dimension for plan generation, idempotent installation with final verification, separate actions for post-install configuration, and implicit constraints on package manager actions.

--- a/docs/designs/current/DESIGN-tap-support.md
+++ b/docs/designs/current/DESIGN-tap-support.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Tsuku users cannot install tools from third-party Homebrew taps, requiring them to either use Homebrew directly or maintain custom recipes.
 decision: Implement a dedicated `tap` version provider that queries GitHub API to fetch formula metadata from third-party tap repositories, following the pattern established in the cask design.

--- a/docs/designs/current/DESIGN-tavily-brave-providers.md
+++ b/docs/designs/current/DESIGN-tavily-brave-providers.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The DDG scraper is the only search provider for local LLMs. Users with API keys

--- a/docs/designs/current/DESIGN-telemetry-cli.md
+++ b/docs/designs/current/DESIGN-telemetry-cli.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Tsuku lacks visibility into recipe usage patterns, platform distribution, and user preferences, making it impossible to prioritize maintenance and feature development based on actual usage data.
 decision: Implement a privacy-first telemetry client in the CLI that collects anonymous usage statistics (action type, recipe name, version, platform, and dependency status) with environment variable opt-out and transparent first-run notice.

--- a/docs/designs/current/DESIGN-tool-lifecycle-hooks.md
+++ b/docs/designs/current/DESIGN-tool-lifecycle-hooks.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 upstream: docs/prds/PRD-tool-lifecycle-hooks.md
 problem: |

--- a/docs/designs/current/DESIGN-toolchain-dependency-pinning.md
+++ b/docs/designs/current/DESIGN-toolchain-dependency-pinning.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Constrained evaluation pins lockfile content but not recipe dependencies, causing golden file validation failures when toolchain versions change upstream.
 decision: Extend EvalConstraints with a DependencyVersions map to extract and apply toolchain version pinning from golden files.

--- a/docs/designs/current/DESIGN-tsuku-ai-skills.md
+++ b/docs/designs/current/DESIGN-tsuku-ai-skills.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 upstream: docs/prds/PRD-tsuku-ai-skills.md
 problem: |

--- a/docs/designs/current/DESIGN-tsuku-homebrew-dylib-chaining.md
+++ b/docs/designs/current/DESIGN-tsuku-homebrew-dylib-chaining.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   tsuku's homebrew action does not chain dylibs from sibling tsuku-installed

--- a/docs/designs/current/DESIGN-unified-batch-pipeline.md
+++ b/docs/designs/current/DESIGN-unified-batch-pipeline.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   The batch pipeline generates zero recipes because the orchestrator filters queue entries

--- a/docs/designs/current/DESIGN-unified-release-versioning.md
+++ b/docs/designs/current/DESIGN-unified-release-versioning.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Tsuku's three binaries (CLI, dltest, llm) are released independently with inconsistent versioning, naming, and enforcement. The CLI and dltest share a `v*` tag in the main repo, but llm has a separate workflow (`llm-release.yml`) triggered by `tsuku-llm-v*` tags that has never been used. Artifact naming varies across all three (GoReleaser default, simple, version-prefixed). Only dltest has compile-time version pinning; llm accepts any installed version with no compatibility checking. This creates risk of version mismatches between binaries that share internal protocols.

--- a/docs/designs/current/DESIGN-update-outcome-telemetry.md
+++ b/docs/designs/current/DESIGN-update-outcome-telemetry.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Auto-updates produce no outcome telemetry. Successful auto-applies reuse the

--- a/docs/designs/current/DESIGN-update-polish.md
+++ b/docs/designs/current/DESIGN-update-polish.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 upstream: docs/prds/PRD-auto-update.md
 spawned_from:

--- a/docs/designs/current/DESIGN-verification-self-repair.md
+++ b/docs/designs/current/DESIGN-verification-self-repair.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: |
   Recipe creation often fails at the verification step because generated recipes

--- a/docs/designs/current/DESIGN-version-sorting.md
+++ b/docs/designs/current/DESIGN-version-sorting.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Version providers return versions in inconsistent and arbitrary order, making it impossible to reliably identify the latest version through programmatic access or CLI output.
 decision: Implement a centralized SortVersionsDescending() function that all version providers call before returning results, combined with test-time validation to catch providers that forget to sort.

--- a/docs/designs/current/DESIGN-version-verification.md
+++ b/docs/designs/current/DESIGN-version-verification.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Recipe verification currently uses inconsistent patterns to match version output, causing mismatches between version provider formats and tool output formats, weak verification for tools without version support, and inadequate validation coverage in CI.
 decision: Implement version format transforms and an output mode fallback to provide flexible yet robust verification that covers all tools while maintaining security through required justification fields and validator enforcement.

--- a/docs/designs/current/DESIGN-when-clause-platform-tuples.md
+++ b/docs/designs/current/DESIGN-when-clause-platform-tuples.md
@@ -1,4 +1,5 @@
 ---
+schema: design/v1
 status: Current
 problem: Recipe steps cannot express OR conditions across multiple platform tuples without duplicating entire steps.
 decision: Implement a structured WhenClause type to replace map[string]string, supporting platform arrays with proper type safety.

--- a/docs/prds/PRD-auto-update.md
+++ b/docs/prds/PRD-auto-update.md
@@ -1,4 +1,5 @@
 ---
+schema: prd/v1
 status: Accepted
 problem: |
   Tsuku has manual update and outdated commands, but no automatic update mechanism
@@ -17,8 +18,7 @@ goals: |
 
 Accepted
 
-## Problem statement
-
+## Problem Statement
 Tsuku users install developer tools and then forget about them. Patches ship, security fixes land, minor versions improve things, but nothing happens unless the user remembers to run `tsuku outdated` and then `tsuku update` for each tool. Most don't.
 
 Three specific problems make this worse:
@@ -39,8 +39,7 @@ These problems compound. Users who try to stay current have incomplete informati
 4. CI pipelines and non-interactive environments aren't affected by auto-update behavior.
 5. Users can see what's available, control what updates, and roll back when something goes wrong.
 
-## User stories
-
+## User Stories
 **US1: Daily developer, automatic patches.** As a developer with 15 tools installed, I want tools to receive updates automatically within my install-time constraints so that I get bug fixes and security patches without running commands manually.
 
 **US2: Daily developer, major version awareness.** As a developer pinned to Node 20, I want to know when Node 22 is available so that I can decide whether to adopt it on my own schedule.
@@ -115,8 +114,7 @@ In all cases, the check is non-blocking: the entry point stats the cache file, s
 
 **R22: Update outcome telemetry.** Successful and failed auto-updates are tracked via the existing telemetry system (extending `NewUpdateEvent`). Telemetry respects the existing opt-out mechanism.
 
-## Acceptance criteria
-
+## Acceptance Criteria
 ### Version pinning
 - [ ] `tsuku install ripgrep` (no version) enables auto-update to any newer version
 - [ ] `tsuku install node@20` enables auto-update within 20.x.y only
@@ -191,8 +189,7 @@ In all cases, the check is non-blocking: the entry point stats the cache file, s
 - [ ] A tool with an exact version in `.tsuku.toml` (e.g., `node = "20.16.0"`) is never auto-updated, even if global config has `updates.enabled = true`
 - [ ] A tool with a prefix version in `.tsuku.toml` (e.g., `node = "20"`) allows auto-update within 20.x.y
 
-## Out of scope
-
+## Out of Scope
 - **Pre-release channel opt-in** (beta/nightly): tools filter pre-releases by default. Named channels are a separate initiative.
 - **Version range constraints in .tsuku.toml**: semver range syntax (e.g., `>=1.29, <2`) is more complexity than needed. Prefix-level pinning is sufficient.
 - **Pre/post-update hooks**: user-defined scripts that run around updates. Separate feature surface.

--- a/docs/prds/PRD-composite-action-checksum-support.md
+++ b/docs/prds/PRD-composite-action-checksum-support.md
@@ -1,4 +1,5 @@
 ---
+schema: prd/v1
 status: Done
 problem: |
   github_archive and download_archive composite actions cannot

--- a/docs/prds/PRD-distributed-recipes.md
+++ b/docs/prds/PRD-distributed-recipes.md
@@ -1,4 +1,5 @@
 ---
+schema: prd/v1
 status: In Progress
 problem: |
   Every tsuku recipe lives in the central registry. Tool authors who want their

--- a/docs/prds/PRD-multi-satisfier-picker.md
+++ b/docs/prds/PRD-multi-satisfier-picker.md
@@ -1,4 +1,5 @@
 ---
+schema: prd/v1
 status: In Progress
 problem: |
   Users typing `tsuku install <name>` cannot pick among multiple recipes that

--- a/docs/prds/PRD-tsuku-ai-skills.md
+++ b/docs/prds/PRD-tsuku-ai-skills.md
@@ -1,4 +1,5 @@
 ---
+schema: prd/v1
 status: Done
 problem: |
   The tsuku repo has no committed CLAUDE.md and no AI skills for recipe authoring,


### PR DESCRIPTION
One hundred and fifty-two documents under `docs/` carried no `schema:` field. `shirabe validate` routes a document to a format by its filename prefix and then reads `schema:` to confirm which contract applies, so the structural pass never ran for any of them -- they have never been checked. Since shirabe #301 that state exits 4 rather than 0, which reports that the run declined to check the document rather than that it passed. This repo's `validate-docs.yml` pins `tsukumogami/shirabe/.github/workflows/validate-docs.yml@main` and treats any non-zero as failure, so each of those documents is a live tripwire: the next pull request whose changed-file set happens to touch one goes red for a reason unrelated to its own work.

One hundred and forty-one of the one hundred and fifty-two are fixed here. The field is chosen by filename prefix and placed on the first line after the opening `---`. Making them validate clean needed three follow-on repairs, none of which writes prose or changes a lifecycle claim.

Fifteen `## Status` sections lose markup that FC03 reads as part of the status. The check compares the whole first non-blank line, so `**Current**`, `**Status:** Current` and `**Status: Current**` are all reported as mismatches while stating exactly what the frontmatter states. Each line becomes the bare word, and the status itself is unchanged in every one of the fifteen. Five section headings are retitled from sentence case to the casing the contract specifies, FC04 matching heading text exactly. Two documents have `## Consequences` moved back to its canonical position after `## Security Considerations`, whole blocks moving.

Apart from those fifteen status lines, every changed document is content-identical to its previous version but for the inserted `schema:` line and heading casing, checked by comparing each file's sorted case-folded token stream against `origin/main`.

---

## Verification

Whole-tree validation over all 181 tracked documents under `docs/`, against `origin/main` as the baseline:

- skip notices: **152 -> 11**
- errors: **0 -> 0**
- findings new since baseline, at any severity: **none**
- all 141 changed documents validate clean individually (exit 0)

The last point is what matters for CI here, since `validate-docs` validates a PR's changed files rather than the whole tree.

## The 11 left alone, and why

A schema-only sweep would be worse than doing nothing: it converts "not checked" into "checked and failing" for exactly the files the PR touches. So a document is only swept here if it comes out clean, and the rest keep the behavior they have today -- including the cosmetic repairs, so they stay out of this PR's changed-file set.

**Seven archived designs have no `## Status` section at all.** `DESIGN-decomposable-actions`, `DESIGN-deterministic-execution`, `DESIGN-installation-plans-eval`, `DESIGN-llm-productionize`, `DESIGN-llm-slice-1-spike`, `DESIGN-llm-slice-3-repair-loop` and `DESIGN-plan-based-installation` predate the section requirement; three are also missing `## Implementation Approach`, `## Considered Options` or `## Decision Outcome`. Adding a Status heading means asserting a lifecycle state for a document already in `archive/`, and the other sections would be reconstructions of decisions the authors recorded elsewhere or not at all.

**Two name another DESIGN as their upstream.** `DESIGN-install-state-abstraction.md` points at `DESIGN-notices-install-event-bus.md`, and `DESIGN-auto-install.md` points at `DESIGN-shell-integration-building-blocks.md`, which additionally does not exist at the path given. A DESIGN may name a PRD, BRIEF, STRATEGY or VISION, so repointing these means deciding what the real parent was.

**One PRD disagrees with itself.** `PRD-tool-lifecycle-hooks.md` is `Done` in frontmatter and `Draft` in the body. Unlike the fifteen above, these are different words, so it is a lifecycle question rather than a formatting one.

**One roadmap predates the profile.** `ROADMAP-auto-update.md` has no `## Progress` or `## Dependency Graph`, and its issues table is `Issue | Dependencies | Tier` where the roadmap profile expects `Feature | Issues | Dependencies | Status`. Reshaping the table means re-deriving which features the issues belong to.

A pull request touching one of these eleven still goes red, exactly as it does today. That is unchanged by this PR rather than caused by it, and it wants a follow-up with someone who knows the history.
