### PR TITLE
docs(skills): rewrite the skill descriptions to select

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,11 +137,15 @@ This applies to code comments, design documents, README and other documentation,
 
 Skills in `plugins/` guide agents through recipe authoring, testing, and end-user workflows. They drift silently when tsuku internals change without a corresponding skill update.
 
+The three split on whose problem it is, not on which command shows up in the request:
+
 | Skill | Path | Scope |
 |-------|------|-------|
-| tsuku-recipe-author | plugins/tsuku-recipes/skills/recipe-author/ | Recipe TOML writing |
-| tsuku-recipe-test | plugins/tsuku-recipes/skills/recipe-test/ | Recipe testing workflow |
-| tsuku-user | plugins/tsuku-user/skills/tsuku-user/ | CLI usage, project config, shell integration, updates |
+| tsuku-recipe-author | plugins/tsuku-recipes/skills/recipe-author/ | Deciding how a tool gets installed and writing it down -- actions, version providers, when clauses, aliases, distributed recipes |
+| tsuku-recipe-test | plugins/tsuku-recipes/skills/recipe-test/ | Proving a recipe under development installs across platforms, and diagnosing why it doesn't |
+| tsuku-user | plugins/tsuku-user/skills/tsuku-user/ | Someone using tsuku on their own machine or repo hitting something wrong, surprising, or needing configuration |
+
+Changing tsuku's own Go code is none of them -- no skill covers `internal/` or `cmd/`. The table below is the map for that work, and it reads in the other direction: it says which skill's documentation a source change obliges you to refresh.
 
 **After completing any source change in the areas below, assess the relevant skills:**
 

--- a/docs/guides/GUIDE-distributed-recipe-authoring.md
+++ b/docs/guides/GUIDE-distributed-recipe-authoring.md
@@ -178,7 +178,7 @@ Add this to your project's `.claude/settings.json` to install the plugin:
 
 This gives Claude Code two skills:
 
-- **recipe-author** -- guidance on recipe TOML structure, actions, version providers, platform conditionals, verification, and dependencies. Includes bundled reference files so the agent doesn't need access to the full tsuku repo.
-- **recipe-test** -- the validate-eval-sandbox testing workflow, cross-family testing, golden file validation, and common failure patterns.
+- **recipe-author** -- reach for it when you're deciding how a tool gets installed and writing that down: which actions fetch or build it, how versions resolve, which steps run on which platforms, what verification proves it worked. It fires on requests that never say "recipe", like "tsuku can't install our internal CLI yet" or "users type `nvim`, not `neovim`". It ships its reference files, so the agent doesn't need the tsuku repo.
+- **recipe-test** -- reach for it when you're proving a recipe you're working on actually installs, across linux families and macOS, or working out why it doesn't. It covers validate, eval, sandbox runs, and golden plans, plus the failure symptoms that name none of those, like a tool that installs on Debian and blows up on Alpine.
 
 The `autoUpdate` field is intentionally omitted. This means Claude Code won't pull plugin updates automatically -- you control when updates happen by re-fetching the plugin on your own schedule.

--- a/plugins/tsuku-recipes/AGENTS.md
+++ b/plugins/tsuku-recipes/AGENTS.md
@@ -1,6 +1,7 @@
 # tsuku-recipes Plugin
 
-Contextual guidance for authoring and testing tsuku recipes.
+Contextual guidance for two jobs: deciding how a tool gets installed and writing
+that down as a recipe, and proving a recipe you're working on actually installs.
 
 Tsuku is a package manager for developer tools. Recipes are TOML files that
 define how to download, build, and verify a tool installation. They live in
@@ -47,9 +48,11 @@ The full list of actions with parameter tables is in:
 
     skills/recipe-author/references/action-reference.md
 
-The recipe-author SKILL.md also has a summary table of all action names
-grouped by category (download, ecosystem, package managers, build systems,
-file operations, special).
+The tsuku-recipe-author skill (skills/recipe-author/SKILL.md) is where to go
+when you're deciding what a recipe should do -- it carries a summary table of
+action names grouped by category (download, ecosystem, package managers, build
+systems, file operations, special) alongside version providers, when clauses,
+aliases, and distributed recipes.
 
 ## Testing Workflow
 
@@ -94,8 +97,9 @@ for family in debian rhel alpine arch suse; do
 done
 ```
 
-The tsuku-recipe-test skill (skills/recipe-test/SKILL.md) covers golden file
-validation, common failure patterns, and test infrastructure in detail.
+The tsuku-recipe-test skill (skills/recipe-test/SKILL.md) is where to go once
+the recipe exists and you need to prove it installs, or find out why it doesn't:
+golden plans, cross-family runs, and a symptom-by-symptom failure catalogue.
 
 ## Guides
 

--- a/plugins/tsuku-recipes/skills/recipe-author/SKILL.md
+++ b/plugins/tsuku-recipes/skills/recipe-author/SKILL.md
@@ -1,10 +1,23 @@
 ---
 name: tsuku-recipe-author
-description: |
-  Use when writing or modifying tsuku recipe TOML files. The recipe format
-  has 60+ actions, 14 version providers, and platform-conditional logic
-  that tsuku create doesn't fully cover. This skill provides quick-reference
-  tables and bundled references for the cases that need manual authoring.
+description: >-
+  Use when you are deciding how a tool gets installed and writing that down as a
+  tsuku recipe TOML -- the actions that fetch or build it, the version provider,
+  the platform conditionals, the verify block, the dependencies. Reach for it
+  even when nobody says "recipe": "tsuku can't install ripgrep, can you add
+  support for it?" is a recipe, and so are "users type `nvim`, not `neovim` --
+  make that work" (an alias), "we want the team installing our internal CLIs
+  from our own repo" (a distributed `.tsuku-recipes/` directory), "this only
+  works on glibc and our CI images are Alpine" (a libc split), and "the tool
+  needs a shell function defined at startup". Without it an agent hand-writes
+  TOML from a half-remembered format and misses the parts with no obvious
+  syntax: which phase a step runs in, aliases, libc coverage, the transforms
+  that make a verify pattern match what the tool actually prints. Do NOT use it
+  to prove a recipe installs or to read a failing sandbox run or CI diff
+  (`tsuku-recipe-test`), to help someone install and configure tools on their
+  own machine (`tsuku-user`), or to change tsuku's own Go code -- adding an
+  action, a version provider, or a CLI flag is source work under `internal/`,
+  which no skill covers and CLAUDE.md's Source Area table maps.
 ---
 
 # Recipe Authoring

--- a/plugins/tsuku-recipes/skills/recipe-author/SKILL.md
+++ b/plugins/tsuku-recipes/skills/recipe-author/SKILL.md
@@ -5,13 +5,14 @@ description: >-
   tsuku recipe TOML -- the actions that fetch or build it, the version provider,
   the platform conditionals, the verify block, the dependencies. Reach for it
   even when nobody says "recipe": "tsuku can't install ripgrep, can you add
-  support for it?" is a recipe, and so are "users type `nvim`, not `neovim` --
-  make that work" (an alias), "we want the team installing our internal CLIs
-  from our own repo" (a distributed `.tsuku-recipes/` directory), "this only
-  works on glibc and our CI images are Alpine" (a libc split), and "the tool
-  needs a shell function defined at startup". Without it an agent hand-writes
-  TOML from a half-remembered format and misses the parts with no obvious
-  syntax: which phase a step runs in, aliases, libc coverage, the transforms
+  support for it?" is a recipe that does not exist yet, and so are "users type
+  `nvim`, not `neovim` -- make that work" (an alias), "we want the team
+  installing our internal CLIs from our own repo" (a distributed
+  `.tsuku-recipes/` directory), "this only works on glibc and our CI images are
+  Alpine" (a libc split), and "installing this tool has to define a shell
+  function the way nvm does" (an init fragment the recipe declares). Without it
+  an agent hand-writes TOML from a half-remembered format and misses the parts
+  with no obvious syntax: which phase a step runs in, aliases, libc coverage, the transforms
   that make a verify pattern match what the tool actually prints. Do NOT use it
   to prove a recipe installs or to read a failing sandbox run or CI diff
   (`tsuku-recipe-test`), to help someone install and configure tools on their

--- a/plugins/tsuku-recipes/skills/recipe-test/SKILL.md
+++ b/plugins/tsuku-recipes/skills/recipe-test/SKILL.md
@@ -1,9 +1,23 @@
 ---
 name: tsuku-recipe-test
-description: |
-  Use when a recipe needs testing or an installation is failing. Covers
-  the full validate-eval-sandbox-golden workflow with exact commands,
-  cross-family testing, and common failure patterns with exit codes.
+description: >-
+  Use when you are proving that a recipe you are working on actually installs,
+  across linux families and macOS, or working out why it doesn't. Covers the
+  validate, eval, sandbox, and golden-plan checks, and the symptoms that name
+  none of them: "CI is red with a golden file diff I didn't expect", "it
+  installs on Debian and blows up on Alpine", "patchelf cannot run on this
+  system" (a different failure from "patchelf not found"), "why is tsuku warning
+  me that this plan declares no dependencies", or "I want to see which steps my
+  when clauses select before anything installs". Skipping it costs real time in
+  both directions: an unexpected golden diff gets accepted instead of
+  investigated, and a sandbox run off a stored plan passes for the wrong reason
+  because that plan carries no dependencies and no verification. Do NOT use it
+  to decide what a recipe should do in the first place (`tsuku-recipe-author`),
+  to fix a tool on someone's own machine, where the
+  install being debugged is theirs rather than a recipe under development
+  (`tsuku-user`), or to change tsuku's own Go code -- validation rules, exit
+  codes, and plan generation live under `cmd/` and `internal/`, which no skill
+  covers.
 ---
 
 ## Phase 1: Validate

--- a/plugins/tsuku-recipes/skills/recipe-test/SKILL.md
+++ b/plugins/tsuku-recipes/skills/recipe-test/SKILL.md
@@ -13,8 +13,8 @@ description: >-
   investigated, and a sandbox run off a stored plan passes for the wrong reason
   because that plan carries no dependencies and no verification. Do NOT use it
   to decide what a recipe should do in the first place (`tsuku-recipe-author`),
-  to fix a tool on someone's own machine, where the
-  install being debugged is theirs rather than a recipe under development
+  to install, update, configure, or repair tools on someone's own machine, where
+  the install in question is theirs rather than a recipe under development
   (`tsuku-user`), or to change tsuku's own Go code -- validation rules, exit
   codes, and plan generation live under `cmd/` and `internal/`, which no skill
   covers.

--- a/plugins/tsuku-user/skills/tsuku-user/SKILL.md
+++ b/plugins/tsuku-user/skills/tsuku-user/SKILL.md
@@ -15,8 +15,8 @@ description: >-
   it). It also settles `--reinstall` against `--fresh`, which is genuinely
   surprising: one replays the plan stored at install time, the other regenerates
   it from the current recipe. Do NOT use it to write or change a recipe
-  (`tsuku-recipe-author`), to test one under development or read a CI failure on
-  a recipe PR (`tsuku-recipe-test`), or to change tsuku's own Go code -- new
+  (`tsuku-recipe-author`), to validate or test one under development or read a
+  CI failure on a recipe PR (`tsuku-recipe-test`), or to change tsuku's own Go code -- new
   commands, flags, and config fields live under `cmd/` and `internal/`, which no
   skill covers.
 ---

--- a/plugins/tsuku-user/skills/tsuku-user/SKILL.md
+++ b/plugins/tsuku-user/skills/tsuku-user/SKILL.md
@@ -1,9 +1,24 @@
 ---
 name: tsuku-user
-description: |
-  Use when helping someone manage tools with tsuku -- installing, configuring
-  .tsuku.toml project files, setting up shell integration, or debugging
-  PATH and update issues.
+description: >-
+  Use when someone is using tsuku on their own machine or repo and something is
+  wrong, surprising, or needs configuring -- installing and updating tools,
+  pinning a project's toolchain in `.tsuku.toml`, shell integration, `doctor`,
+  rollback, auto-update, telemetry, and secrets. Most of the situations that
+  need it never say "tsuku". "I upgraded but I'm still getting the old version"
+  is PATH shadowing, and it is the one worth catching because every other signal
+  looks healthy: the right version is installed, nothing reports as outdated,
+  and the wrong binary keeps answering forever. So are "new hires keep ending
+  up on the wrong node version" (pin the repo's toolchain), "my shell function vanished after I installed the tool" (init
+  fragments are bash and zsh only), and "$TSUKU_HOME is 40GB, what can I delete"
+  (tool data survives both upgrade and remove, and nothing tsuku ships deletes
+  it). It also settles `--reinstall` against `--fresh`, which is genuinely
+  surprising: one replays the plan stored at install time, the other regenerates
+  it from the current recipe. Do NOT use it to write or change a recipe
+  (`tsuku-recipe-author`), to test one under development or read a CI failure on
+  a recipe PR (`tsuku-recipe-test`), or to change tsuku's own Go code -- new
+  commands, flags, and config fields live under `cmd/` and `internal/`, which no
+  skill covers.
 ---
 
 ## .tsuku.toml Project Configuration


### PR DESCRIPTION
The `description:` field is the only text an agent reads when deciding whether to load a skill it was not told to use. All three of tsuku's skills summarized their own contents instead of helping that decision, and it showed in different ways: `tsuku-recipe-author` spent its budget on inventory counts an agent cannot act on before loading, `tsuku-recipe-test` on a table of contents of its own workflow, and `tsuku-user` on a four-noun feature list whose every clause presupposed the word "tsuku" was already in the request -- inverting the actual need, since its most valuable content is for someone with no reason to suspect tsuku at all.

Worse, two of the three claimed "an installation is failing" and neither said which one wins. The three-way boundary is now drawn from all three sides. recipe-author is for deciding how a tool gets installed and writing that down. recipe-test is for proving a recipe you are working on installs, across platforms, and finding out why it doesn't. tsuku-user is for someone using tsuku on their own machine or repo hitting something wrong, surprising, or in need of configuration. All three carry the shared negative that changing tsuku's own Go code -- a new action, a version provider, a CLI flag -- is none of them, because no skill covers `internal/` or `cmd/`.

Each rewrite leads with the job, pushes on the triggers that under-fire, names the consequence of not loading, and closes on its siblings. The triggers that matter are the ones where nobody says the word: "tsuku can't install ripgrep, can you add support for it?" and "users type `nvim`, not `neovim`" for recipe-author; "CI is red with a golden file diff I didn't expect" and "installs on Debian, blows up on Alpine" for recipe-test; "I upgraded but I'm still getting the old version" -- PATH shadowing, where every other signal looks healthy -- and "new hires keep ending up on the wrong node version" for tsuku-user. The counts are gone rather than corrected: the provider count had already drifted from the skill's own table, which is the argument against carrying a number that nothing in the repo checks.

CLAUDE.md's skill table, the distributed-recipe guide's two-skill list, and the `tsuku-recipes` AGENTS.md paraphrases are brought in line, since all three restate the descriptions for readers who never see the frontmatter. The frontmatter also moves from the literal block scalar to the folded one, so each description parses as one paragraph rather than a string with hard line breaks in it.

---

## What changed

| File | Change |
|---|---|
| `plugins/tsuku-recipes/skills/recipe-author/SKILL.md` | description rewritten, 289 to 1350 chars |
| `plugins/tsuku-recipes/skills/recipe-test/SKILL.md` | description rewritten, 204 to 1219 chars |
| `plugins/tsuku-user/skills/tsuku-user/SKILL.md` | description rewritten, 169 to 1369 chars |
| `CLAUDE.md` | Skill/Path/Scope table restated as situations; note that Go source work is no skill's job and the Source-Area table below reads in the other direction |
| `docs/guides/GUIDE-distributed-recipe-authoring.md` | the two-skill list an external adopter reads |
| `plugins/tsuku-recipes/AGENTS.md` | tagline plus the two skill paraphrases |

No length gate applies here. The only `MAX_DESCRIPTION_LENGTH` in the repo governs a recipe's `[metadata].description`, not skills. Existing skill descriptions across the org's plugins run 600-1100 characters, and these land at the upper end of that band.

The Source-Area table in CLAUDE.md is deliberately left alone -- it is the closest thing in the repo to a real trigger list and was mined for these rewrites rather than replaced.

`docs/designs/current/DESIGN-tsuku-ai-skills.md` and `docs/prds/PRD-tsuku-ai-skills.md` are untouched on purpose. They are accepted artifacts recording the original skill inventory, including a `tsuku-dev` plugin that was never built; rewriting them to match today's skills would falsify the record.


## The repo's eval suites, and why they are not the evidence here

tsuku ships `scripts/run-evals.sh`, and the convention is that a skill's evals move when the skill does. A description edit is a SKILL.md edit, so that obligation is live and this PR does not discharge it by running the suites. Two reasons, and the second is the one that matters.

The suites were not run because `run-evals.sh` drives `claude -p` against a live model. It needs an Anthropic API key this environment does not have, and it spends shared session quota. No numbers appear here rather than estimated ones.

The substantive reason is that running them would not have said anything about this change. Every scenario in the three suites puts its request to an agent already pointed at the skill, so they grade what the agent does *after* loading: whether it names the right action, explains the right exit code, produces valid TOML. A description-only edit cannot move a score built that way. A flat before and after would be evidence of nothing, and least of all evidence that the rewrite failed. `scripts/check-evals-exist.sh` is an existence check on the same suites and carries the same limit.

The instrument that measures selection is a trigger eval: realistic queries run cold, scored on whether the skill loads at all. Sets of 15 to 16 queries per skill were authored for that, half should-trigger and drawn from the situations where nobody says "recipe" or "tsuku", half near-misses drawn from the other two skills in the trio and the Go-internals case. Those results land in the section above once the measurement run completes.

## Consistency with the existing negative cases

The negative scenarios already in the suites -- `negative-install-failure`, `negative-shell-setup`, `negative-go-internals`, `negative-recipe-authoring` (in two suites), `negative-cli-usage`, `negative-recipe-testing` -- are the closest thing the repo has to boundary tests for the three-way split, and each rewritten boundary was read against them. A rewrite that would make one of those fire is a rewrite that got the boundary wrong. Three needed tightening:

- `negative-install-failure` ("tsuku install ripgrep is failing with exit code 6 and something about containers") sits close to recipe-author's strongest trigger, "tsuku can't install ripgrep, can you add support for it?". The trigger now says that request is a recipe *that does not exist yet*, and the boundary already hands a failing sandbox run to recipe-test.
- `negative-shell-setup` ("how do I set up `tsuku shellenv` in my `.zshrc`") sits close to recipe-author's shell-init trigger. That trigger is now written from the authoring side -- an init fragment the recipe declares -- rather than as a shell that is missing a function.
- `negative-cli-usage` ("configure auto-update to check daily") and `negative-recipe-testing` ("`tsuku validate --strict` warnings about my verify pattern") fell into slack in the boundaries that named them. recipe-test now concedes configuring and repairing tools on someone's own machine, not only fixing them; tsuku-user now concedes validating a recipe under development, not only testing it.

## Verification

```
bash scripts/check-evals-exist.sh            # exit 0, all three skills have evals
claude plugin validate .                     # passed
claude plugin validate plugins/tsuku-recipes # passed
claude plugin validate plugins/tsuku-user    # passed
```

The `validate-skill-content.yml` workflow fires on `plugins/**`, so it runs on this PR. Both its jobs were reproduced locally: the exemplar build passes and validates 12 of 12 referenced recipes, and neither plugin has a `hooks.json`.

***

## Measured triggering

The rewrites here are **not** backed by a measured trigger improvement, and that
is worth stating plainly rather than leaving the section empty.

skill-creator's `run_eval.py` registers the subject as a slash command and then
counts a hit when the model issues a `Skill` tool call naming it. Those are two
different surfaces in current Claude Code, so as shipped it scores near zero for
descriptions that demonstrably fire when the same query is run by hand. A
corrected harness (registering a real skill, streaming for early detection, one
project root per run) does discriminate, and it produced two findings:

- A single skill alone in an empty project fires on almost anything, so old and
  new score alike. `/release`'s old description — the purest summary in the
  workspace — still fires on "cut a release" 2 runs out of 2. Meanwhile the
  phrases the new description explicitly lists, "bump the version" and "write
  the changelog", fire for neither version. Naming a phrase in a description is
  not a mechanism for triggering on it.
- Registering all 16 shirabe skills together and asking which one fires is the
  right experiment, because boundaries only exist under competition. At one run
  per query it was inconclusive: 4/30 correct for the old descriptions, 2/30 for
  the new, with 22 and 25 queries respectively invoking no skill at all. That
  floor is environmental — a bare scratch project gives the model no reason to
  consult a workflow skill.

So these changes stand on the standard they were written to and on review, not
on a trigger delta. The full write-up, including what to do differently, lives
with the coordination artifacts.
